### PR TITLE
don't use subPath mounts and update tests

### DIFF
--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -3,7 +3,7 @@ name: k8ssandra
 description: |
   Provisions and configures an instance of the entire K8ssandra stack. This includes Apache Cassandra, Stargate, Reaper, Medusa, Prometheus, and Grafana.
 type: application
-version: 0.44.0
+version: 0.45.0
 appVersion: 3.11.7
 dependencies:
   - name: cass-operator

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -186,8 +186,7 @@ spec:
         {{- end}}
         volumeMounts:
           - name: {{ .Release.Name }}-medusa-config-k8ssandra
-            mountPath: /etc/medusa/medusa.ini
-            subPath: medusa.ini
+            mountPath: /etc/medusa
           - name: server-config
             mountPath: /etc/cassandra
           - mountPath: /var/lib/cassandra
@@ -258,8 +257,7 @@ spec:
           initialDelaySeconds: 10
         volumeMounts:
           - name: {{ .Release.Name }}-medusa-config-k8ssandra
-            mountPath: /etc/medusa/medusa.ini
-            subPath: medusa.ini
+            mountPath: /etc/medusa
           - name: cassandra-config
             mountPath: /etc/cassandra
           - mountPath: /var/lib/cassandra

--- a/tests/unit/template_cassdc_test.go
+++ b/tests/unit/template_cassdc_test.go
@@ -436,9 +436,7 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 				cqlPasswordEnvVar,
 			}))
 
-			// Verify volumeMounts and volumes
-			Expect(len(medusaContainer.VolumeMounts)).To(Equal(4))
-			Expect(medusaContainer.VolumeMounts[0].Name).To(Equal(medusaConfigVolumeName))
+			verifyMedusaVolumeMounts(medusaContainer)
 
 			Expect(len(cassdc.Spec.PodTemplateSpec.Spec.Volumes)).To(Equal(3))
 			Expect(cassdc.Spec.PodTemplateSpec.Spec.Volumes[0].Name).To(Equal(medusaConfigVolumeName))
@@ -520,9 +518,7 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 				cqlPasswordEnvVar,
 			}))
 
-			// Verify volumeMounts and volumes
-			Expect(len(medusaContainer.VolumeMounts)).To(Equal(4))
-			Expect(medusaContainer.VolumeMounts[0].Name).To(Equal(medusaConfigVolumeName))
+			verifyMedusaVolumeMounts(medusaContainer)
 
 			Expect(len(cassdc.Spec.PodTemplateSpec.Spec.Volumes)).To(Equal(3))
 			Expect(cassdc.Spec.PodTemplateSpec.Spec.Volumes[0].Name).To(Equal(medusaConfigVolumeName))
@@ -897,6 +893,11 @@ func getInitContainer(cassdc *cassdcv1beta1.CassandraDatacenter, name string) *c
 func getContainer(cassdc *cassdcv1beta1.CassandraDatacenter, name string) *corev1.Container {
 	return getContainerByName(cassdc.Spec.PodTemplateSpec.Spec.Containers, name)
 
+}
+
+func verifyMedusaVolumeMounts(container *corev1.Container) {
+	ExpectWithOffset(1, len(container.VolumeMounts)).To(Equal(4))
+	ExpectWithOffset(1, container.VolumeMounts[0]).To(Equal(corev1.VolumeMount{Name: medusaConfigVolumeName, MountPath: "/etc/medusa"}))
 }
 
 func assertInitContainerNamesMatch(cassdc *cassdcv1beta1.CassandraDatacenter, names ...string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Stops using subPath volume mounts for the medusa configmap

**Which issue(s) this PR fixes**:
Fixes #328 

**Checklist**
- [x] Changes manually tested
- [x] Chart versions updated (if necessary)
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
