### PR TITLE
JVM options heap inclusion

### DIFF
--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -43,7 +43,7 @@ spec:
 {{- else if .Values.cassandra.resources }}
   resources:
 {{ toYaml .Values.cassandra.resources | indent 6 }}
-{{- end}}
+{{- end }}
 {{- if .Values.cassandra.auth.superuser.secret }}
   superuserSecretName: {{ .Values.cassandra.auth.superuser.secret }}
 {{- else if .Values.cassandra.auth.superuser.username }}
@@ -66,9 +66,19 @@ spec:
       credentials_validity_in_ms: {{ .Values.cassandra.auth.cacheValidityPeriodMillis }}
       credentials_update_interval_in_ms: {{ .Values.cassandra.auth.cacheUpdateIntervalMillis }}
     jvm-options:
-      initial_heap_size: "800M"
-      max_heap_size: "800M"
-
+{{- if (index .Values.cassandra.datacenters 0).heap }}
+      initial_heap_size: {{ default "800M" (index .Values.cassandra.datacenters 0).heap.size }}
+      max_heap_size: {{ default "800M" (index .Values.cassandra.datacenters 0).heap.size }}
+      heap_size_young_generation: {{ default "1.6Gi" (index .Values.cassandra.datacenters 0).heap.newGenSize }}
+{{- else if .Values.cassandra.heap }}
+      initial_heap_size: {{ default "800M" .Values.cassandra.heap.size }}
+      max_heap_size: {{ default "800M" .Values.cassandra.heap.size }}
+      heap_size_young_generation: {{ default "1.6Gi" .Values.cassandra.heap.newGenSize}}
+{{- else }}
+      initial_heap_size: {{ "800M" }}
+      max_heap_size: {{ "800M" }}
+      heap_size_young_generation: {{ "1.6Gi" }}
+{{- end}}
       additional-jvm-opts:
 {{- if .Values.cassandra.auth.enabled }}
         - "-Dcassandra.system_distributed_replication_dc_names={{ (index .Values.cassandra.datacenters 0).name }}"

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -67,13 +67,21 @@ spec:
       credentials_update_interval_in_ms: {{ .Values.cassandra.auth.cacheUpdateIntervalMillis }}
     jvm-options:
 {{- if (index .Values.cassandra.datacenters 0).heap }}
-      initial_heap_size: {{  (index .Values.cassandra.datacenters 0).heap.size }}
-      max_heap_size: {{  (index .Values.cassandra.datacenters 0).heap.size }}
-      heap_size_young_generation: {{  (index .Values.cassandra.datacenters 0).heap.newGenSize }}
-{{- else if .Values.cassandra.heap }}
-      initial_heap_size: {{  .Values.cassandra.heap.size }}
+  {{- if (index .Values.cassandra.datacenters 0).heap.size }}
+      initial_heap_size: {{ (index .Values.cassandra.datacenters 0).heap.size }}
+      max_heap_size: {{ (index .Values.cassandra.datacenters 0).heap.size}}
+  {{- end }}
+  {{- if (index .Values.cassandra.datacenters 0).heap.newGenSize }}
+      heap_size_young_generation: {{ (index .Values.cassandra.datacenters 0).heap.newGenSize }}
+  {{- end }}
+  {{- else if .Values.cassandra.heap }}
+  {{- if .Values.cassandra.heap.size  }}
+      initial_heap_size: {{ .Values.cassandra.heap.size }}
       max_heap_size: {{ .Values.cassandra.heap.size }}
-      heap_size_young_generation: {{  .Values.cassandra.heap.newGenSize}}
+  {{- end }}
+  {{- if  .Values.cassandra.heap.newGenSize }}
+      heap_size_young_generation: {{ .Values.cassandra.heap.newGenSize }}
+  {{- end }}
 {{- end}}
       additional-jvm-opts:
 {{- if .Values.cassandra.auth.enabled }}

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -67,17 +67,13 @@ spec:
       credentials_update_interval_in_ms: {{ .Values.cassandra.auth.cacheUpdateIntervalMillis }}
     jvm-options:
 {{- if (index .Values.cassandra.datacenters 0).heap }}
