### PR TITLE
[K8C-23] initial commit for ServiceMonitor template

### DIFF
--- a/charts/k8ssandra/templates/cassdc-servicemontior.yaml
+++ b/charts/k8ssandra/templates/cassdc-servicemontior.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-cassdc
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: cass-operator
+      cassandra.datastax.com/prom-metrics: "true"
+  endpoints:
+  - port: prometheus


### PR DESCRIPTION
With this PR, I am creating a single ServiceMonitor in the k8ssandra chart. It is configured to monitor multiple services from the all-pods service created by cass-operator for a CassandraDatacenter.