### PR TITLE
If no Reaper or Medusa is present, do not render empty slices

### DIFF
--- a/charts/k8ssandra-cluster/templates/cassdc.yaml
+++ b/charts/k8ssandra-cluster/templates/cassdc.yaml
@@ -34,6 +34,7 @@ spec:
       max_heap_size: "800M"
   podTemplateSpec:
     spec:
+{{- if or .Values.repair.reaper.enabled .Values.backupRestore.medusa.enabled }}
       initContainers:
 {{- if .Values.repair.reaper.enabled }}
       - name: jmx-credentials
@@ -91,8 +92,10 @@ spec:
             mountPath: /etc/medusa-secrets
 {{- end}}
 {{- end}}
+{{- end}}
       containers:
       - name: cassandra
+{{- if or .Values.repair.reaper.enabled .Values.backupRestore.medusa.enabled }}
         env:
 {{- if .Values.repair.reaper.enabled }}
           - name: LOCAL_JMX
@@ -143,4 +146,5 @@ spec:
       - name:  {{ .Values.backupRestore.medusa.bucketSecret }}
         secret:
           secretName: {{ .Values.backupRestore.medusa.bucketSecret }}
+{{- end }}
 {{- end }}

--- a/tests/unit/template_cassdc_test.go
+++ b/tests/unit/template_cassdc_test.go
@@ -80,8 +80,10 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 			Expect(cassdc.Annotations).ShouldNot(HaveKeyWithValue(reaperInstanceAnnotation, reaperInstanceValue))
 
 			Expect(len(cassdc.Spec.PodTemplateSpec.Spec.Containers)).To(Equal(1))
-			// No reaper or medusa env variables should be present
-			Expect(len(cassdc.Spec.PodTemplateSpec.Spec.Containers[0].Env)).To(Equal(0))
+			// No env slice should be present
+			Expect(cassdc.Spec.PodTemplateSpec.Spec.Containers[0].Env).To(BeNil())
+			// No initcontainers slice should be present
+			Expect(cassdc.Spec.PodTemplateSpec.Spec.InitContainers).To(BeNil())
 		})
 
 		It("enabling only medusa", func() {


### PR DESCRIPTION
Env nor InitContainers should be present if Reaper and Medusa are disabled, fixes #135 