### PR TITLE
Adding routePrefix to url template

### DIFF
--- a/charts/k8ssandra-cluster/templates/grafana/datasource.yaml
+++ b/charts/k8ssandra-cluster/templates/grafana/datasource.yaml
@@ -12,6 +12,6 @@ spec:
         timeInterval: 5s
       name: Prometheus
       type: prometheus
-      url: http://{{ .Release.Name }}-prometheus-k8ssandra.{{ .Release.Namespace }}:9090
+      url: http://{{ .Release.Name }}-prometheus-k8ssandra.{{ .Release.Namespace }}:9090/{{ .Values.monitoring.prometheus.routePrefix }}
       version: 1
   name: prometheus-datasources.yaml


### PR DESCRIPTION
Inclusion of routePrefix to the url for Grafana datasources.