### PR TITLE
Fix layout issues of home screen cards

### DIFF
--- a/docs/assets/scss/_variables_project.scss
+++ b/docs/assets/scss/_variables_project.scss
@@ -98,6 +98,7 @@ Add styles or override variables from the theme here.
       border-radius: 0;
       border: none;
       box-shadow: 0px 14px 32px rgba(0, 0, 0, 0.08);
+      display: block;
 
       img {
         margin-top: 31px;

--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -53,7 +53,7 @@ linkTitle: K8ssandra
 	<main role="main" class="td-main">
 		<div class="row">
 			<section class="col">
-				<div class="card text-center" style="display: block;">
+				<div class="card text-center">
 					<img src="/images/icons/helm.svg" />
 					<h2>Helm</h2>
 					<div class="description">
@@ -65,7 +65,7 @@ linkTitle: K8ssandra
 				</div>
 			</section>
 			<section class="col">
-				<div class="card text-center" style="display: block;">
+				<div class="card text-center">
 					<img src="/images/icons/github.svg" />
 					<h2>Contributions Welcome</h2>
 					<div class="description">
@@ -77,7 +77,7 @@ linkTitle: K8ssandra
 				</div>
 			</section>
 			<section class="col">
-				<div class="card text-center" style="display: block;">
+				<div class="card text-center">
 					<img src="/images/icons/twitter.svg" />
 					<h2>Follow Us on Twitter</h2>
 					<div class="description">

--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -53,7 +53,7 @@ linkTitle: K8ssandra
 	<main role="main" class="td-main">
 		<div class="row">
 			<section class="col">
-				<div class="card text-center">
+				<div class="card text-center" style="display: block;">
 					<img src="/images/icons/helm.svg" />
 					<h2>Helm</h2>
 					<div class="description">
@@ -65,7 +65,7 @@ linkTitle: K8ssandra
 				</div>
 			</section>
 			<section class="col">
-				<div class="card text-center">
+				<div class="card text-center" style="display: block;">
 					<img src="/images/icons/github.svg" />
 					<h2>Contributions Welcome</h2>
 					<div class="description">
@@ -77,7 +77,7 @@ linkTitle: K8ssandra
 				</div>
 			</section>
 			<section class="col">
-				<div class="card text-center">
+				<div class="card text-center" style="display: block;">
 					<img src="/images/icons/twitter.svg" />
 					<h2>Follow Us on Twitter</h2>
 					<div class="description">


### PR DESCRIPTION
* Small layout issue in the docs that Chris mentioned to me earlier
* Core of the problem is FF's sizing of images within flex containers, it behaves differently than Chrome and Safari (I didn't try Edge)
* The template that we use includes these cards, which get a flex display applied to them, in this particular case there is no necessity for that, so I've forced the display in those cased only back to the default.
* This same change also fixed a wrapping issue with the cards that I noticed - that happens on all browsers, not just FF

FF Icon Issue Before and After:

![image](https://user-images.githubusercontent.com/7901615/103859110-7b0a1f00-5087-11eb-9523-80463549487d.png)

Card Wrapping Issue Before and After:

![image](https://user-images.githubusercontent.com/7901615/103859166-92490c80-5087-11eb-9b0d-2df39d2c068e.png)