-      initial_heap_size: {{ default "800M" (index .Values.cassandra.datacenters 0).heap.size }}
-      max_heap_size: {{ default "800M" (index .Values.cassandra.datacenters 0).heap.size }}
-      heap_size_young_generation: {{ default "1.6Gi" (index .Values.cassandra.datacenters 0).heap.newGenSize }}
+      initial_heap_size: {{  (index .Values.cassandra.datacenters 0).heap.size }}
+      max_heap_size: {{  (index .Values.cassandra.datacenters 0).heap.size }}
+      heap_size_young_generation: {{  (index .Values.cassandra.datacenters 0).heap.newGenSize }}
 {{- else if .Values.cassandra.heap }}
-      initial_heap_size: {{ default "800M" .Values.cassandra.heap.size }}
-      max_heap_size: {{ default "800M" .Values.cassandra.heap.size }}
-      heap_size_young_generation: {{ default "1.6Gi" .Values.cassandra.heap.newGenSize}}
-{{- else }}
-      initial_heap_size: {{ "800M" }}
-      max_heap_size: {{ "800M" }}
-      heap_size_young_generation: {{ "1.6Gi" }}
+      initial_heap_size: {{  .Values.cassandra.heap.size }}
+      max_heap_size: {{ .Values.cassandra.heap.size }}
+      heap_size_young_generation: {{  .Values.cassandra.heap.newGenSize}}
 {{- end}}
       additional-jvm-opts:
 {{- if .Values.cassandra.auth.enabled }}

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -34,11 +34,20 @@ cassandra:
   # If enabled, resources.limits and resources.requests must be defined
   allowMultipleNodesPerWorker: false
 
+  # -- Optional cluster-level heap setting
+  #heap:
+  #  size: 800M
+  #  newGenSize: 400M
+
   resources: {}
 
   datacenters:
   - name: dc1
     size: 1
