### PR TITLE
remove chart version checks

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,41 +40,6 @@ jobs:
           helm version
           yq -V
   
-  versions-match-check:
-    needs:
-      - setup
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Cache bin path
-        id: cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/bin
-          key: ${{ runner.os }}-${{ needs.setup.outputs.HELM_VERSION }}-${{ needs.setup.outputs.YQ_VERSION }}
-      - name: Update PATH
-        run: |
-          echo "$HOME/bin" >> $GITHUB_PATH
-      - name: Setup working directory
-        run: |
-          mkdir build
-          cp -rv charts/* build/
-      - name: Validate version numbers match on all charts
-        run: |
-          VERSION_COUNT=`ls | while read c; do
-            if [[ -d $c ]]; then
-              yq read $c/Chart.yaml version
-            fi
-          done | sort | uniq | wc -l`
-
-          if [[ $VERSION_COUNT -ne 1 ]]; then
-            echo "::error ::Version numbers do not match across charts"
-            exit 1
-          fi
-        working-directory: build
-
   lint-check:
     needs:
       - setup

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,43 +46,8 @@ jobs:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
         run: echo "::set-output name=SHORT_VERSION::${VERSION:1}"
 
-  version-check:
-    needs:
-      - setup
-    runs-on: ubuntu-latest
-    steps: 
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Cache bin path
-        id: cache
-        uses: actions/cache@v2
-        with:
-          path: ~/bin
-          key: ${{ runner.os }}-${{ needs.setup.outputs.HELM_VERSION }}-${{ needs.setup.outputs.YQ_VERSION }}
-      - name: Update PATH
-        run: echo "$HOME/bin" >> $GITHUB_PATH
-      - name: Create build directory and copy charts
-        run: |
-          mkdir build
-          cp -rv charts/* build/
-      - name: Validate version number in charts match tag
-        env:
-          SHORT_VERSION: ${{ needs.setup.outputs.SHORT_VERSION }}
-        run: |
-          ls | while read c; do
-            if [[ -d $c ]]; then
-              CHART_VERSION=`yq read $c/Chart.yaml version`
-              if [[ "$CHART_VERSION" != "$SHORT_VERSION" ]]; then
-                echo "::error file=charts/$c/Chart.yaml::Chart version, $CHART_VERSION, does not match pushed tag, $SHORT_VERSION."
-                exit 1
-              fi
-            fi
-          done
-        working-directory: build
-  
   package:
     needs:
-      - version-check
       - setup
     runs-on: ubuntu-latest
     steps: 
@@ -117,7 +82,6 @@ jobs:
   gh-release:
     needs:
       - setup
-      - version-check
     runs-on: ubuntu-latest
     outputs:
       RELEASE_UPLOAD_URL: ${{ steps.create_release.outputs.upload_url}}
@@ -159,7 +123,6 @@ jobs:
 
   helm-release:
     needs:
-      - version-check
       - package
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Fixes #145 

As has been discussed previously it does not make sense to require the versions to be the same across all charts. We do want to follow the practice of bumping the version when is modified. This PR does not include a check for that.

As a follow up to this, we should tackle #145 whereby pushing a git tag would result in charts being pushed to a _stable_ chart repo.