### PR TITLE
enable copying of code samples in docs

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -125,7 +125,7 @@ algolia_docsearch = false
 offlineSearch = false
 
 # Enable syntax highlighting and copy buttons on code blocks with Prism
-prism_syntax_highlighting = false
+prism_syntax_highlighting = true
 
 # User interface configuration
 [params.ui]


### PR DESCRIPTION
Enabling the `prism_syntax_highlighting` option in the doc site configuration makes it possible to copy/paste content from tutorials, which makes the tutorials easier to consume.