### PR TITLE
set prometheusSpec to a value and add some comments

### DIFF
--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.40.0
+version: 0.41.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -286,9 +286,12 @@ kube-prometheus-stack:
     # Provisions an instance of Prometheus as part of this release
     enabled: true
     prometheusSpec:
-      # Uncomment to listen for Prometheus traffic under a route prefix
-      # externalUrl: http://localhost:9090/prometheus
-      # routePrefix: /prometheus
+      # routePrefix is used to register routes, overriding externalUrl route. It is useful
+      # for proxies that rewrite URLs.
+      routePrefix: /
+
+      # externalUrl is an external URL at which Prometheus will be reachable.
+      externalUrl: ""
 
     # Enable templating of ingress resources for external prometheus traffic
     ingress:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Makes sure that the `prometheusSpec` property is set properly in order to eliminate the Helm warnings. This is done by uncommenting the `routePrefix` and `externalUrl` properties. I set them to their default values define in the kube-prometheus-stack chart.

**Which issue(s) this PR fixes**:
Fixes #295

**Checklist**
- [x] Changes manually tested
- [x] Chart versions updated (if necessary)
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
