### PR TITLE
Set the default value of tokens for each supported version

### DIFF
--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -3,7 +3,7 @@ name: k8ssandra
 description: |
   Provisions and configures an instance of the entire K8ssandra stack. This includes Apache Cassandra, Stargate, Reaper, Medusa, Prometheus, and Grafana.
 type: application
-version: 0.50.0
+version: 0.51.0
 appVersion: 3.11.10
 
 dependencies:

--- a/charts/k8ssandra/templates/_helpers.tpl
+++ b/charts/k8ssandra/templates/_helpers.tpl
@@ -87,3 +87,19 @@ Create the jvm options based on heap properties specified.
   {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Set default num_tokens based on the server version
+*/}}
+{{- define "k8ssandra.default_num_tokens" -}}
+{{- $datacenter := (index .Values.cassandra.datacenters 0) -}}
+    {{- if $datacenter.num_tokens }}
+      num_tokens: {{ $datacenter.num_tokens }}
+    {{- else }}
+    {{- if hasPrefix "3.11" .Values.cassandra.version }}
+      num_tokens: 256
+    {{- else }}
+      num_tokens: 16
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -75,6 +75,7 @@ spec:
 {{- end }}
   config:    
     cassandra-yaml:
+      {{- include "k8ssandra.default_num_tokens" . }}
 {{- if .Values.cassandra.auth.enabled }}
       authenticator: PasswordAuthenticator
       authorizer: CassandraAuthorizer

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -98,7 +98,7 @@ cassandra:
     size: 1
 
     # -- Number of tokens within the datacenter. If not defined, the default values will be
-    # used. 
+    # used, which are 256 tokens for 3.11 releases and 16 tokens for 4.0 releases.
     # num_tokens: 16
 
     # -- Specifies the racks for the data center, if unset the datacenter will

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -97,6 +97,10 @@ cassandra:
     # environments.
     size: 1
 
+    # -- Number of tokens within the datacenter. If not defined, the default values will be
+    # used. 
+    # num_tokens: 16
+
     # -- Specifies the racks for the data center, if unset the datacenter will
     # be composed of a single rack named `default`. The number of racks should
     # equal the replication factor of your application keyspaces. Cassandra will

--- a/tests/unit/template_cassdc_test.go
+++ b/tests/unit/template_cassdc_test.go
@@ -895,7 +895,7 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 		Expect(cassdc.Spec.Users).To(ConsistOf(cassdcv1beta1.CassandraUser{Superuser: true, SecretName: clusterName + "-stargate"}))
 	})
 
-	FDescribeTable("check num_tokens",
+	DescribeTable("check num_tokens",
 		func(version, numTokens string, expectedTokens int) {
 			options := &helm.Options{
 				KubectlOptions: defaultKubeCtlOptions,

--- a/tests/unit/template_cassdc_test.go
+++ b/tests/unit/template_cassdc_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/helm"
 	. "github.com/k8ssandra/k8ssandra/tests/unit/utils/cassdc"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -27,6 +28,7 @@ type CassandraConfig struct {
 	PermissionsUpdateMillis   int64 `json:"permissions_update_interval_in_ms"`
 	CredentialsValidityMillis int64 `json:"credentials_validity_in_ms"`
 	CredentialsUpdateMillis   int64 `json:"credentials_update_interval_in_ms"`
+	NumTokens                 int64 `json:"num_tokens"`
 }
 
 type JvmOptions struct {
@@ -892,6 +894,30 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 
 		Expect(cassdc.Spec.Users).To(ConsistOf(cassdcv1beta1.CassandraUser{Superuser: true, SecretName: clusterName + "-stargate"}))
 	})
+
+	FDescribeTable("check num_tokens",
+		func(version, numTokens string, expectedTokens int) {
+			options := &helm.Options{
+				KubectlOptions: defaultKubeCtlOptions,
+				SetValues: map[string]string{
+					"cassandra.version": version,
+					// Need the following parameters to succeed in rendering
+					"cassandra.datacenters[0].name": "dc-test",
+					"cassandra.datacenters[0].size": "1",
+				},
+			}
+			if numTokens != "" {
+				options.SetValues["cassandra.datacenters[0].num_tokens"] = numTokens
+			}
+
+			Expect(renderTemplate(options)).To(Succeed())
+			var config Config
+			Expect(json.Unmarshal(cassdc.Spec.Config, &config)).To(Succeed())
+			Expect(config.CassandraConfig.NumTokens).To(Equal(int64(expectedTokens)))
+		},
+		Entry("3.11.10 default", "3.11.10", "", 256),
+		Entry("3.11.10 custom", "3.11.10", "16", 16),
+	)
 })
 
 func verifyMedusaVolumeMounts(container *corev1.Container) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Overrides the num_tokens in cass-operator by setting it to a default value as defined in the used version. This would be 256 for 3.11.* and 16 for 4.0*. Also allows overriding to set a defined value.

**Which issue(s) this PR fixes**:
Fixes #324 

**Checklist**
- [ ] Changes manually tested
- [x] Chart versions updated (if necessary)
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
