### PR TITLE
Allow defining the TLSOptions for Traefik Ingress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,10 +226,6 @@ tags
 
 ### VisualStudioCode ###
 .vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
 *.code-workspace
 
 ### VisualStudioCode Patch ###

--- a/charts/k8ssandra-cluster/templates/_helpers.tpl
+++ b/charts/k8ssandra-cluster/templates/_helpers.tpl
@@ -61,3 +61,17 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Include Traefik TLSOptions reference to Ingress
+*/}}
+{{- define "k8ssandra-cluster.traefikTls" -}}
+{{- if .Values.ingress.traefik.tls.options.name }}
+  tls:
+    options:
+    {{- with .Values.ingress.traefik.tls.options }}
+      name: {{ .name }}
+      namespace: {{ .namespace }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/k8ssandra-cluster/templates/traefik.ingressroutes.yaml
+++ b/charts/k8ssandra-cluster/templates/traefik.ingressroutes.yaml
@@ -23,6 +23,7 @@ spec:
     - name: {{ $releaseName }}-reaper-k8ssandra-reaper-service
       kind: Service
       port: 8080
+{{- include "k8ssandra-cluster.traefikTls" . }}
 {{- end }}
 {{- if and $traefik.enabled $traefik.cassandra.enabled }}
 ---
@@ -42,6 +43,7 @@ spec:
       services:
         - name: {{ $clusterName }}-{{ $datacenterName }}-service
           port: 9042
+{{- include "k8ssandra-cluster.traefikTls" . }}
 {{- end }}
 {{- if and $traefik.enabled $traefik.monitoring.grafana.enabled }}
 ---
@@ -65,6 +67,7 @@ spec:
     - name: grafana-service
       kind: Service
       port: 3000
+{{- include "k8ssandra-cluster.traefikTls" . }}
 {{- end }}
 {{- if and $traefik.enabled $traefik.monitoring.prometheus.enabled }}
 ---
@@ -86,4 +89,5 @@ spec:
     - name: {{ .Release.Name }}-prometheus-k8ssandra
       kind: Service
       port: 9090
+{{- include "k8ssandra-cluster.traefikTls" . }}
 {{- end }}

--- a/charts/k8ssandra-cluster/values.yaml
+++ b/charts/k8ssandra-cluster/values.yaml
@@ -55,6 +55,12 @@ ingress:
     # Set to `true` to enable the templating of Traefik ingress custom resources
     enabled: false
 
+    # Specify custom TLSOptions to use for IngressRoutes
+    tls:
+      options:
+        name: ""
+        namespace: ""
+
     # Repair service
     repair:
       # Note this will **only** work if `ingress.traefik.enabled` is also `true`

--- a/tests/unit/template_ingress_test.go
+++ b/tests/unit/template_ingress_test.go
@@ -1,0 +1,58 @@
+package unit_test
+
+import (
+	"path/filepath"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Verify Ingress templates", func() {
+	var (
+		helmChartPath string
+		err           error
+	)
+
+	BeforeEach(func() {
+		helmChartPath, err = filepath.Abs(chartsPath)
+		Expect(err).To(BeNil())
+	})
+
+	AfterEach(func() {
+		err = nil
+	})
+
+	renderTemplate := func(options *helm.Options) {
+		helm.RenderTemplate(
+			GinkgoT(), options, helmChartPath, helmReleaseName,
+			[]string{"templates/traefik.ingressroutes.yaml"},
+		)
+
+		// helm.UnmarshalK8SYaml(GinkgoT(), renderedOutput, ingress)
+	}
+
+	Context("by rendering it with options", func() {
+		It("using only enabled option", func() {
+			options := &helm.Options{
+				SetStrValues:   map[string]string{"ingress.traefik.enabled": "true"},
+				KubectlOptions: defaultKubeCtlOptions,
+			}
+
+			renderTemplate(options)
+		})
+
+		It("enabling the TLS", func() {
+			options := &helm.Options{
+				SetStrValues: map[string]string{
+					"ingress.traefik.enabled":               "true",
+					"ingress.traefik.tls.options.name":      "custom-tls",
+					"ingress.traefik.tls.options.namespace": "current",
+				},
+				KubectlOptions: defaultKubeCtlOptions,
+			}
+
+			renderTemplate(options)
+		})
+	})
+})


### PR DESCRIPTION
Adds the possibility of setting up a custom TLSOptions reference for the created IngressRoutes. We can add some examples to the documentation. 

Fixes #171 excluding the docs.

https://doc.traefik.io/traefik/https/tls/



┆Issue is synchronized with this [Jiraserver Task](https://k8ssandra.atlassian.net/browse/K8SSAND-776) by [Unito](https://www.unito.io)
┆Issue Number: K8SSAND-776
┆Priority: Medium
