### PR TITLE
Add ability to define s3_compatible settings as well as aws region

### DIFF
--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -3,7 +3,7 @@ name: k8ssandra
 description: |
   Provisions and configures an instance of the entire K8ssandra stack. This includes Apache Cassandra, Stargate, Reaper, Medusa, Prometheus, and Grafana.
 type: application
-version: 0.49.1
+version: 0.50.0
 appVersion: 3.11.10
 
 dependencies:

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -177,13 +177,8 @@ spec:
             mountPath: /etc/cassandra
           - mountPath: /var/lib/cassandra
             name: server-data
-{{- if eq .Values.backupRestore.medusa.storage "s3"}}
-          - name: medusa-bucket-key
-            mountPath: /etc/medusa-secrets
-{{- else if eq .Values.backupRestore.medusa.storage "gcs"}}
           - name:  {{ .Values.backupRestore.medusa.bucketSecret }}
             mountPath: /etc/medusa-secrets
-{{- end}}
 {{- end}}
 {{- end}}
       containers:

--- a/charts/k8ssandra/templates/medusa/medusa-config.yaml
+++ b/charts/k8ssandra/templates/medusa/medusa-config.yaml
@@ -21,8 +21,19 @@ data:
     [storage]
 {{- if eq .Values.backupRestore.medusa.storage "s3" }}
     storage_provider = s3
+    {{- if .Values.backupRestore.medusa.storage_properties.region }}
+    region = {{ .Values.backupRestore.medusa.storage_properties.region }}
+    {{- end}}
 {{- else if eq .Values.backupRestore.medusa.storage "gcs" }}
     storage_provider = gcs
+{{- else if eq .Values.backupRestore.medusa.storage "s3_compatible" }}
+    storage_provider = s3_compatible
+    {{- if .Values.backupRestore.medusa.storage_properties.region }}
+    region = {{ .Values.backupRestore.medusa.storage_properties.region }}
+    {{- end}}
+    host = {{ .Values.backupRestore.medusa.storage_properties.host }}
+    port = {{ .Values.backupRestore.medusa.storage_properties.port }}
+    secure = {{ .Values.backupRestore.medusa.storage_properties.secure }}
 {{- end }}
     bucket_name = {{ .Values.backupRestore.medusa.bucketName }}
     # TODO The file name needs to be parameterized. In the current set up it comes from the secret.

--- a/charts/k8ssandra/templates/medusa/medusa-config.yaml
+++ b/charts/k8ssandra/templates/medusa/medusa-config.yaml
@@ -19,23 +19,15 @@ data:
     check_running = nodetool version
 
     [storage]
-{{- if eq .Values.backupRestore.medusa.storage "s3" }}
-    storage_provider = s3
-    {{- if .Values.backupRestore.medusa.storage_properties.region }}
-    region = {{ .Values.backupRestore.medusa.storage_properties.region }}
-    {{- end}}
-{{- else if eq .Values.backupRestore.medusa.storage "gcs" }}
-    storage_provider = gcs
-{{- else if eq .Values.backupRestore.medusa.storage "s3_compatible" }}
-    storage_provider = s3_compatible
-    {{- if .Values.backupRestore.medusa.storage_properties.region }}
-    region = {{ .Values.backupRestore.medusa.storage_properties.region }}
-    {{- end}}
-    host = {{ .Values.backupRestore.medusa.storage_properties.host }}
-    port = {{ .Values.backupRestore.medusa.storage_properties.port }}
-    secure = {{ .Values.backupRestore.medusa.storage_properties.secure }}
+    storage_provider = {{ .Values.backupRestore.medusa.storage }}
+{{- range $key, $value := .Values.backupRestore.medusa.storage_properties -}}
+    $key = $value
 {{- end }}
+{{- if eq "local" .Values.backupRestore.medusa.storage -}}
+    base_path = {{ .Values.backupRestore.medusa.bucketName }}
+{{- else }}
     bucket_name = {{ .Values.backupRestore.medusa.bucketName }}
+{{- end }}
     # TODO The file name needs to be parameterized. In the current set up it comes from the secret.
     key_file = /etc/medusa-secrets/medusa_s3_credentials
 {{- if and .Values.backupRestore.medusa.multiTenant (has .Values.backupRestore.medusa.storage $bucketStorageTypes)}}

