### PR TITLE
Add FAQ outlining the versions of the high-order components deployed …

### DIFF
--- a/docs/content/en/docs/faqs/_index.md
+++ b/docs/content/en/docs/faqs/_index.md
@@ -19,7 +19,7 @@ Any way you want! But think of it this way:  "Kate" + "Sandra".
 
 At a pure component level, K8ssandra integrates and packages together:
 
-* Apache Cassandra 3.11.7
+* Apache Cassandra
 * Kubernetes Operator for Apache Cassandra (cass-operator)
 * Reaper, also known as the Repair Web Interface
 * Medusa for backup and restore
@@ -79,13 +79,34 @@ $ helm install k8ssandra k8ssandra/k8ssandra -n k8ssandra --create-namespace
 Some of the objects installed by the k8ssandra chart are currently configured to be cluster-scoped; consequently, you should only install those components once. This should be
 fixed before version 1.0 to allow multiple installations. Other parts can be installed multiple times to allow creating multiple Cassandra clusters in a single k8s cluster.
 
+### What components does k8ssandra install?
+
+K8ssandra deploys the following components, some components are optional, and depending on the configuration, may not be deployed:
+
+* [Apache Cassandra](https://cassandra.apache.org/) (version deployed is dependent upon configuration)
+  * 3.11.7
+  * 3.11.8
+  * 3.11.9
+* [Management API for Apache Cassandra](https://github.com/datastax/management-api-for-apache-cassandra)
+  * 0.1.17
+* [Metric Collector for Apache Cassandra (MCAC)](https://github.com/datastax/metric-collector-for-apache-cassandra)
+  * 0.1.7
+* [Prometheus](https://prometheus.io/)
+  * 2.21.0
+* [Grafana](https://grafana.com/)
+  * 7.1.1
+* [Medusa](https://github.com/thelastpickle/cassandra-medusa)
+  * 0.8.0
+* [Cassandra Reaper](http://cassandra-reaper.io/)
+  * 2.1.3
+* [Stargate](https://stargate.io/)
+  * 1.0.0
+
+*Note: Throughout these docs, examples are shown to deploy [Traefik](https://traefik.io/) as a means to provide external access to the k8ssandra cluster.  It is deployed separately from k8ssandra, and as such, the version deployed will vary.*
+
 ### What is cass-operator?
 
 Kubernetes Operator for Apache Cassandra -- [cass-operator](https://github.com/datastax/cass-operator) -- is the most critical element bridging Kubernetes and Cassandra. The community has been focusing much of its attention on operators over the past two years, as the appropriate starting place. If there is magic happening, it’s all in the operator. The cass-operator serves as the translation layer between the control plane of Kubernetes and actual operation done by the Cassandra cluster. Recently, the Apache Cassandra project agreed on gathering around a single operator: cass-operator. Some great contributions from Orange with CassKop will be merged with the DataStax operator and a final version will be merged into the Apache project. This is the best example of actual production knowledge finding its way into code. Community members contributing to cass-operator are running large amounts of Cassandra in Kubernetes every day. 
-
-### What version of Cassandra does K8ssandra install and manage via the cass-operator?
-
-It's Apache Cassandra 3.11.7 currently.
 
 ### What is Reaper?
 


### PR DESCRIPTION
…in our system.

This should represent the current set of versions included - We'll need to update this prior to 1.0.0 when we bring in new versions of some items, like the management-api.

![image](https://user-images.githubusercontent.com/7901615/105232061-d92e0c00-5b35-11eb-95b5-4bae8e11f0cf.png)
