### PR TITLE
If stargate, medusa and reaper are disabled, do not render users.

### DIFF
--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -3,7 +3,7 @@ name: k8ssandra
 description: |
   Provisions and configures an instance of the entire K8ssandra stack. This includes Apache Cassandra, Stargate, Reaper, Medusa, Prometheus, and Grafana.
 type: application
-version: 0.46.0
+version: 0.46.1
 appVersion: 3.11.7
 dependencies:
   - name: cass-operator

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -57,6 +57,7 @@ spec:
 {{- else if .Values.cassandra.auth.superuser.username }}
   superuserSecretName: {{ include "k8ssandra.clusterName" . }}-superuser
 {{- end }}
+  {{- if or .Values.repair.reaper.enabled .Values.backupRestore.medusa.enabled .Values.stargate.enabled }}
   users:
   {{- if .Values.repair.reaper.enabled }}
     - secretName: {{ default (printf "%s-%s" (include "k8ssandra.clusterName" .) "reaper") .Values.repair.reaper.cassandraUser.secret }}
@@ -69,6 +70,7 @@ spec:
   {{- if .Values.stargate.enabled }}
     - secretName: {{ default (printf "%s-%s" (include "k8ssandra.clusterName" .) "stargate") .Values.stargate.cassandraUser.secret }}
       superuser: true
+  {{- end }}
   {{- end }}
 {{- end }}
   config:    


### PR DESCRIPTION
**What this PR does**:
Adds a if clause to the cassdc.yaml template to prevent rendering of empty "users" definition in CassandraDatacenter.

**Which issue(s) this PR fixes**:
 Fixes #334 

**Checklist**
- [x] Changes manually tested
- [x] Chart versions updated (if necessary)
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
