### PR TITLE
Version and image target updated

### DIFF
--- a/charts/k8ssandra-cluster/templates/cassdc.yaml
+++ b/charts/k8ssandra-cluster/templates/cassdc.yaml
@@ -14,9 +14,7 @@ spec:
   clusterName: {{ .Values.k8ssandra.clusterName }}
   serverType: cassandra
   serverVersion: "3.11.7"
-  # We need to use a patched version of the management api image.
-  # See https://k8ssandra.atlassian.net/browse/K8C-88 for details.
-  serverImage: jsanda/mgmtapi-3_11:v0.1.13-k8c-88
+  serverImage: datastax/cassandra-mgmtapi-3_11_7:v0.1.17
   managementApiAuth:
     insecure: {}
   size: {{ .Values.k8ssandra.size }}

--- a/tests/unit/template_cassdc_test.go
+++ b/tests/unit/template_cassdc_test.go
@@ -2,13 +2,12 @@ package unit_test
 
 import (
 	"fmt"
-	"path/filepath"
-
 	cassdcv1beta1 "github.com/datastax/cass-operator/operator/pkg/apis/cassandra/v1beta1"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"path/filepath"
 )
 
 var (
@@ -65,6 +64,10 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 			Expect(len(cassdc.Spec.PodTemplateSpec.Spec.Containers[0].Env)).To(Equal(1))
 			Expect(cassdc.Spec.PodTemplateSpec.Spec.Containers[0].Env[0].Name).To(Equal("LOCAL_JMX"))
 			Expect(cassdc.Spec.PodTemplateSpec.Spec.Containers[0].Env[0].Value).To(Equal("no"))
+
+			// Server version and mgmt-api image specified
+			Expect(cassdc.Spec.ServerVersion).ToNot(BeEmpty())
+			Expect(cassdc.Spec.ServerImage).ToNot(BeEmpty())
 		})
 
 		It("override clusterName", func() {
@@ -171,5 +174,6 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 			// Two containers, medusa and cassandra
 			Expect(len(cassdc.Spec.PodTemplateSpec.Spec.Containers)).To(Equal(2))
 		})
+
 	})
 })


### PR DESCRIPTION
Image from DataStax Docker image v0.1.17 `cassandra-mgmtapi-3_11_7:v0.1.17`