### PR TITLE
Stargate support for 4.0.0

### DIFF
--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -3,7 +3,7 @@ name: k8ssandra
 description: |
   Provisions and configures an instance of the entire K8ssandra stack. This includes Apache Cassandra, Stargate, Reaper, Medusa, Prometheus, and Grafana.
 type: application
-version: 0.53.0
+version: 0.54.0
 appVersion: 3.11.10
 
 dependencies:

--- a/charts/k8ssandra/templates/stargate/stargate.yaml
+++ b/charts/k8ssandra/templates/stargate/stargate.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.stargate.enabled }}
 {{- $heapMB := required "stargate.heapMB is required" .Values.stargate.heapMB -}}
-{{- $image := default "stargateio/stargate-3_11:v1.0.7" .Values.stargate.image -}}
+{{- $image := default "stargateio/stargate-3_11:v1.0.8" .Values.stargate.image -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -84,7 +84,7 @@ spec:
             - name: CLUSTER_NAME
               value: {{ include "k8ssandra.clusterName" . | quote }}
             - name: CLUSTER_VERSION
-              value: "3.11"
+              value: {{ .Values.stargate.clusterVersion | default "3.11" | quote }}
             - name: SEED
               value: "{{ include "k8ssandra.clusterName" . }}-seed-service.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain | default "cluster.local" }}"
             - name: DATACENTER_NAME

--- a/charts/k8ssandra/templates/stargate/stargate.yaml
+++ b/charts/k8ssandra/templates/stargate/stargate.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.stargate.enabled }}
 {{- $heapMB := required "stargate.heapMB is required" .Values.stargate.heapMB -}}
