### PR TITLE
Add a script to update operator image tag

### DIFF
--- a/scripts/helm-version.py
+++ b/scripts/helm-version.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 import subprocess
 from ruamel.yaml import YAML
-import glob
 import re
 import argparse
+
 
 class Semver:
     def __init__(self, major: int, minor: int, patch: int):
@@ -36,29 +36,32 @@ class Semver:
 
         raise Exception(F'Invalid input version value: {input_str}')
 
+
 def update_chart_version(update_func, chart_name, update_dep):
-        yaml = YAML()
-        yaml.indent(mapping = 2, sequence=4, offset=2)
-        main_dir = subprocess.run(["git", "rev-parse", "--show-toplevel"], check=True, stdout=subprocess.PIPE).stdout.strip().decode('utf-8')
-        path = F'{main_dir}/charts/{chart_name}/Chart.yaml'
-        with open(path) as f:
-            chart = yaml.load(f)
+    yaml = YAML()
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    main_dir = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                              check=True, stdout=subprocess.PIPE).stdout.strip().decode('utf-8')
+    path = F'{main_dir}/charts/{chart_name}/Chart.yaml'
+    with open(path) as f:
+        chart = yaml.load(f)
 
-        semver = Semver.parse(chart['version'])
-        update_func(semver)
-        chart['version'] = semver.to_string()        
+    semver = Semver.parse(chart['version'])
+    update_func(semver)
+    chart['version'] = semver.to_string()
 
-        with open(path, 'w') as f:
-            yaml.dump(chart, f)
+    with open(path, 'w') as f:
+        yaml.dump(chart, f)
 
-        print(F'Updated {path} to {semver.to_string()}')
-        if chart_name != 'k8ssandra' and update_dep is True:
-            update_dependency(main_dir, chart_name, semver.to_string())
-            update_chart_version(update_func, 'k8ssandra', False)
+    print(F'Updated {path} to {semver.to_string()}')
+    if chart_name != 'k8ssandra' and update_dep is True:
+        update_dependency(main_dir, chart_name, semver.to_string())
+        update_chart_version(update_func, 'k8ssandra', False)
+
 
 def update_dependency(main_dir, dependency, target_version):
     yaml = YAML()
-    yaml.indent(mapping = 2, sequence=4, offset=2)
+    yaml.indent(mapping=2, sequence=4, offset=2)
     path = F'{main_dir}/charts/k8ssandra/Chart.yaml'
     # If we update the k8ssandra dependency.. we need to update its version also. Why not do it with the same code as above?
     with open(path) as f:
@@ -73,11 +76,16 @@ def update_dependency(main_dir, dependency, target_version):
             print(F'Updated dependency {dependency} to {target_version}')
             break
 
+
 def main():
-    parser = argparse.ArgumentParser(description='Update Helm chart versions in k8ssandra project')
-    parser.add_argument('--incr', choices=['major', 'minor', 'patch'], help='increase part of semver by one')
-    parser.add_argument('--chart', choices=['medusa-operator','k8ssandra-common','reaper-operator','k8ssandra','cass-operator','backup','restore'], help='increase only a single chart')
-    parser.add_argument('--dep', help='update the k8ssandra dependency to newest version also', dest='dep_update', action='store_true')
+    parser = argparse.ArgumentParser(
+        description='Update Helm chart versions in k8ssandra project')
+    parser.add_argument(
+        '--incr', choices=['major', 'minor', 'patch'], help='increase part of semver by one')
+    parser.add_argument('--chart', choices=['medusa-operator', 'k8ssandra-common', 'reaper-operator',
+                                            'k8ssandra', 'cass-operator', 'backup', 'restore'], help='target chart to update')
+    parser.add_argument('--dep', help='update the k8ssandra dependency to newest version also',
+                        dest='dep_update', action='store_true')
     args = parser.parse_args()
 
     chart = args.chart
@@ -96,6 +104,7 @@ def main():
             update_chart_version(Semver.incr_minor, chart, update_dep)
         elif args.incr == 'patch':
             update_chart_version(Semver.incr_patch, chart, update_dep)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/image-update.py
+++ b/scripts/image-update.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+import subprocess
+from ruamel.yaml import YAML
+import argparse
+
+
+def update_tag_version(chart, tag):
+    yaml = YAML()
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    main_dir = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                              check=True, stdout=subprocess.PIPE).stdout.strip().decode('utf-8')
+    path = F'{main_dir}/charts/{chart}/values.yaml'
+    with open(path) as f:
+        values = yaml.load(f)
+
+    values['image']['tag'] = tag
+
+    with open(path, 'w') as f:
+        yaml.dump(values, f)
+
+    print(F'Updated {chart} to use {values["image"]["repository"]}:{tag}')
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Update image tag version in k8ssandra project')
+    parser.add_argument('--tag', dest='image_tag', action='store')
+    parser.add_argument('--chart', choices=['medusa-operator', 'reaper-operator',
+                                            'cass-operator'], help='target operator image version to update')
+    args = parser.parse_args()
+
+    if args.image_tag and args.chart:
+        update_tag_version(args.chart, args.image_tag)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**What this PR does**:
Adds the ability to update the default image tag in values.yaml for an operator. Works with cass-operator, reaper-operator and medusa-operator. 

```
➜  k8ssandra git:(main) ✗ scripts/image-update.py --chart medusa-operator --tag asddsa
Updated medusa-operator to use docker.io/k8ssandra/medusa-operator:asddsa
➜  k8ssandra git:(main) ✗
```

Also updates some descriptions and indentation fixes.

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Changes manually tested
- [ ] Chart versions updated (if necessary)
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
