### PR TITLE
#164: adding correct labels for Prometheus to pick up the Stargate ServiceMonitor

### DIFF
--- a/charts/k8ssandra/templates/stargate/service.yaml
+++ b/charts/k8ssandra/templates/stargate/service.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: {{ .Release.Name }}-{{ include "k8ssandra.datacenterName" . }}-stargate-service
   labels:
+    release: {{ .Release.Name }}
+    app: {{ .Release.Name }}-{{ include "k8ssandra.datacenterName" . }}-stargate
 {{ include "k8ssandra.labels" . | indent 4 }}
 spec:
   type: ClusterIP

--- a/charts/k8ssandra/templates/stargate/service_monitor.yaml
+++ b/charts/k8ssandra/templates/stargate/service_monitor.yaml
@@ -4,13 +4,15 @@ kind: ServiceMonitor
 metadata:
   name: {{ .Release.Name }}-prometheus-{{ include "k8ssandra.datacenterName" . }}-stargate
   labels:
+    release: {{ .Release.Name }}
+    app: {{ .Release.Name }}-{{ include "k8ssandra.datacenterName" . }}-stargate
 {{ include "k8ssandra.labels" . | indent 4 }}
 spec:
   selector:
     matchLabels:
       app: {{ .Release.Name }}-{{ include "k8ssandra.datacenterName" . }}-stargate
   endpoints:
-  - port: metrics
+  - port: health
     interval: 15s
     path: /metrics
     scheme: http

--- a/charts/k8ssandra/templates/stargate/stargate.yaml
+++ b/charts/k8ssandra/templates/stargate/stargate.yaml
@@ -4,6 +4,7 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}-{{ include "k8ssandra.datacenterName" . }}-stargate
   labels:
+    release: {{ .Release.Name }}
     app: {{ .Release.Name }}-{{ include "k8ssandra.datacenterName" . }}-stargate
 {{ include "k8ssandra.labels" . | indent 4 }}
 spec:


### PR DESCRIPTION
**What this PR does**:

The Stargate ServiceMonitor was merged as part of the original Stargate PR, but it wasn't quite right and Prometheus wasn't picking it up. This PR resolves those issues.

**Which issue(s) this PR fixes**:
Fixes #164

**Checklist**
- [x] Changes manually tested
- [ ] Chart versions updated (if necessary)
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
