### PR TITLE
Do not generate secret or set superUsername if auth is disabled

### DIFF
--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.42.0
+version: 0.42.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -54,12 +54,12 @@ spec:
   resources:
 {{ toYaml .Values.cassandra.resources | indent 6 }}
 {{- end }}
+{{- if .Values.cassandra.auth.enabled }}
 {{- if .Values.cassandra.auth.superuser.secret }}
   superuserSecretName: {{ .Values.cassandra.auth.superuser.secret }}
 {{- else if .Values.cassandra.auth.superuser.username }}
   superuserSecretName: {{ .Values.cassandra.clusterName }}-superuser
 {{- end }}
-{{- if .Values.cassandra.auth.enabled }}
   users:
   {{- if .Values.repair.reaper.enabled }}
     - secretName: {{ default (printf "%s-%s" .Values.cassandra.clusterName "reaper") .Values.repair.reaper.cassandraUser.secret }}

--- a/charts/k8ssandra/templates/cassandra/superuser-secret.yaml
+++ b/charts/k8ssandra/templates/cassandra/superuser-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.cassandra.auth.superuser.username (not .Values.cassandra.auth.superuser.secret) }}
+{{- if and .Values.cassandra.auth.superuser.username (not .Values.cassandra.auth.superuser.secret) .Values.cassandra.auth.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/tests/unit/template_superuser_secret_test.go
+++ b/tests/unit/template_superuser_secret_test.go
@@ -69,5 +69,23 @@ var _ = Describe("Verify superuser secret template", func() {
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(ContainSubstring("could not find template"))
 		})
+
+		It("disabling auth", func() {
+			username := "admin"
+			clusterName := "secret-test"
+			options := &helm.Options{
+				KubectlOptions: defaultKubeCtlOptions,
+				SetValues: map[string]string{
+					"cassandra.clusterName":             clusterName,
+					"cassandra.auth.superuser.username": username,
+					"cassandra.auth.enabled":            "false",
+				},
+			}
+
+			err := renderTemplate(options)
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("could not find template"))
+		})
+
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Fixes #261 by not generating a secret or set superUsername in CassandraDatacenter if auth is disabled

**Which issue(s) this PR fixes**:
Fixes #261

**Checklist**
- [ ] Changes manually tested
- [x] Chart versions updated (if necessary)
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