+    # -- Optional dc-level heap setting, overrides cluster-level
+    #heap:
+      #size: 800M
+      #newGenSize: 400M
 
 stargate:
   # configuration regarding the Stargate API

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,11 @@ require (
 	github.com/k8ssandra/reaper-operator v0.0.0-20210122200305-0d6525659e9d
 	github.com/onsi/ginkgo v1.14.2
 	github.com/onsi/gomega v1.10.3
+	github.com/stretchr/testify v1.6.1 // indirect
 	k8s.io/api v0.18.6
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v12.0.0+incompatible
+	k8s.io/kubernetes v1.18.6 // indirect
 	sigs.k8s.io/controller-runtime v0.6.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -32,7 +32,6 @@ github.com/Azure/azure-storage-blob-go v0.8.0/go.mod h1:lPI3aLPpuLTeUwh1sViKXFxw
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest v10.8.1+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest v11.2.8+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
-github.com/Azure/go-autorest v12.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest v0.9.3-0.20191028180845-3492b2aff503/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
@@ -243,7 +242,6 @@ github.com/cznic/ql v1.2.0/go.mod h1:FbpzhyZrqr0PVlK6ury+PoW3T0ODUV22OeWIxcaOrSE
 github.com/cznic/sortutil v0.0.0-20150617083342-4c7342852e65/go.mod h1:q2w6Bg5jeox1B+QkJ6Wp/+Vn0G/bo3f1uY7Fn3vivIQ=
 github.com/cznic/strutil v0.0.0-20171016134553-529a34b1c186/go.mod h1:AHHPPPXTw0h6pVabbcbyGRK1DckRn7r/STdZEeIDzZc=
 github.com/cznic/zappy v0.0.0-20160723133515-2533cb5b45cc/go.mod h1:Y1SNZ4dRUOKXshKUbwUapqNncRrho4mkjQebgEHZLj8=
-github.com/datastax/cass-operator v1.4.1/go.mod h1:n4+2yl15us4FGWcfScw42U8Yt3CWTgNR82We9q09FO8=
 github.com/datastax/cass-operator v1.5.1-0.20210112050706-a45fd80b40e0 h1:LO+BvZ63cF0J2eJv0idDBWHDppRarfQMo8crnrTa/y4=
 github.com/datastax/cass-operator v1.5.1-0.20210112050706-a45fd80b40e0/go.mod h1:rEuOcRPV4cPbTU+Pu2glGwOzlPwWkgpZYK/xaVP8NrM=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -266,6 +264,7 @@ github.com/docker/cli v0.0.0-20200109221225-a4f60165b7a3/go.mod h1:JLrzqnKDaYBop
 github.com/docker/cli v0.0.0-20200130152716-5d0cf8839492/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v0.0.0-20191216044856-a8371794149d/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
 github.com/docker/distribution v2.7.0+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v0.7.3-0.20190103212154-2b7e084dc98b/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
@@ -573,8 +572,6 @@ github.com/gruntwork-io/gruntwork-cli v0.7.0 h1:YgSAmfCj9c61H+zuvHwKfYUwlMhu5arn
 github.com/gruntwork-io/gruntwork-cli v0.7.0/go.mod h1:jp6Z7NcLF2avpY8v71fBx6hds9eOFPELSuD/VPv7w00=
 github.com/gruntwork-io/terratest v0.30.15 h1:/OAnHKEERSsy03wYi8dyEwnpYy2XV8wpzwq0c4BHvoc=
 github.com/gruntwork-io/terratest v0.30.15/go.mod h1:vl/YEB2AEqVZOv9zg0nlBX+fgfqcqNcpqNfjvhRFLXo=
-github.com/gruntwork-io/terratest v0.31.2 h1:xvYHA80MUq5kx670dM18HInewOrrQrAN+XbVVtytUHg=
-github.com/gruntwork-io/terratest v0.31.3 h1:iyTRcIaB3rPHwKNLPBpoRHfo18H79dLt71jFhif/K0o=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
@@ -648,8 +645,6 @@ github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
-github.com/jsanda/cass-operator v1.0.1-0.20201111154347-91205f4d8f1e h1:H3aWukUHRLgcduiU3xOLQnGYHofMWM8M6y/BsdVjQeI=
-github.com/jsanda/cass-operator v1.0.1-0.20201111154347-91205f4d8f1e/go.mod h1:4FruKM7wFQMawYvZMlup+6uoDWwIEsLPoF9oDh6pLlU=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -666,10 +661,7 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/k8ssandra/reaper-client-go v0.3.0 h1:77F37hIJrP/YrwIYbJ1LOucJ7CwKWLAt8OM7TD0mDBk=
 github.com/k8ssandra/reaper-client-go v0.3.0/go.mod h1:1yol6YTcKcLOmPH9CfAdeFnVg/KCCTSbIUXMsF1cKII=
-github.com/k8ssandra/reaper-operator v0.0.0-20201204054951-d4834fcfac4d h1:U9TZ10PCnePMR3l2IFdW58Mp0GIwj4DubUCf/SoOg30=
-github.com/k8ssandra/reaper-operator v0.0.0-20201204054951-d4834fcfac4d/go.mod h1:I9rHky3x4988ch7erva5PRgVj/ZD/4vmnRhb3W9wL2U=
 github.com/k8ssandra/reaper-operator v0.0.0-20210122200305-0d6525659e9d h1:BA28uoP4d43e9f5MNAlmqxZwkUxR9BqeYAbnpA1h6TM=
 github.com/k8ssandra/reaper-operator v0.0.0-20210122200305-0d6525659e9d/go.mod h1:alzgcDgwXvxEyTjSBWJNGox1qb0Pw9wHBD/gPIVRzYw=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
@@ -844,6 +836,7 @@ github.com/onsi/gomega v1.10.3 h1:gph6h/qe9GSUw1NhH1gp+qb+h8rXD8Cy60Z32Qw3ELA=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
+github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/image-spec v1.0.0/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
@@ -1008,6 +1001,7 @@ github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasO
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.0/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
+github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.2.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
@@ -1030,6 +1024,7 @@ github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/y
 github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc/go.mod h1:ZrLn+e0ZuF3Y65PNF6dIwbJPZqfmtCXxFm9ckv0agOY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/tests/unit/template_cassdc_test.go
+++ b/tests/unit/template_cassdc_test.go
@@ -486,5 +486,95 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 			Expect(config.JvmOptions.MaxHeapSize).To(Equal("300M"))
 			Expect(config.JvmOptions.YoungGenSize).To(Equal("150M"))
 		})
