### PR TITLE
Fix trademark violation

### DIFF
--- a/docs/content/en/docs/topics/accessing-services/repair/_index.md
+++ b/docs/content/en/docs/topics/accessing-services/repair/_index.md
@@ -6,7 +6,7 @@ description: |
   Follow these steps to access the Repair Web Interface (Reaper).
 ---
 
-Repairs are a critical anti-entropy operation in Apache Cassandra&reg;. In the past, there have been many custom solutions to manage them outside of your main Cassandra Installation. K8ssandra provides the Repair Web Interface (also known as Cassandra Reaper) that eliminates the need for a custom solution. Just like K8ssandra makes Cassandra setup easy, Reaper makes configuration of repairs even easier.
+Repairs are a critical anti-entropy operation in Apache Cassandra&reg;. In the past, there have been many custom solutions to manage them outside of your main Cassandra Installation. K8ssandra provides the Repair Web Interface (also known as Reaper) that eliminates the need for a custom solution. Just like K8ssandra makes Cassandra setup easy, Reaper makes configuration of repairs even easier.
 
 **Note:** The requirement for your environment may vary considerably, however the general recommendation is to run a repair operation on your Cassandra clusters about once a week. 
 


### PR DESCRIPTION
Projects and domain names can not use "Cassandra".
It is "Reaper" or "Reaper for Apache Cassandra".

https://www.apache.org/foundation/marks/faq/#products
https://apache.org/foundation/marks/#domains
