### PR TITLE
Removing the pathType as suggested by Michael to resolve backwards co…

### DIFF
--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -3,7 +3,7 @@ name: k8ssandra
 description: |
   Provisions and configures an instance of the entire K8ssandra stack. This includes Apache Cassandra, Stargate, Reaper, Medusa, Prometheus, and Grafana.
 type: application
-version: 0.49.0
+version: 0.49.1
 appVersion: 3.11.10
 
 dependencies:

--- a/charts/k8ssandra/templates/stargate/ingress.yaml
+++ b/charts/k8ssandra/templates/stargate/ingress.yaml
@@ -40,7 +40,6 @@ spec:
               servicePort: 8080
   {{- if $traefik.stargate.graphql.playground.enabled }}
           - path: /playground
-            pathType: Exact
             backend:
               serviceName: {{ $releaseName }}-{{ $datacenterName }}-stargate-service
               servicePort: 8080

--- a/tests/unit/template_stargate_ingress_test.go
+++ b/tests/unit/template_stargate_ingress_test.go
@@ -165,8 +165,7 @@ func verifyIngressRules(ingress networking.Ingress, host *string, graphEnabled b
 		kubeapi.VerifyIngressRule(rules, "/graphql/", nil, host, serviceName, 8080)
 		kubeapi.VerifyIngressRule(rules, "/graphql-schema", nil, host, serviceName, 8080)
 		if playgroundEnabled {
-			pathType := networking.PathTypeExact
-			kubeapi.VerifyIngressRule(rules, "/playground", &pathType, host, serviceName, 8080)
+			kubeapi.VerifyIngressRule(rules, "/playground", nil, host, serviceName, 8080)
 		} else {
 			kubeapi.VerifyNoRuleWithPath(rules, "/playground")
 		}


### PR DESCRIPTION
…mpatibility issues with older versions of kubernetes.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Removes the pathType specification in the template deployed for the stargate ingress resources.  Per discussion in #366 it's not supported < 1.18.

I did some testing to make sure that after the change ingress was working as expected, things seem good:

```
% curl -L -X POST 'http://stargate.127.0.0.1.nip.io:8081/v1/auth' -H 'Content-Type: application/json' --data-raw '{"username": "k8ssandra-cluster-superuser", "password": "XOHBHcJs_f8CFcciczCJYjmZEvoJmpBKpHVTVjO3G386yqWV6HtrEA"}'
{"authToken":"f9e58ea3-8460-452a-8584-01e3479ffcac"}%                                  
```

```
% curl --location --request GET 'http://stargate.127.0.0.1.nip.io:8080/v2/schemas/namespaces' \
--header "x-cassandra-token: f9e58ea3-8460-452a-8584-01e3479ffcac"
{"data":[{"name":"medusa_test"},{"name":"system_distributed"},{"name":"system"},{"name":"data_endpoint_auth"},{"name":"system_schema"},{"name":"stargate_system"},{"name":"reaper_db","datacenters":[{"name":"dc1","replicas":1}]},{"name":"system_auth"},{"name":"system_traces"}]}%   
```

```                                                                    
% curl -L \
-X GET 'http://stargate.127.0.0.1.nip.io:8080/v2/schemas/keyspaces/'medusa_test'/tables/users' \
-H "X-Cassandra-Token: f9e58ea3-8460-452a-8584-01e3479ffcac" \
-H "accept: application/json"
{"data":{"name":"users","keyspace":"medusa_test","columnDefinitions":[{"name":"email","typeDefinition":"varchar","static":false},{"name":"name","typeDefinition":"varchar","static":false},{"name":"state","typeDefinition":"varchar","static":false}],"primaryKey":{"partitionKey":["email"],"clusteringKey":[]},"tableOptions":{"defaultTimeToLive":0,"clusteringExpression":[]}}}%    
```

```
% wget http://stargate.127.0.0.1.nip.io:8080/playground
--2021-02-12 10:58:40--  http://stargate.127.0.0.1.nip.io:8080/playground
Resolving stargate.127.0.0.1.nip.io (stargate.127.0.0.1.nip.io)... 127.0.0.1
Connecting to stargate.127.0.0.1.nip.io (stargate.127.0.0.1.nip.io)|127.0.0.1|:8080... connected.
HTTP request sent, awaiting response... 200 OK
Length: unspecified [text/html]
Saving to: ‘playground’

playground                [ <=>                     ]  18.64K  --.-KB/s    in 0s      

2021-02-12 10:58:40 (190 MB/s) - ‘playground’ saved [19090]
```

```
% wget http://repair.127.0.0.1.nip.io:8080/webui/
--2021-02-12 11:03:19--  http://repair.127.0.0.1.nip.io:8080/webui/
Resolving repair.127.0.0.1.nip.io (repair.127.0.0.1.nip.io)... 127.0.0.1
Connecting to repair.127.0.0.1.nip.io (repair.127.0.0.1.nip.io)|127.0.0.1|:8080... connected.
HTTP request sent, awaiting response... 200 OK
Length: 1932 (1.9K) [text/html]
Saving to: ‘index.html’

index.html     0%       0  --.-KB/s  index.html   100%   1.89K  --.-KB/s    in 0s      

2021-02-12 11:03:19 (132 MB/s) - ‘index.html’ saved [1932/1932]
```

As I was was testing I did encounter a problem with the CQL via Stargate:

![image](https://user-images.githubusercontent.com/7901615/107796322-b6070e80-6d27-11eb-887f-495ae01f08fb.png)

@jakerobb let me know that he's addressing that as part of what he's working on now, I will file a separate issue to track that.  But the pathType change seems working.

**Which issue(s) this PR fixes**:
Fixes #366 

**Checklist**
- [x] Changes manually tested
- [x] Chart versions updated (if necessary)
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