+
+		It("setting JVM heap settings at dc-level without newGenSize", func() {
+
+			dcName := "dc1"
+			options := &helm.Options{
+				SetValues: map[string]string{
+					"cassandra.datacenters[0].heap.size": "300M",
+					"cassandra.datacenters[0].name":      dcName,
+					// Note: not setting - "cassandra.datacenters[0].heap.newGenSize": "150M",
+				},
+				KubectlOptions: defaultKubeCtlOptions,
+			}
+
+			Expect(renderTemplate(options)).To(Succeed())
+
+			var config Config
+			Expect(json.Unmarshal(cassdc.Spec.Config, &config)).To(Succeed())
+			Expect(config.JvmOptions).ToNot(BeNil())
+			Expect(config.JvmOptions.InitialHeapSize).To(Equal("300M"))
+			Expect(config.JvmOptions.MaxHeapSize).To(Equal("300M"))
+			Expect(config.JvmOptions.YoungGenSize).To(Equal(""))
+		})
+
+		It("setting JVM heap settings at dc-level without size", func() {
+
+			dcName := "dc1"
+			options := &helm.Options{
+				SetValues: map[string]string{
+					// Note: not setting "cassandra.datacenters[0].heap.size":       "300M",
+					"cassandra.datacenters[0].name":            dcName,
+					"cassandra.datacenters[0].heap.newGenSize": "150M",
+				},
+				KubectlOptions: defaultKubeCtlOptions,
+			}
+
+			Expect(renderTemplate(options)).To(Succeed())
+
+			var config Config
+			Expect(json.Unmarshal(cassdc.Spec.Config, &config)).To(Succeed())
+			Expect(config.JvmOptions).ToNot(BeNil())
+			Expect(config.JvmOptions.InitialHeapSize).To(Equal(""))
+			Expect(config.JvmOptions.MaxHeapSize).To(Equal(""))
+			Expect(config.JvmOptions.YoungGenSize).To(Equal("150M"))
+		})
+
+		It("setting JVM heap settings at cluster-level without newGenSize", func() {
+
+			dcName := "dc1"
+			options := &helm.Options{
+				SetValues: map[string]string{
+					"cassandra.heap.size":           "300M",
+					"cassandra.datacenters[0].name": dcName,
+					// Note: not setting - "cassandra.heap.newGenSize": "150M",
+				},
+				KubectlOptions: defaultKubeCtlOptions,
+			}
+
+			Expect(renderTemplate(options)).To(Succeed())
+
+			var config Config
+			Expect(json.Unmarshal(cassdc.Spec.Config, &config)).To(Succeed())
+
+			Expect(config.JvmOptions).ToNot(BeNil())
+			Expect(config.JvmOptions.InitialHeapSize).To(Equal("300M"))
+			Expect(config.JvmOptions.MaxHeapSize).To(Equal("300M"))
+			Expect(config.JvmOptions.YoungGenSize).To(Equal(""))
+		})
+
+		It("setting JVM heap settings at cluster-level without size", func() {
+
+			dcName := "dc1"
+			options := &helm.Options{
+				SetValues: map[string]string{
+					// Note: not setting - "cassandra.heap.size": "300M",
+					"cassandra.heap.newGenSize":     "150M",
+					"cassandra.datacenters[0].name": dcName,
+				},
+				KubectlOptions: defaultKubeCtlOptions,
+			}
+
+			Expect(renderTemplate(options)).To(Succeed())
+
+			var config Config
+			Expect(json.Unmarshal(cassdc.Spec.Config, &config)).To(Succeed())
+
+			Expect(config.JvmOptions).ToNot(BeNil())
+			Expect(config.JvmOptions.InitialHeapSize).To(Equal(""))
+			Expect(config.JvmOptions.MaxHeapSize).To(Equal(""))
+			Expect(config.JvmOptions.YoungGenSize).To(Equal("150M"))
+		})
 	})
 })

--- a/tests/unit/template_cassdc_test.go
+++ b/tests/unit/template_cassdc_test.go
@@ -103,9 +103,9 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 			var config Config
 			Expect(json.Unmarshal(cassdc.Spec.Config, &config)).To(Succeed())
 			Expect(config.JvmOptions).ToNot(BeNil())
