### PR TITLE
need to make sure the enabled flag for kubernetes is set

### DIFF
--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.33.0
+version: 0.34.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/k8ssandra/templates/medusa-config.yaml
+++ b/charts/k8ssandra/templates/medusa-config.yaml
@@ -35,6 +35,7 @@ data:
 
     [kubernetes]
     cassandra_url = http://localhost:7373/jolokia/
+    enabled = 1
 
     [logging]
     level = DEBUG


### PR DESCRIPTION
With the Medusa image upgrade, there is a new config setting that we need to make sure is set. It basically tells Medusa it is running in k8s which will in turn cause Medusa to use Jolokia (and later the management-api) instead of nodetool.