### PR TITLE
Added storageClass and PV size to Helm values for external customisation

### DIFF
--- a/charts/backup/Chart.yaml
+++ b/charts/backup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0
+version: 0.15.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/k8ssandra-cluster/Chart.yaml
+++ b/charts/k8ssandra-cluster/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0
+version: 0.15.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/k8ssandra-cluster/templates/cassdc.yaml
+++ b/charts/k8ssandra-cluster/templates/cassdc.yaml
@@ -22,12 +22,16 @@ spec:
   size: {{ .Values.size }}
   storageConfig:
     cassandraDataVolumeClaimSpec:
+{{- if (eq "-" .Values.k8ssandra.persistentVolume.storageClass) }}
       storageClassName: standard
+{{- else }}
+      storageClassName: "{{ .Values.k8ssandra.persistentVolume.storageClass }}"
+{{- end }}        
       accessModes:
         - ReadWriteOnce
       resources:
         requests:
-          storage: 5Gi
+          storage: "{{ .Values.k8ssandra.persistentVolume.size }}"
   config:    
     jvm-options:
       initial_heap_size: "800M"

--- a/charts/k8ssandra-cluster/templates/cassdc.yaml
+++ b/charts/k8ssandra-cluster/templates/cassdc.yaml
@@ -22,16 +22,12 @@ spec:
   size: {{ .Values.size }}
   storageConfig:
     cassandraDataVolumeClaimSpec:
-{{- if (eq "-" .Values.k8ssandra.cassandraLibDirVolume.storageClass) }}
-      storageClassName: standard
-{{- else }}
-      storageClassName: "{{ .Values.k8ssandra.cassandraLibDirVolume.storageClass }}"
-{{- end }}        
+      storageClassName: {{ .Values.k8ssandra.cassandraLibDirVolume.storageClass | default "standard" }}
       accessModes:
         - ReadWriteOnce
       resources:
         requests:
-          storage: "{{ .Values.k8ssandra.cassandraLibDirVolume.size }}"
+          storage: {{ .Values.k8ssandra.cassandraLibDirVolume.size | default "5Gi" }}
   config:    
     jvm-options:
       initial_heap_size: "800M"

--- a/charts/k8ssandra-cluster/templates/cassdc.yaml
+++ b/charts/k8ssandra-cluster/templates/cassdc.yaml
@@ -22,16 +22,16 @@ spec:
   size: {{ .Values.size }}
   storageConfig:
     cassandraDataVolumeClaimSpec:
-{{- if (eq "-" .Values.k8ssandra.persistentVolume.storageClass) }}
+{{- if (eq "-" .Values.k8ssandra.cassandraLibDirVolume.storageClass) }}
       storageClassName: standard
 {{- else }}
-      storageClassName: "{{ .Values.k8ssandra.persistentVolume.storageClass }}"
+      storageClassName: "{{ .Values.k8ssandra.cassandraLibDirVolume.storageClass }}"
 {{- end }}        
       accessModes:
         - ReadWriteOnce
       resources:
         requests:
-          storage: "{{ .Values.k8ssandra.persistentVolume.size }}"
+          storage: "{{ .Values.k8ssandra.cassandraLibDirVolume.size }}"
   config:    
     jvm-options:
       initial_heap_size: "800M"

--- a/charts/k8ssandra-cluster/values.yaml
+++ b/charts/k8ssandra-cluster/values.yaml
@@ -13,7 +13,7 @@ k8ssandra:
   # to configure some resources like the Grafana data source.
   namespace: default
   name: k8ssandra
-  persistentVolume:
+  cassandraLibDirVolume:
     storageClass: standard
     size: 5Gi
 

--- a/charts/k8ssandra-cluster/values.yaml
+++ b/charts/k8ssandra-cluster/values.yaml
@@ -13,6 +13,9 @@ k8ssandra:
   # to configure some resources like the Grafana data source.
   namespace: default
   name: k8ssandra
+  persistentVolume:
+    storageClass: standard
+    size: 5Gi
 
 # Configuration regarding configuration of repair services
 repair:

--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0
+version: 0.15.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/restore/Chart.yaml
+++ b/charts/restore/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0
+version: 0.15.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
The original chart didn't allow for the persistentVolume to be configurable. 
It is particularly useful to allow the configuration for 
- storageClass
- storage request

since the `standard` storageClass is not always present and must be created  (k3d for instance has only support for a local-path provisioner, Openshift is usually installed with glusterfs-storage,...) .

I added the following section in the default values file:

```yaml
name: k8ssandra
clusterName: k8ssandra
datacenterName: dc1
size: 1

k8ssandra:
  # The k8ssandra chart installs operators with cluster scope. It can be installed in a
  # different namespace. The namespace and name of the k8ssandra chart release are needed
  # to configure some resources like the Grafana data source.
  namespace: default
  name: k8ssandra
  persistentVolume:
    storageClass: standard
    size: 5Gi
...
```

allowing the configuration with  standard helm values override.

I didn't touch the `accessModes`  since I assume that `ReadWriteOnce` must not be changed for K8ssandra use case.


