### PR TITLE
Add a line to remind to change directory to charts

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -4,6 +4,7 @@ K8ssandra is installed and configured through Helm charts.
 [Helm 3](https://helm.sh/) must be installed to use the charts.
 
 The charts are not yet deployed to a Helm repo. For now you need use the charts directly from this Git repo.
+Or if you cloned a copy of this repo, cd into the charts folder: k8ssandra/charts
 
 # Getting Started
 First you need to deploy the k8ssandra stack:


### PR DESCRIPTION
For some users who might be new to helm charts, would be better to add a line to remind to change directory to the k8ssandra charts folder before running the installations.