### PR TITLE
Cassandra ingress should be enabled by default

### DIFF
--- a/charts/k8ssandra-cluster/values.yaml
+++ b/charts/k8ssandra-cluster/values.yaml
@@ -78,7 +78,7 @@ ingress:
     # Cassandra native transport ingress support
     cassandra:
       # Note this will **only** work if `ingress.traefik.enabled` is also `true`
-      enabled: false
+      enabled: true
 
       # Name of the Traefik entrypoints for source traffic
       entrypoints:


### PR DESCRIPTION
This make the ingress enabled property consistent across the various services.