### PR TITLE
[K8C-94] deploy prometheus per cluster

### DIFF
--- a/charts/k8ssandra-cluster/templates/prometheus/prometheus.yaml
+++ b/charts/k8ssandra-cluster/templates/prometheus/prometheus.yaml
@@ -3,7 +3,7 @@ kind: Prometheus
 metadata:
   name: {{ .Release.Name }}-prometheus-k8ssandra
   labels:
-{{ include "k8ssandra.labels" . | indent 4 }}
+{{ include "k8ssandra-cluster.labels" . | indent 4 }}
 spec:
   replicas: 1
   baseImage: quay.io/prometheus/prometheus
@@ -17,7 +17,7 @@ spec:
   serviceMonitorSelector:
     matchLabels:
       app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/name: {{ template "k8ssandra.name" . }}
+      app.kubernetes.io/name: {{ template "k8ssandra-cluster.name" . }}
   ruleSelector: {}
   alerting:
     alertmanagers: []

--- a/charts/k8ssandra-cluster/templates/prometheus/role.yaml
+++ b/charts/k8ssandra-cluster/templates/prometheus/role.yaml
@@ -1,9 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: {{ .Release.Name }}-prometheus-k8ssandra
   labels:
-{{ include "k8ssandra.labels" . | indent 4 }}
+{{ include "k8ssandra-cluster.labels" . | indent 4 }}
 rules:
 - apiGroups: [""]
   resources:
@@ -22,5 +22,3 @@ rules:
   resources:
   - ingresses
   verbs: ["get", "list", "watch"]
-- nonResourceURLs: ["/metrics"]
-  verbs: ["get"]

--- a/charts/k8ssandra-cluster/templates/prometheus/role_binding.yaml
+++ b/charts/k8ssandra-cluster/templates/prometheus/role_binding.yaml
@@ -1,14 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: {{ .Release.Name }}-prometheus-k8ssandra
   labels:
-{{ include "k8ssandra.labels" . | indent 4 }}
+{{ include "k8ssandra-cluster.labels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: {{ .Release.Name }}-prometheus-k8ssandra
 subjects:
 - kind: ServiceAccount
   name: {{ .Release.Name }}-prometheus-k8ssandra
-  namespace: {{ .Release.Namespace }}

--- a/charts/k8ssandra-cluster/templates/prometheus/service.yaml
+++ b/charts/k8ssandra-cluster/templates/prometheus/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ .Release.Name }}-prometheus-k8ssandra
   labels:
-{{ include "k8ssandra.labels" . | indent 4 }}
+{{ include "k8ssandra-cluster.labels" . | indent 4 }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/k8ssandra-cluster/templates/prometheus/service_account.yaml
+++ b/charts/k8ssandra-cluster/templates/prometheus/service_account.yaml
@@ -3,4 +3,4 @@ kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}-prometheus-k8ssandra
   labels:
-{{ include "k8ssandra.labels" . | indent 4 }}
+{{ include "k8ssandra-cluster.labels" . | indent 4 }}

--- a/charts/k8ssandra-cluster/templates/prometheus/service_monitor.yaml
+++ b/charts/k8ssandra-cluster/templates/prometheus/service_monitor.yaml
@@ -3,15 +3,15 @@ kind: ServiceMonitor
 metadata:
   name: {{ .Release.Name }}-prometheus-k8ssandra
   labels:
-{{ include "k8ssandra.labels" . | indent 4 }}
+{{ include "k8ssandra-cluster.labels" . | indent 4 }}
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/managed-by: cass-operator
       cassandra.datastax.com/prom-metrics: "true"
     matchExpressions:
-      - {key: cassandra.datastax.com/cluster, operator: Exists}
-      - {key: cassandra.datastax.com/datacenter, operator: Exists}
+      - {key: cassandra.datastax.com/cluster, operator: In, values: [{{ .Values.clusterName }}]}
+      - {key: cassandra.datastax.com/datacenter, operator: In, values: [{{ .Values.datacenterName }}]}
   targetLabels:
   - cassandra.datastax.com/cluster
   - cassandra.datastax.com/datacenter

--- a/charts/k8ssandra-cluster/values.yaml
+++ b/charts/k8ssandra-cluster/values.yaml
@@ -20,7 +20,8 @@ repair:
 
 backupRestore:
   medusa:
-    enabled: true
+    # If enabled, bucketName and bucketSecret must be defined.
+    enabled: false
 
     # Accepted values are s3 and gcs
     storage: s3


### PR DESCRIPTION
Changes in this PR:

* Deploy Prometheus in k8ssandra-cluster instead of k8ssandra chart
* Use Role instead of ClusterRole
* Update ServiceMonitor so that it will only select the CassandraDatacenter with which it is deployed