### PR TITLE
Configurable Resources Additions

### DIFF
--- a/charts/k8ssandra-cluster/values.yaml
+++ b/charts/k8ssandra-cluster/values.yaml
@@ -7,6 +7,7 @@ k8ssandra:
   cassandraLibDirVolume:
     storageClass: standard
     size: 5Gi
+  # If enabled, resources.limits and resources.requests must be defined
   allowMultipleNodesPerWorker: false
   resources: {}
 

--- a/tests/unit/template_cassdc_test.go
+++ b/tests/unit/template_cassdc_test.go
@@ -294,9 +294,11 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 				},
 				KubectlOptions: defaultKubeCtlOptions,
 			}
-			error := renderTemplate(options)
 
-			Expect(error.Error()).To(ContainSubstring("set resource limits/requests when enabling allowMultipleNodesPerWorker"))
+			err := renderTemplate(options)
+
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("set resource limits/requests when enabling allowMultipleNodesPerWorker"))
 
 		})
 	})


### PR DESCRIPTION
Expansion on [PR#160](https://github.com/k8ssandra/k8ssandra/pull/160).

- Documented relationship of k8ssandra `allowMultipleNodesPerWorker` and `resources`
- If enabled, k8ssandra `resources.limits` and `resources.requests` must be defined.