--- a/charts/k8ssandra/templates/medusa/medusa-config.yaml
+++ b/charts/k8ssandra/templates/medusa/medusa-config.yaml
@@ -19,18 +19,18 @@ data:
     check_running = nodetool version
 
     [storage]
-{{- if not (or (eq .Values.backupRestore.medusa.storage "s3") (eq .Values.backupRestore.medusa.storage "gcs") (eq .Values.backupRestore.medusa.storage "s3_compatible") (eq .Values.backupRestore.medusa.storage "local")) }}
-  {{ fail "Accepted storage type values are s3, s3_compatible, local and gcs" }}
-{{- end }}
+  {{- if not (or (eq .Values.backupRestore.medusa.storage "s3") (eq .Values.backupRestore.medusa.storage "gcs") (eq .Values.backupRestore.medusa.storage "s3_compatible") (eq .Values.backupRestore.medusa.storage "local")) }}
+    {{ fail "Accepted storage type values are s3, s3_compatible, local and gcs" }}
+  {{- end }}
     storage_provider = {{ .Values.backupRestore.medusa.storage }}
-{{- range $key, $value := .Values.backupRestore.medusa.storage_properties -}}
+  {{- range $key, $value := .Values.backupRestore.medusa.storage_properties }}
     {{ $key }} = {{ $value }}
-{{- end }}
-{{- if eq "local" .Values.backupRestore.medusa.storage -}}
+  {{- end }}
+  {{- if eq "local" .Values.backupRestore.medusa.storage }}
     base_path = {{ .Values.backupRestore.medusa.bucketName }}
-{{- else }}
+  {{- else }}
     bucket_name = {{ .Values.backupRestore.medusa.bucketName }}
-{{- end }}
+  {{- end }}
     # TODO The file name needs to be parameterized. In the current set up it comes from the secret.
     key_file = /etc/medusa-secrets/medusa_s3_credentials
 {{- if and .Values.backupRestore.medusa.multiTenant (has .Values.backupRestore.medusa.storage $bucketStorageTypes)}}

--- a/charts/k8ssandra/templates/medusa/medusa-config.yaml
+++ b/charts/k8ssandra/templates/medusa/medusa-config.yaml
@@ -19,9 +19,12 @@ data:
     check_running = nodetool version
 
     [storage]
+{{- if not (or (eq .Values.backupRestore.medusa.storage "s3") (eq .Values.backupRestore.medusa.storage "gcs") (eq .Values.backupRestore.medusa.storage "s3_compatible") (eq .Values.backupRestore.medusa.storage "local")) }}
+  {{ fail "Accepted storage type values are s3, s3_compatible, local and gcs" }}
+{{- end }}
     storage_provider = {{ .Values.backupRestore.medusa.storage }}
 {{- range $key, $value := .Values.backupRestore.medusa.storage_properties -}}
-    $key = $value
+    {{ $key }} = {{ $value }}
 {{- end }}
 {{- if eq "local" .Values.backupRestore.medusa.storage -}}
     base_path = {{ .Values.backupRestore.medusa.bucketName }}

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -250,16 +250,30 @@ backupRestore:
     # -- Enables usage of a bucket across multiple clusters.
     multiTenant: false
 
-    # -- API interface used by the object store. Supported values include `s3`
-    # and `gcs`
-    storage: s3
+    # -- API interface used by the object store. Supported values include `s3`, 's3_compatible'
+    # and `gcs`. For pod mapped storage, use 'local'
+    storage: s3_compatible
+
+    # -- Optional properties for storage
+    storage_properties:
+      # Optional argument to define region for s3
+      # region: eu-west-1
+
+      # For s3_compatible option, one must define target host
+      # host: 192.168.1.201
+
+      # For s3_compatible option, port is optional
+      # port: 9000
+
+      # Is SSL used or not, for s3_compatible
+      # secure: false
 
     # -- Name of the remote storage bucket where backups will be stored.
-    bucketName: ""
+    bucketName: awstest
 
     # -- Name of the Kubernetes `Secret` that stores the key file for the
     # storage provider's API
-    bucketSecret: ""
+    bucketSecret: medusaminiotest
 
 # Support for accessing the various web-interfaces via K8s ingress controllers.
 # Depending on the ingress available in your cluster enable the appropriate

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -229,7 +229,7 @@ backupRestore:
       # -- Specifies the container repository for Medusa
       repository: docker.io/k8ssandra/medusa
       # -- Tag of an image within the specified repository
