### PR TITLE
[GH 90] make prometheus external url configurable

### DIFF
--- a/charts/backup/Chart.yaml
+++ b/charts/backup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.0
+version: 0.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/k8ssandra-cluster/Chart.yaml
+++ b/charts/k8ssandra-cluster/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.0
+version: 0.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/k8ssandra-cluster/templates/prometheus/prometheus.yaml
+++ b/charts/k8ssandra-cluster/templates/prometheus/prometheus.yaml
@@ -21,6 +21,9 @@ spec:
 {{- if not (empty .Values.monitoring.prometheus.externalUrl) }}
   externalUrl: {{ .Values.monitoring.prometheus.externalUrl }}
 {{- end }}
+{{- if not (empty .Values.monitoring.prometheus.routePrefix) }}
+  routePrefix: {{ .Values.monitoring.prometheus.routePrefix }}
+{{- end}}
   ruleSelector: {}
   alerting:
     alertmanagers: []

--- a/charts/k8ssandra-cluster/templates/prometheus/prometheus.yaml
+++ b/charts/k8ssandra-cluster/templates/prometheus/prometheus.yaml
@@ -18,6 +18,9 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/name: {{ template "k8ssandra-cluster.name" . }}
+{{- if not (empty .Values.monitoring.prometheus.externalUrl) }}
+  externalUrl: {{ .Values.monitoring.prometheus.externalUrl }}
+{{- end }}
   ruleSelector: {}
   alerting:
     alertmanagers: []

--- a/charts/k8ssandra-cluster/values.yaml
+++ b/charts/k8ssandra-cluster/values.yaml
@@ -121,3 +121,7 @@ monitoring:
         # Set to to true to serve Grafana from subpath specified in rootUrl. If set to
         # true, rootUrl should be set as well.
         serveFromSubPath: false
+
+  prometheus:
+    # The external URL the Prometheus instances will be available under.
+    externalUrl: ""

--- a/charts/k8ssandra-cluster/values.yaml
+++ b/charts/k8ssandra-cluster/values.yaml
@@ -125,3 +125,9 @@ monitoring:
   prometheus:
     # The external URL the Prometheus instances will be available under.
     externalUrl: ""
+
+    # The route prefix Prometheus registers HTTP handlers for. This is useful,
+    # if using ExternalURL and a proxy is rewriting HTTP routes of a request,
+    # and the actual ExternalURL is still true, but the server serves requests
+    # under a different route prefix. For example for use with `kubectl proxy`.
+    routePrefix: ""

--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.0
+version: 0.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/restore/Chart.yaml
+++ b/charts/restore/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.0
+version: 0.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Fixes #90 

To test,

```
$ helm install k8ssandra-tools ./k8ssandra
$ helm install prom-config ./k8ssandra-cluster -f prom-values.yaml
```

where `prom-values.yaml` looks like this:

```yaml
monitoring:
  prometheus:
    externalUrl: localhost
```