-			Expect(config.JvmOptions.InitialHeapSize).To(Equal("800M"))
-			Expect(config.JvmOptions.MaxHeapSize).To(Equal("800M"))
-			Expect(config.JvmOptions.YoungGenSize).To(Equal("1.6Gi"))
+			Expect(config.JvmOptions.InitialHeapSize).To(BeEmpty())
+			Expect(config.JvmOptions.MaxHeapSize).To(BeEmpty())
+			Expect(config.JvmOptions.YoungGenSize).To(BeEmpty())
 		})
 
 		It("override clusterName", func() {
@@ -443,10 +443,10 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 			dcName := "dc1"
 			options := &helm.Options{
 				SetValues: map[string]string{
-					"cassandra.datacenters[0].name": dcName,
+					"cassandra.heap.size":           "700M",
+					"cassandra.heap.newGenSize":     "350M",
 					"cassandra.datacenters[0].heap": "",
-					"cassandra.heap.size":           "100M",
-					"cassandra.heap.newGenSize":     "200M",
+					"cassandra.datacenters[0].name": dcName,
 				},
 				KubectlOptions: defaultKubeCtlOptions,
 			}
@@ -455,22 +455,23 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 
 			var config Config
 			Expect(json.Unmarshal(cassdc.Spec.Config, &config)).To(Succeed())
+
 			Expect(config.JvmOptions).ToNot(BeNil())
-			Expect(config.JvmOptions.InitialHeapSize).To(Equal("100M"))
-			Expect(config.JvmOptions.MaxHeapSize).To(Equal("100M"))
-			Expect(config.JvmOptions.YoungGenSize).To(Equal("200M"))
+			Expect(config.JvmOptions.InitialHeapSize).To(Equal("700M"))
+			Expect(config.JvmOptions.MaxHeapSize).To(Equal("700M"))
+			Expect(config.JvmOptions.YoungGenSize).To(Equal("350M"))
 		})
 
 		// Note: currently only one DC supported, to be expanded in future release.
-		It("setting JVM heap settings at dc level overriding cluster level", func() {
+		It("setting JVM heap settings at dc-level overriding cluster level", func() {
 
 			dcName := "dc1"
 			options := &helm.Options{
 				SetValues: map[string]string{
-					"cassandra.heap.size":                      "100M",
-					"cassandra.heap.newGenSize":                "200M",
+					"cassandra.heap.size":                      "700M",
+					"cassandra.heap.newGenSize":                "350M",
 					"cassandra.datacenters[0].heap.size":       "300M",
-					"cassandra.datacenters[0].heap.newGenSize": "600M",
+					"cassandra.datacenters[0].heap.newGenSize": "150M",
 					"cassandra.datacenters[0].name":            dcName,
 				},
 				KubectlOptions: defaultKubeCtlOptions,
@@ -483,31 +484,7 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 			Expect(config.JvmOptions).ToNot(BeNil())
 			Expect(config.JvmOptions.InitialHeapSize).To(Equal("300M"))
 			Expect(config.JvmOptions.MaxHeapSize).To(Equal("300M"))
-			Expect(config.JvmOptions.YoungGenSize).To(Equal("600M"))
-		})
-
-		// Note: currently only one DC supported, to be expanded in future release.
-		It("setting JVM heap settings at datacenter WITHOUT cluster-level settings", func() {
-
-			dcName := "dc1"
-			options := &helm.Options{
-				SetValues: map[string]string{
-					"cassandra.heap":                           "",
-					"cassandra.datacenters[0].name":            dcName,
-					"cassandra.datacenters[0].heap.size":       "600M",
-					"cassandra.datacenters[0].heap.newGenSize": "1.2Gi",
-				},
-				KubectlOptions: defaultKubeCtlOptions,
-			}
-
-			Expect(renderTemplate(options)).To(Succeed())
-
-			var config Config
-			Expect(json.Unmarshal(cassdc.Spec.Config, &config)).To(Succeed())
-			Expect(config.JvmOptions).ToNot(BeNil())
-			Expect(config.JvmOptions.InitialHeapSize).To(Equal("600M"))
-			Expect(config.JvmOptions.MaxHeapSize).To(Equal("600M"))
-			Expect(config.JvmOptions.YoungGenSize).To(Equal("1.2Gi"))
+			Expect(config.JvmOptions.YoungGenSize).To(Equal("150M"))
 		})
 	})
 })


### PR DESCRIPTION
Provides cluster, dc, and default jvm heap option configurations as described in #158.

[Design Notes](https://github.com/k8ssandra/k8ssandra/issues/158#issuecomment-765010492)