### PR TITLE
Allow to run subset of unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,18 @@ CLEANER_LATEST_IMAGE=$(CLEANER_IMAGE_BASE):latest
 # Image URL to use all building/pushing image targets
 CLEANER_IMG ?= $(CLEANER_LATEST_IMAGE)
 
+TESTS=all
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
-test: fmt vet
+test: fmt vet unit-test pkg-test
+
+unit-test:
+ifeq ($(TESTS), all)
 	go test -v -test.timeout=3m ./tests/unit/... -coverprofile cover.out
+else
+	go test -v -test.timeout=3m ./tests/unit/... -coverprofile cover.out -args -ginkgo.focus="$(TESTS)"
+endif
+
+pkg-test:
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh && fetch_envtest_tools $(ENVTEST_ASSETS_DIR) && setup_envtest_env $(ENVTEST_ASSETS_DIR) && go test -v -test.timeout=3m ./pkg/... -coverprofile cover.out

--- a/Makefile
+++ b/Makefile
@@ -14,23 +14,24 @@ CLEANER_LATEST_IMAGE=$(CLEANER_IMAGE_BASE):latest
 CLEANER_IMG ?= $(CLEANER_LATEST_IMAGE)
 
 TESTS=all
+GO_FLAGS=
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: fmt vet unit-test pkg-test
 
 unit-test:
 ifeq ($(TESTS), all)
-	go test -v -test.timeout=3m ./tests/unit/... -coverprofile cover.out
+	go test $(GO_FLAGS) -test.timeout=3m ./tests/unit/... -coverprofile cover.out
 else
-	go test -v -test.timeout=3m ./tests/unit/... -coverprofile cover.out -args -ginkgo.focus="$(TESTS)"
+	go test $(GO_FLAGS) -test.timeout=3m ./tests/unit/... -coverprofile cover.out -args -ginkgo.focus="$(TESTS)"
 endif
 
 pkg-test:
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh && fetch_envtest_tools $(ENVTEST_ASSETS_DIR) && setup_envtest_env $(ENVTEST_ASSETS_DIR) && go test -v -test.timeout=3m ./pkg/... -coverprofile cover.out
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh && fetch_envtest_tools $(ENVTEST_ASSETS_DIR) && setup_envtest_env $(ENVTEST_ASSETS_DIR) && go test $(GO_FLAGS) -test.timeout=3m ./pkg/... -coverprofile cover.out
 
 integ-test:
-	go test -v -test.timeout=5m ./tests/integration/... -coverprofile cover.out
+	go test $(GO_FLAGS) -test.timeout=5m ./tests/integration/... -coverprofile cover.out
 
 fmt:
 	go fmt ./pkg/...


### PR DESCRIPTION
**What this PR does**:
Adds TESTS parameter to the Makefile, allowing the following behavior:

```
⋊> ~/p/g/d/k8ssandra on main ⨯ make TESTS=".*auth.*" unit-test                                                                                                                                                                                                                           09:01:49
go test -v -test.timeout=3m ./tests/unit/... -coverprofile cover.out -args -ginkgo.focus=".*auth.*"
=== RUN   TestTemplateUnitTests
Running Suite: Unit tests suite
===============================
Random Seed: 1613977317
Will run 7 of 126 specs
```

With just ``make unit-test`` all unit tests (template tests basically) are run and ``make test`` behavior will remain the same as before. ``make pkg-test`` allows running the pkg/* tests only.

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Changes manually tested
- [ ] Chart versions updated (if necessary)
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
