### PR TITLE
Upgrade Stargate and improve doc comments for stargate.image

### DIFF
--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -3,7 +3,7 @@ name: k8ssandra
 description: |
   Provisions and configures an instance of the entire K8ssandra stack. This includes Apache Cassandra, Stargate, Reaper, Medusa, Prometheus, and Grafana.
 type: application
-version: 0.55.0
+version: 0.56.0
 appVersion: 3.11.10
 
 dependencies:

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -269,7 +269,7 @@ stargate:
 
   # -- version of Stargate to deploy. This is used in conjunction with cassandra.version to select the Stargate container image.
   # If stargate.image is set, this value has no effect.
-  version: "1.0.8"
+  version: "1.0.9"
 
   # -- Number of Stargate instances to deploy. This value may be scaled independently of
   # Cassandra cluster nodes. Each instance handles API and coordination tasks

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -284,11 +284,6 @@ stargate:
   # -- Sets the imagePullPolicy used by the Stargate pods
   imagePullPolicy: IfNotPresent
 
-  # -- Sets the CLUSTER_VERSION environment variable provided to the Stargate containers.
-  # This value must be compatible with the value provided for stargate.image. If left blank (recommended),
-  # k8ssandra will derive an appropriate image based on cassandra.clusterVersion.
-  clusterVersion:
-
   # -- Sets the heap size Stargate will use in megabytes. Memory request and
   # limit for the pod will be set to this value x2 and x4, respectively.
   heapMB: 256

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -267,7 +267,8 @@ stargate:
   # -- Enable Stargate resources as part of this release
   enabled: true
 
-  # -- version of Stargate to deploy
+  # -- version of Stargate to deploy. This is used in conjunction with cassandra.version to select the Stargate container image.
+  # If stargate.image is set, this value has no effect.
   version: "1.0.8"
 
   # -- Number of Stargate instances to deploy. This value may be scaled independently of

--- a/docs/content/en/docs/faqs/_index.md
+++ b/docs/content/en/docs/faqs/_index.md
@@ -112,7 +112,7 @@ K8ssandra deploys the following components, some components are optional, and de
 * [Cassandra Reaper](http://cassandra-reaper.io/)
   * 2.1.3
 * [Stargate](https://stargate.io/)
-  * 1.0.8
+  * 1.0.9
 
 *Note: Throughout these docs, examples are shown to deploy [Traefik](https://traefik.io/) as a means to provide external access to the k8ssandra cluster.  It is deployed separately from k8ssandra, and as such, the version deployed will vary.*
 

--- a/tests/unit/template_stargate_test.go
+++ b/tests/unit/template_stargate_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	DefaultStargate3Image          = "stargateio/stargate-3_11:v1.0.8"
-	DefaultStargate4Image          = "stargateio/stargate-4_0:v1.0.8"
+	DefaultStargate3Image          = "stargateio/stargate-3_11:v1.0.9"
+	DefaultStargate4Image          = "stargateio/stargate-4_0:v1.0.9"
 	DefaultStargate3ClusterVersion = "3.11"
 	DefaultStargate4ClusterVersion = "4.0"
 	DefaultStargateImage           = DefaultStargate3Image


### PR DESCRIPTION
**What this PR does**:
Upgrades Stargate to 1.0.9
Adds a bit of clarity to the doc comment for stargate.version

This is in draft mode because the images for 1.0.9 have not yet been published to Docker Hub. The changes themselves should be final, but I need to test with a cluster using the actual images.

**Which issue(s) this PR fixes**:
None

**Checklist**
- [x] Changes manually tested
- [x] Chart versions updated (if necessary)
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
