### PR TITLE
[GH 71] expose root_url and serve_from_sub_path settings

### DIFF
--- a/charts/backup/Chart.yaml
+++ b/charts/backup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: 0.11.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/k8ssandra-cluster/Chart.yaml
+++ b/charts/k8ssandra-cluster/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: 0.11.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/k8ssandra-cluster/templates/grafana/instance.yaml
+++ b/charts/k8ssandra-cluster/templates/grafana/instance.yaml
@@ -3,6 +3,8 @@ apiVersion: integreatly.org/v1alpha1
 kind: Grafana
 metadata:
   name: {{ .Release.Name }}-grafana-k8ssandra
+  labels:
+{{ include "k8ssandra-cluster.labels" . | indent 4 }}
 spec:
   ingress:
     enabled: false
@@ -15,8 +17,17 @@ spec:
       level: warn
       mode: console
     security:
-      admin_password: {{ .Values.grafana.adminPassword }}
-      admin_user: {{ .Values.grafana.adminUsername }}
+      admin_password: {{ .Values.monitoring.grafana.security.adminPassword }}
+      admin_user: {{ .Values.monitoring.grafana.security.adminUser }}
+{{- if .Values.monitoring.grafana.config.server }}
+    server:
+{{- if not (empty .Values.monitoring.grafana.config.server.rootUrl) }}
+      root_url: {{ .Values.monitoring.grafana.config.server.rootUrl }}
+{{- end }}
+{{- if and (not (empty .Values.monitoring.grafana.config.server.rootUrl)) .Values.monitoring.grafana.config.server.serveFromSubPath }}
+      serve_from_sub_path: true
+{{- end }}
+{{- end }}
   dashboardLabelSelector:
     - matchExpressions:
         - key: app

--- a/charts/k8ssandra-cluster/values.yaml
+++ b/charts/k8ssandra-cluster/values.yaml
@@ -96,6 +96,27 @@ ingress:
         # Hostname Traefik should use for matching requests.
         host: prometheus.k8ssandra.cluster.local
 
-grafana:
-  adminUser: admin
-  adminPassword: secret
+monitoring:
+  grafana:
+    security:
+      # TODO Add support for configuring credentials via a secret
+
+      # The admin username
+      adminUser: admin
+
+      # The admin password
+      adminPassword: secret
+
+    # Grafana server configuration settings. Corresponds to settings in /etc/grafana/grafana.ini.
+    config:
+      # Corresponds to properties in the server section of grafana.ini.
+      server:
+        # This is the full URL used to access Grafana from a web browser. This setting
+        # is also important if you have a reverse proxy in front of Grafana that
+        # exposes it through a subpath. In that case add the subpath to the end of this
+        # URL setting.
+        rootUrl: ""
+
+        # Set to to true to serve Grafana from subpath specified in rootUrl. If set to
+        # true, rootUrl should be set as well.
+        serveFromSubPath: false

--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: 0.11.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/restore/Chart.yaml
+++ b/charts/restore/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: 0.11.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Fixes #71 

This PR exposes the `root_url` and `serve_from_sub_path` settings in `/etc/grafana/grafana.ini`. 

I tested as follows:

```
$ helm install grafana-config ./k8ssandra-cluster -f grafana-values.yaml
```

where `grafana-values.yaml` looks like this:

```yaml
monitoring:
  grafana:
    config:
      server:
        rootUrl: http://localhost:3000
        serveFromSubPath: true
```