### PR TITLE
Update name of service routed to by reaper ingress rule

### DIFF
--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -3,7 +3,7 @@ name: k8ssandra
 description: |
   Provisions and configures an instance of the entire K8ssandra stack. This includes Apache Cassandra, Stargate, Reaper, Medusa, Prometheus, and Grafana.
 type: application
-version: 0.60.0
+version: 0.60.1
 appVersion: 3.11.10
 
 dependencies:

--- a/charts/k8ssandra/templates/reaper/ingress.yaml
+++ b/charts/k8ssandra/templates/reaper/ingress.yaml
@@ -18,7 +18,7 @@ spec:
   - match: Host(`{{ required "reaper.ingress.host must be specified when reaper.ingress.enabled is true" $reaperIngress.host }}`)
     kind: Rule
     services:
-    - name: {{ $releaseName }}-reaper-service
+    - name: {{ $releaseName }}-reaper-reaper-service
       kind: Service
       port: 8080
     {{- end }}

--- a/tests/unit/template_reaper_ingress_test.go
+++ b/tests/unit/template_reaper_ingress_test.go
@@ -2,13 +2,14 @@ package unit_test
 
 import (
 	. "fmt"
+	"path/filepath"
+
 	"github.com/gruntwork-io/terratest/modules/helm"
 	helmUtils "github.com/k8ssandra/k8ssandra/tests/unit/utils/helm"
 	. "github.com/k8ssandra/k8ssandra/tests/unit/utils/traefik"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	traefik "github.com/traefik/traefik/v2/pkg/provider/kubernetes/crd/traefik/v1alpha1"
-	"path/filepath"
 )
 
 var _ = Describe("Verify Reaper ingress template", func() {
@@ -102,7 +103,7 @@ var _ = Describe("Verify Reaper ingress template", func() {
 
 			Expect(renderTemplate(options)).To(Succeed())
 			Expect(ingress.Kind).To(Equal("IngressRoute"))
-			VerifyTraefikHTTPIngressRoute(ingress, "web", "Host(`*`)", Sprintf("%s-reaper-service", HelmReleaseName), 8080)
+			VerifyTraefikHTTPIngressRoute(ingress, "web", "Host(`*`)", Sprintf("%s-reaper-reaper-service", HelmReleaseName), 8080)
 		})
 
 		It("with custom host", func() {
@@ -116,7 +117,7 @@ var _ = Describe("Verify Reaper ingress template", func() {
 
 			Expect(renderTemplate(options)).To(Succeed())
 			Expect(ingress.Kind).To(Equal("IngressRoute"))
-			VerifyTraefikHTTPIngressRoute(ingress, "web", "Host(`reaper.host`)", Sprintf("%s-reaper-service", HelmReleaseName), 8080)
+			VerifyTraefikHTTPIngressRoute(ingress, "web", "Host(`reaper.host`)", Sprintf("%s-reaper-reaper-service", HelmReleaseName), 8080)
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
* Talked with @jsanda about this one and he explained that the recent changes in reaper-operator necessitated a change to the structure of the service name deployed
* This brings the name in-line with what reaper-operator produces and updates the tests

**Which issue(s) this PR fixes**:
Fixes #431 

**Checklist**
- [ ] Changes manually tested
- [x] Chart versions updated (if necessary)
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