-      tag: eaed2410
+      tag: 1e8a4695
       # -- The image pull policy
       pullPolicy: IfNotPresent
 

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -252,11 +252,11 @@ backupRestore:
 
     # -- API interface used by the object store. Supported values include `s3`, 's3_compatible'
     # and `gcs`. For pod mapped storage, use 'local'
-    storage: s3_compatible
+    storage: s3
 
-    # -- Optional properties for storage
-    storage_properties:
-      # Optional argument to define region for s3
+    # -- Optional properties for storage. Supported values depend on the type of the storage. 
+    storage_properties: {}
+      # Define region for s3 / s3_compatible
       # region: eu-west-1
 
       # For s3_compatible option, one must define target host
@@ -265,15 +265,16 @@ backupRestore:
       # For s3_compatible option, port is optional
       # port: 9000
 
-      # Is SSL used or not, for s3_compatible
+      # Is SSL used or not for s3_compatible connection
       # secure: false
 
-    # -- Name of the remote storage bucket where backups will be stored.
+    # -- Name of the remote storage bucket where backups will be stored. If using 'local' storage, set the
+    # path of the local storage here.
     bucketName: awstest
 
     # -- Name of the Kubernetes `Secret` that stores the key file for the
     # storage provider's API
-    bucketSecret: medusaminiotest
+    bucketSecret: medusa-bucket-key
 
 # Support for accessing the various web-interfaces via K8s ingress controllers.
 # Depending on the ingress available in your cluster enable the appropriate

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -229,7 +229,7 @@ backupRestore:
       # -- Specifies the container repository for Medusa
       repository: docker.io/k8ssandra/medusa
       # -- Tag of an image within the specified repository
-      tag: 48a42da3
+      tag: eaed2410
       # -- The image pull policy
       pullPolicy: IfNotPresent
 

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -229,7 +229,7 @@ backupRestore:
       # -- Specifies the container repository for Medusa
       repository: docker.io/k8ssandra/medusa
       # -- Tag of an image within the specified repository
-      tag: 6ab6a55541e9
+      tag: 48a42da3
       # -- The image pull policy
       pullPolicy: IfNotPresent
 

--- a/tests/unit/template_medusa_config_test.go
+++ b/tests/unit/template_medusa_config_test.go
@@ -1,0 +1,59 @@
+package unit_test
+
+import (
+	"path/filepath"
+
+	helmUtils "github.com/k8ssandra/k8ssandra/tests/unit/utils/helm"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("Verify medusa config template", func() {
+	var (
+		helmChartPath string
+		secret        *corev1.Secret
+	)
+
+	BeforeEach(func() {
+		path, err := filepath.Abs(ChartsPath)
+		Expect(err).To(BeNil())
+		helmChartPath = path
+		secret = &corev1.Secret{}
+	})
+
+	renderTemplate := func(options *helm.Options) error {
+		return helmUtils.RenderAndUnmarshall("templates/medusa/medusa-config.yaml",
+			options, helmChartPath, HelmReleaseName,
+			func(renderedYaml string) error {
+				return helm.UnmarshalK8SYamlE(GinkgoT(), renderedYaml, secret)
+			})
+	}
+
+	Context("generating medusa storage properties", func() {
+		DescribeTable("render template",
+			func(storageType string, expected bool) {
+				options := &helm.Options{
+					KubectlOptions: defaultKubeCtlOptions,
+					SetValues: map[string]string{
+						"backupRestore.medusa.enabled":      "true",
+						"backupRestore.medusa.storage":      storageType,
+						"backupRestore.medusa.bucketName":   "testbucket",
+						"backupRestore.medusa.bucketSecret": "secretkey",
+					},
+				}
+				Expect(renderTemplate(options)).To(Succeed())
+			},
+			Entry("supported s3", "s3", true),
+			Entry("supported s3 compatible", "s3_compatible", true),
+			Entry("supported gcs", "gcs", true),
+			Entry("supported local", "local", true),
+			Entry("unsupported azure", "azure", false),
+			Entry("unsupported ibm_storage (use s3_compatible instead)", "ibm_storage", false),
+			Entry("supported value", "random", false),
+		)
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds the ability to set region for AWS as well as use S3 compatible storage options that are not AWS S3.

**Which issue(s) this PR fixes**:
Fixes #142 

**Checklist**
- [x] Changes manually tested
- [ ] Chart versions updated (if necessary)
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
