### PR TITLE
Fix passing credentials to S3 compatible backends in Medusa

### DIFF
--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -3,7 +3,7 @@ name: k8ssandra
 description: |
   Provisions and configures an instance of the entire K8ssandra stack. This includes Apache Cassandra, Stargate, Reaper, Medusa, Prometheus, and Grafana.
 type: application
-version: 1.0.1
+version: 1.0.2
 
 dependencies:
   - name: cass-operator

--- a/charts/k8ssandra/templates/medusa/medusa-config.yaml
+++ b/charts/k8ssandra/templates/medusa/medusa-config.yaml
@@ -36,7 +36,7 @@ data:
   {{- else }}
     bucket_name = {{ .Values.medusa.bucketName }}
   {{- end }}
-  {{- if (eq .Values.medusa.storage "s3") }}
+  {{- if or (eq .Values.medusa.storage "s3") (eq .Values.medusa.storage "s3_compatible") }}
     key_file = /etc/medusa-secrets/medusa_s3_credentials
   {{- else if (eq .Values.medusa.storage "google_storage") }}
     key_file = /etc/medusa-secrets/medusa_gcp_key.json


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Allows to pass credentials to s3 compatible Medusa backends (aside from AWS S3).

**Which issue(s) this PR fixes**:
Fixes #487

**Checklist**
- [x] Changes manually tested
- [x] Chart versions updated (if necessary)
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
