### PR TITLE
Remove obsolete cassandra.size property

### DIFF
--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.29.0
+version: 0.30.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -1,7 +1,6 @@
 cassandra:
   version: "3.11.9"
   clusterName: k8ssandra
-  size: 1
   # auth is authentication and authorization related settings.
   auth:
     # enabled enables or disables authentication and authorization


### PR DESCRIPTION
This property moved under the datacenters objects.