### PR TITLE
Make TESTS and GO_FLAGS conditional so they can be set from cmd line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When cutting a new release of the parent `k8ssandra` chart update the `main / un
 
 ## main / unreleased
 * [BUGFIX] #396 cqlsh commands show warnings
+* [BUGFIX] #507 `TESTS` and `GO_FLAGS` Makefile vars cannot be set from command line
 
 ## v1.0.0 - 2021-02-26
 

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ CLEANER_LATEST_IMAGE=$(CLEANER_IMAGE_BASE):latest
 # Image URL to use all building/pushing image targets
 CLEANER_IMG ?= $(CLEANER_LATEST_IMAGE)
 
-TESTS=all
-GO_FLAGS=
+TESTS?=all
+GO_FLAGS?=
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: fmt vet unit-test pkg-test
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Makes the `TESTS` and `GO_FLAGS` Makefile vars conditional so that they can be set from the cmd line.

**Which issue(s) this PR fixes**:
Fixes #507

**Checklist**
- [x] Changes manually tested
- [ ] Chart versions updated (if necessary)
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
