### PR TITLE
397 support cass4 with stargate

### DIFF
--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -3,7 +3,7 @@ name: k8ssandra
 description: |
   Provisions and configures an instance of the entire K8ssandra stack. This includes Apache Cassandra, Stargate, Reaper, Medusa, Prometheus, and Grafana.
 type: application
-version: 0.53.0
+version: 0.54.0
 appVersion: 3.11.10
 
 dependencies:

--- a/charts/k8ssandra/templates/stargate/stargate.yaml
+++ b/charts/k8ssandra/templates/stargate/stargate.yaml
@@ -1,6 +1,13 @@
 {{- if .Values.stargate.enabled }}
-{{- $heapMB := required "stargate.heapMB is required" .Values.stargate.heapMB -}}
-{{- $image := default "stargateio/stargate-3_11:v1.0.7" .Values.stargate.image -}}
+  {{- $stargateVersion := "1.0.8" }}
+  {{- $heapMB := required "stargate.heapMB is required" .Values.stargate.heapMB -}}
+  {{- $clusterVersion := "3.11" }}
+  {{- $computedImage := printf "stargateio/stargate-3_11:v%s" $stargateVersion }}
+  {{- if eq .Values.cassandra.version "4.0.0" }}
+    {{ $clusterVersion = "4.0" }}
+    {{- $computedImage = printf "stargateio/stargate-4_0:v%s" $stargateVersion }}
+  {{- end }}
+  {{- $image := default $computedImage .Values.stargate.image -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -84,7 +91,7 @@ spec:
             - name: CLUSTER_NAME
               value: {{ include "k8ssandra.clusterName" . | quote }}
             - name: CLUSTER_VERSION
-              value: "3.11"
+              value: {{ $clusterVersion | quote }}
             - name: SEED
               value: "{{ include "k8ssandra.clusterName" . }}-seed-service.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain | default "cluster.local" }}"
             - name: DATACENTER_NAME

--- a/charts/k8ssandra/templates/stargate/stargate.yaml
+++ b/charts/k8ssandra/templates/stargate/stargate.yaml
@@ -3,7 +3,7 @@
   {{- $heapMB := required "stargate.heapMB is required" .Values.stargate.heapMB -}}
   {{- $clusterVersion := "3.11" }}
   {{- $computedImage := printf "stargateio/stargate-3_11:v%s" $stargateVersion }}
-  {{- if eq .Values.cassandra.version "4.0.0" }}
+  {{- if not (hasPrefix "3" .Values.cassandra.version) }}
     {{ $clusterVersion = "4.0" }}
     {{- $computedImage = printf "stargateio/stargate-4_0:v%s" $stargateVersion }}
   {{- end }}

--- a/charts/k8ssandra/templates/stargate/stargate.yaml
+++ b/charts/k8ssandra/templates/stargate/stargate.yaml
@@ -1,13 +1,17 @@
 {{- if .Values.stargate.enabled }}
-  {{- $stargateVersion := "1.0.8" }}
-  {{- $heapMB := required "stargate.heapMB is required" .Values.stargate.heapMB -}}
-  {{- $clusterVersion := "3.11" }}
-  {{- $computedImage := printf "stargateio/stargate-3_11:v%s" $stargateVersion }}
-  {{- if not (hasPrefix "3" .Values.cassandra.version) }}
-    {{ $clusterVersion = "4.0" }}
+  {{- $stargateVersion := .Values.stargate.version }}
+  {{- $computedClusterVersion := "" }}
+  {{- $computedImage := "" }}
+  {{- if hasPrefix "3" .Values.cassandra.version }}
+    {{- $computedClusterVersion = "3.11" }}
+    {{- $computedImage = printf "stargateio/stargate-3_11:v%s" $stargateVersion }}
+  {{- else }}
+    {{- $computedClusterVersion = "4.0" }}
     {{- $computedImage = printf "stargateio/stargate-4_0:v%s" $stargateVersion }}
   {{- end }}
   {{- $image := default $computedImage .Values.stargate.image -}}
+  {{- $clusterVersion := default $computedClusterVersion .Values.stargate.clusterVersion -}}
+  {{- $heapMB := required "stargate.heapMB is required" .Values.stargate.heapMB -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -167,17 +167,26 @@ stargate:
   # -- Enable Stargate resources as part of this release
   enabled: true
 
+  # -- version of Stargate to deploy
+  version: "1.0.8"
+
   # -- Number of Stargate instances to deploy. This value may be scaled independently of
   # Cassandra cluster nodes. Each instance handles API and coordination tasks
   # for inbound queries.
   replicas: 1
 
-  # -- Sets the Stargate container image. If left blank (recommended), k8ssandra
-  # will derive an appropriate image based on your cluster version.
+  # -- Sets the Stargate container image. This value must be compatible
+  # with the value provided for stargate.clusterVersion. If left blank (recommended),
+  # k8ssandra will derive an appropriate image based on cassandra.clusterVersion.
   image:
 
   # -- Sets the imagePullPolicy used by the Stargate pods
   imagePullPolicy: IfNotPresent
+
+  # -- Sets the CLUSTER_VERSION environment variable provided to the Stargate containers.
+  # This value must be compatible with the value provided for stargate.image. If left blank (recommended),
+  # k8ssandra will derive an appropriate image based on cassandra.clusterVersion.
+  clusterVersion:
 
   # -- Sets the heap size Stargate will use in megabytes. Memory request and
   # limit for the pod will be set to this value x2 and x4, respectively.

--- a/docs/content/en/docs/faqs/_index.md
+++ b/docs/content/en/docs/faqs/_index.md
@@ -112,7 +112,7 @@ K8ssandra deploys the following components, some components are optional, and de
 * [Cassandra Reaper](http://cassandra-reaper.io/)
   * 2.1.3
 * [Stargate](https://stargate.io/)
-  * 1.0.7
+  * 1.0.8
 
 *Note: Throughout these docs, examples are shown to deploy [Traefik](https://traefik.io/) as a means to provide external access to the k8ssandra cluster.  It is deployed separately from k8ssandra, and as such, the version deployed will vary.*
 

--- a/tests/unit/template_stargate_test.go
+++ b/tests/unit/template_stargate_test.go
@@ -12,6 +12,15 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 )
 
+const (
+	DefaultStargate3Image          = "stargateio/stargate-3_11:v1.0.8"
+	DefaultStargate4Image          = "stargateio/stargate-4_0:v1.0.8"
+	DefaultStargate3ClusterVersion = "3.11"
+	DefaultStargate4ClusterVersion = "4.0"
+	DefaultStargateImage           = DefaultStargate3Image
+	DefaultStargateClusterVersion  = DefaultStargate3ClusterVersion
+)
+
 var _ = Describe("Verify Stargate template", func() {
 	var (
 		helmChartPath string
@@ -90,7 +99,7 @@ var _ = Describe("Verify Stargate template", func() {
 
 			Expect(len(templateSpec.Containers)).To(Equal(1))
 			container := templateSpec.Containers[0]
-			Expect(container.Image).To(Equal("stargateio/stargate-3_11:v1.0.8"))
+			Expect(container.Image).To(Equal(DefaultStargateImage))
 			Expect(container.Name).To(Equal(Sprintf("%s-dc1-stargate", HelmReleaseName)))
 			Expect(string(container.ImagePullPolicy)).To(Equal("IfNotPresent"))
 
@@ -111,13 +120,91 @@ var _ = Describe("Verify Stargate template", func() {
 			Expect(clusterName.Value).To(Equal(HelmReleaseName))
 
 			clusterVersion := kubeapi.FindEnvVarByName(container, "CLUSTER_VERSION")
-			Expect(clusterVersion.Value).To(Equal("3.11"))
+			Expect(clusterVersion.Value).To(Equal(DefaultStargateClusterVersion))
 
 			seed := kubeapi.FindEnvVarByName(container, "SEED")
 			Expect(seed.Value).To(Equal(Sprintf("%s-seed-service.%s.svc.cluster.local", HelmReleaseName, DefaultTestNamespace)))
 
 			datacenterName := kubeapi.FindEnvVarByName(container, "DATACENTER_NAME")
 			Expect(datacenterName.Value).To(Equal("dc1"))
+		})
+
+		It("using custom image and clusterVersion", func() {
+			// This combination of values makes no real sense and would not work
+			// but this tests that the defaults are avoided when a specific value is provided
+			image := "stargateio/stargate-4_0:v1.0.5"
+			clusterVersion := "3.0"
+
+			options := &helm.Options{
+				KubectlOptions: defaultKubeCtlOptions,
+				SetValues: map[string]string{
+					"stargate.enabled":        "true",
+					"stargate.image":          image,
+					"stargate.clusterVersion": clusterVersion,
+				},
+			}
+
+			Expect(renderTemplate(options)).To(Succeed())
+			templateSpec := deployment.Spec.Template.Spec
+			Expect(len(templateSpec.Containers)).To(Equal(1))
+			container := templateSpec.Containers[0]
+			Expect(container.Image).To(Equal(image))
+			clusterVersionEnv := kubeapi.FindEnvVarByName(container, "CLUSTER_VERSION")
+			Expect(clusterVersionEnv.Value).To(Equal(clusterVersion))
+		})
+
+		It("using defaults and empty clusterVersion", func() {
+			options := &helm.Options{
+				KubectlOptions: defaultKubeCtlOptions,
+				SetValues: map[string]string{
+					"stargate.enabled":        "true",
+					"stargate.clusterVersion": "",
+				},
+			}
+
+			Expect(renderTemplate(options)).To(Succeed())
+			templateSpec := deployment.Spec.Template.Spec
+			Expect(len(templateSpec.Containers)).To(Equal(1))
+			container := templateSpec.Containers[0]
+			Expect(container.Image).To(Equal(DefaultStargateImage))
+			clusterVersionEnv := kubeapi.FindEnvVarByName(container, "CLUSTER_VERSION")
+			Expect(clusterVersionEnv.Value).To(Equal(DefaultStargateClusterVersion))
+		})
+
+		It("using cassandra version 4.0.0", func() {
+			options := &helm.Options{
+				KubectlOptions: defaultKubeCtlOptions,
+				SetValues: map[string]string{
+					"stargate.enabled":  "true",
+					"cassandra.version": "4.0.0",
+				},
+			}
+
+			Expect(renderTemplate(options)).To(Succeed())
+			templateSpec := deployment.Spec.Template.Spec
+			Expect(len(templateSpec.Containers)).To(Equal(1))
+			container := templateSpec.Containers[0]
+			Expect(container.Image).To(Equal(DefaultStargate4Image))
+			clusterVersionEnv := kubeapi.FindEnvVarByName(container, "CLUSTER_VERSION")
+			Expect(clusterVersionEnv.Value).To(Equal(DefaultStargate4ClusterVersion))
+		})
+
+		It("using cassandra version 3.11.10", func() {
+			options := &helm.Options{
+				KubectlOptions: defaultKubeCtlOptions,
+				SetValues: map[string]string{
+					"stargate.enabled":  "true",
+					"cassandra.version": "3.11.10",
+				},
+			}
+
+			Expect(renderTemplate(options)).To(Succeed())
+			templateSpec := deployment.Spec.Template.Spec
+			Expect(len(templateSpec.Containers)).To(Equal(1))
+			container := templateSpec.Containers[0]
+			Expect(container.Image).To(Equal(DefaultStargate3Image))
+			clusterVersionEnv := kubeapi.FindEnvVarByName(container, "CLUSTER_VERSION")
+			Expect(clusterVersionEnv.Value).To(Equal(DefaultStargate3ClusterVersion))
 		})
 
 		It("changing cluster name", func() {
@@ -221,22 +308,19 @@ var _ = Describe("Verify Stargate template", func() {
 			Expect(string(container.ImagePullPolicy)).To(Equal(alternatePullPolicy))
 		})
 
-		It("using Cassandra 4.0", func() {
+		It("changing stargate version", func() {
+			alternateImage := "stargateio/stargate-3_11:v1.0.5"
 			options := &helm.Options{
 				KubectlOptions: defaultKubeCtlOptions,
 				SetValues: map[string]string{
-					"stargate.enabled":                    "true",
-					"cassandra.version":                   "4.0.0",
-					"cassandra.versionImageMap.4\\.0\\.0": "some/irrelevant:image",
+					"stargate.enabled": "true",
+					"stargate.version": "1.0.5",
 				},
 			}
 
 			Expect(renderTemplate(options)).To(Succeed())
-			Expect(deployment.Spec.Template.Spec.Containers).ToNot(BeNil())
-			Expect(len(deployment.Spec.Template.Spec.Containers)).To(Equal(1))
 			container := deployment.Spec.Template.Spec.Containers[0]
-			clusterVersion := kubeapi.FindEnvVarByName(container, "CLUSTER_VERSION")
-			Expect(clusterVersion.Value).To(Equal("4.0"))
+			Expect(container.Image).To(Equal(alternateImage))
 		})
 	})
 })

--- a/tests/unit/template_stargate_test.go
+++ b/tests/unit/template_stargate_test.go
@@ -322,5 +322,21 @@ var _ = Describe("Verify Stargate template", func() {
 			container := deployment.Spec.Template.Spec.Containers[0]
 			Expect(container.Image).To(Equal(alternateImage))
 		})
+
+		It("changing stargate version with Cassandra 4.0", func() {
+			alternateImage := "stargateio/stargate-4_0:v1.0.6"
+			options := &helm.Options{
+				KubectlOptions: defaultKubeCtlOptions,
+				SetValues: map[string]string{
+					"stargate.enabled":  "true",
+					"stargate.version":  "1.0.6",
+					"cassandra.version": "4.0.0",
+				},
+			}
+
+			Expect(renderTemplate(options)).To(Succeed())
+			container := deployment.Spec.Template.Spec.Containers[0]
+			Expect(container.Image).To(Equal(alternateImage))
+		})
 	})
 })


### PR DESCRIPTION
**What this PR does**:
Adds support for Stargate to run the correct image and supply the correct CLUSTER_VERSION when using Cassandra 4.0

**Which issue(s) this PR fixes**:
Fixes #397 

**Checklist**
- [x] Changes manually tested
- [x] Chart versions updated (if necessary)
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
