### PR TITLE
remove what k8ssandra is not good for section

### DIFF
--- a/docs/content/en/docs/_index.md
+++ b/docs/content/en/docs/_index.md
@@ -39,10 +39,6 @@ K8ssandra is a great fit for operators looking for easy to install and manage Ca
 * Grafana Operator `Dashboard` custom resources configured with metrics exposed by Prometheus
 * Reaper for Apache Cassandra custom resources connected to the cluster.
 
-## What is K8ssandra *not yet* good for?
-
-Right now K8ssandra is deployed as an entire stack. It currently assumes your deployment uses the entire stack. Trading out certain components for others is not supported. As part of the [Roadmap]({{< ref "roadmap" >}}) we would like to see this change to support a la carte composition of components.
-
 ## Where should I go next?
 
 Depending on your needs, see the following:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Chart versions updated (if necessary)
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)

This PR removes the _What is K8ssandra not yet good for?_ section. The content is incorrect. It says:

>Right now K8ssandra is deployed as an entire stack. It currently assumes your deployment uses the entire stack. Trading out certain components for others is not supported. 

This is wrong. We do not deploy all components by default. For example, Medusa and Traefik are disabled by default. Secondly, there is no assumption about the entire stack being used since it is possible to disable components. Lastly, it is entirely possible to swap out components. There is nothing to prevent you from swapping out the monitoring bits for example. In fact, I would consider this a feature. 

I think it is better to simply altogether remove this section rather talk about what k8ssandra is not good for since that could be  arbitrary and is subjective.