-{{- $image := default "stargateio/stargate-3_11:v1.0.8" .Values.stargate.image -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -35,7 +34,13 @@ spec:
                 echo "Cassandra is ready. Starting Stargate..."
       containers:
         - name: {{ .Release.Name }}-{{ include "k8ssandra.datacenterName" . }}-stargate
-          image: {{ $image }}
+        {{- if .Values.stargate.image }}
+          image: {{ .Values.stargate.image | quote }}
+        {{- else if (hasPrefix "3" .Values.cassandra.version) }}
+          image: "stargateio/stargate-3_11:v1.0.8"
+        {{- else }}
+          image: "stargateio/stargate-4_0:v1.0.8"
+        {{- end }}
           imagePullPolicy: {{ .Values.stargate.imagePullPolicy }}
           ports:
             - name: graphql
@@ -84,7 +89,13 @@ spec:
             - name: CLUSTER_NAME
               value: {{ include "k8ssandra.clusterName" . | quote }}
             - name: CLUSTER_VERSION
-              value: {{ .Values.stargate.clusterVersion | default "3.11" | quote }}
+            {{- if .Values.stargate.clusterVersion }}
+              value: {{ .Values.stargate.clusterVersion | quote }}
+            {{- else if (hasPrefix "3" .Values.cassandra.version) }}
+              value: "3.11"
+            {{- else }}
+              value: "4.0"
+            {{- end }}
             - name: SEED
               value: "{{ include "k8ssandra.clusterName" . }}-seed-service.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain | default "cluster.local" }}"
             - name: DATACENTER_NAME

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -176,6 +176,10 @@ stargate:
   # will derive an appropriate image based on your cluster version.
   image:
 
+  # -- Sets the CLUSTER_VERSION variable provided to the Stargate containers.
+  # If left blank (recommended), k8ssandra will derive an appropriate image based on your cluster version.
+  clusterVersion:
+
   # -- Sets the imagePullPolicy used by the Stargate pods
   imagePullPolicy: IfNotPresent
 

--- a/tests/unit/template_stargate_test.go
+++ b/tests/unit/template_stargate_test.go
@@ -12,6 +12,15 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 )
 
+const (
+	DefaultStargate3Image          = "stargateio/stargate-3_11:v1.0.8"
+	DefaultStargate4Image          = "stargateio/stargate-4_0:v1.0.8"
+	DefaultStargate3ClusterVersion = "3.11"
+	DefaultStargate4ClusterVersion = "4.0"
+	DefaultStargateImage           = DefaultStargate3Image
+	DefaultStargateClusterVersion  = DefaultStargate3ClusterVersion
+)
+
 var _ = Describe("Verify Stargate template", func() {
 	var (
 		helmChartPath string
@@ -90,7 +99,7 @@ var _ = Describe("Verify Stargate template", func() {
 
 			Expect(len(templateSpec.Containers)).To(Equal(1))
 			container := templateSpec.Containers[0]
-			Expect(container.Image).To(Equal("stargateio/stargate-3_11:v1.0.7"))
+			Expect(container.Image).To(Equal(DefaultStargateImage))
 			Expect(container.Name).To(Equal(Sprintf("%s-dc1-stargate", HelmReleaseName)))
 			Expect(string(container.ImagePullPolicy)).To(Equal("IfNotPresent"))
 
@@ -110,11 +119,91 @@ var _ = Describe("Verify Stargate template", func() {
 			clusterName := kubeapi.FindEnvVarByName(container, "CLUSTER_NAME")
 			Expect(clusterName.Value).To(Equal(HelmReleaseName))
 
+			clusterVersion := kubeapi.FindEnvVarByName(container, "CLUSTER_VERSION")
+			Expect(clusterVersion.Value).To(Equal(DefaultStargateClusterVersion))
+
 			seed := kubeapi.FindEnvVarByName(container, "SEED")
 			Expect(seed.Value).To(Equal(Sprintf("%s-seed-service.%s.svc.cluster.local", HelmReleaseName, DefaultTestNamespace)))
 
 			datacenterName := kubeapi.FindEnvVarByName(container, "DATACENTER_NAME")
 			Expect(datacenterName.Value).To(Equal("dc1"))
+		})
+
+		It("using custom image and clusterVersion", func() {
+			// This combination of values makes no real sense and would not work
+			// but this tests that the defaults are avoided when a specific value is provided
+			image := "stargateio/stargate-4_0:v1.0.5"
+			clusterVersion := "3.0"
+
+			options := &helm.Options{
+				KubectlOptions: defaultKubeCtlOptions,
+				SetValues: map[string]string{
+					"stargate.enabled":        "true",
+					"stargate.image":          image,
+					"stargate.clusterVersion": clusterVersion,
+				},
+			}
+
+			Expect(renderTemplate(options)).To(Succeed())
+			templateSpec := deployment.Spec.Template.Spec
+			Expect(len(templateSpec.Containers)).To(Equal(1))
+			container := templateSpec.Containers[0]
+			Expect(container.Image).To(Equal(image))
+			clusterVersionEnv := kubeapi.FindEnvVarByName(container, "CLUSTER_VERSION")
+			Expect(clusterVersionEnv.Value).To(Equal(clusterVersion))
+		})
+
+		It("using defaults and empty clusterVersion", func() {
+			options := &helm.Options{
+				KubectlOptions: defaultKubeCtlOptions,
+				SetValues: map[string]string{
+					"stargate.enabled":        "true",
+					"stargate.clusterVersion": "",
+				},
+			}
+
+			Expect(renderTemplate(options)).To(Succeed())
+			templateSpec := deployment.Spec.Template.Spec
+			Expect(len(templateSpec.Containers)).To(Equal(1))
+			container := templateSpec.Containers[0]
+			clusterVersionEnv := kubeapi.FindEnvVarByName(container, "CLUSTER_VERSION")
+			Expect(clusterVersionEnv.Value).To(Equal(DefaultStargateClusterVersion))
+		})
+
+		It("using cassandra version 4.0.0", func() {
+			options := &helm.Options{
+				KubectlOptions: defaultKubeCtlOptions,
+				SetValues: map[string]string{
+					"stargate.enabled":  "true",
+					"cassandra.version": "4.0.0",
+				},
+			}
+
+			Expect(renderTemplate(options)).To(Succeed())
+			templateSpec := deployment.Spec.Template.Spec
+			Expect(len(templateSpec.Containers)).To(Equal(1))
+			container := templateSpec.Containers[0]
+			Expect(container.Image).To(Equal(DefaultStargate4Image))
+			clusterVersionEnv := kubeapi.FindEnvVarByName(container, "CLUSTER_VERSION")
+			Expect(clusterVersionEnv.Value).To(Equal(DefaultStargate4ClusterVersion))
+		})
+
+		It("using cassandra version 3.11.10", func() {
+			options := &helm.Options{
+				KubectlOptions: defaultKubeCtlOptions,
+				SetValues: map[string]string{
+					"stargate.enabled":  "true",
+					"cassandra.version": "3.11.10",
+				},
+			}
+
+			Expect(renderTemplate(options)).To(Succeed())
+			templateSpec := deployment.Spec.Template.Spec
+			Expect(len(templateSpec.Containers)).To(Equal(1))
+			container := templateSpec.Containers[0]
+			Expect(container.Image).To(Equal(DefaultStargate3Image))
+			clusterVersionEnv := kubeapi.FindEnvVarByName(container, "CLUSTER_VERSION")
+			Expect(clusterVersionEnv.Value).To(Equal(DefaultStargate3ClusterVersion))
 		})
 
 		It("changing cluster name", func() {

--- a/tests/unit/template_stargate_test.go
+++ b/tests/unit/template_stargate_test.go
@@ -166,6 +166,7 @@ var _ = Describe("Verify Stargate template", func() {
 			templateSpec := deployment.Spec.Template.Spec
 			Expect(len(templateSpec.Containers)).To(Equal(1))
 			container := templateSpec.Containers[0]
+			Expect(container.Image).To(Equal(DefaultStargateImage))
 			clusterVersionEnv := kubeapi.FindEnvVarByName(container, "CLUSTER_VERSION")
 			Expect(clusterVersionEnv.Value).To(Equal(DefaultStargateClusterVersion))
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Adds support for 4.0.0 via Stargate
* Automatically selects the stargate image based on cassandra.version
* Automatically selects the stargate CLUSTER_VERSION based on cassandra.version
* Allows for manual override of stargate image and CLUSTER_VERSION
* Upgrades to latest available stargate images: 1.0.8

**Which issue(s) this PR fixes**:
Fixes #397

**Checklist**
- [x] Changes manually tested
- [x] Chart versions updated (if necessary)
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
