### PR TITLE
Fix Cassandra config clobbering when enabling Medusa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for K8ssandra, new PRs should update the `main / unreleased` section w
 When cutting a new release of the parent `k8ssandra` chart update the `main / unreleased` heading to the tag being generated and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `main / unreleased` entries.
 
 ## main / unreleased
+* [BUGFIX] #475 Fix Cassandra config clobbering when enabling Medusa
 * [ENHANCEMENT] #504 split dashboards into separate configmaps
 * [ENHANCEMENT] #436 Upgrade Stargate to 1.0.11 and add a `preStop` lifecycle hook to improve behavior when reducing the number of Stargate replicas in the presence of live traffic
 * [ENHANCEMENT] #419 Add automation for stable and next release streams

--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -3,7 +3,7 @@ name: k8ssandra
 description: |
   Provisions and configures an instance of the entire K8ssandra stack. This includes Apache Cassandra, Stargate, Reaper, Medusa, Prometheus, and Grafana.
 type: application
-version: 1.0.4
+version: 1.0.5
 
 dependencies:
   - name: cass-operator

--- a/charts/k8ssandra/templates/_helpers.tpl
+++ b/charts/k8ssandra/templates/_helpers.tpl
@@ -341,3 +341,10 @@ Add garbage collection settings based on the following rules in the order listed
   {{ indent 4 (cat "conc_gc_threads:" .concurrentGcThreads) }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Cassandra image (Management API image and version tag).
+*/}}
+{{- define "k8ssandra.cassandraImage" -}}
+{{- default (get .Values.cassandra.versionImageMap .Values.cassandra.version) .Values.cassandra.image }}
+{{- end }}

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -19,7 +19,7 @@ spec:
   serverType: cassandra
   serverVersion: {{ .Values.cassandra.version | quote }}
   dockerImageRunsAsCassandra: true
-  serverImage: {{ default (get .Values.cassandra.versionImageMap .Values.cassandra.version) .Values.cassandra.image }}
+  serverImage: {{ include "k8ssandra.cassandraImage" . }}
   managementApiAuth:
     insecure: {}
   size: {{ $datacenter.size }}
@@ -114,6 +114,17 @@ spec:
   podTemplateSpec:
     spec:
       initContainers:
+      - name: base-config-init
+        image: {{ include "k8ssandra.cassandraImage" . }}
+        imagePullPolicy: IfNotPresent
+        command:
+          - /bin/sh
+        args:
+          - -c
+          - cp -r /etc/cassandra/* /cassandra-base-config/
+        volumeMounts:
+          - name: cassandra-config
+            mountPath: /cassandra-base-config/
       - name: server-config-init
      {{- if (or .Values.cassandra.auth.enabled .Values.reaper.enabled) }}
       - name: jmx-credentials
@@ -150,39 +161,6 @@ spec:
         {{- else }}
           - echo "$SUPERUSER_JMX_USERNAME $SUPERUSER_JMX_PASSWORD" > /config/jmxremote.password
         {{- end }}
-        volumeMounts:
-          - mountPath: /config
-            name: server-config
-      {{- end }}
-      {{- if (hasPrefix "4" .Values.cassandra.version) }}
-      - name: jvm-client-options
-        image: busybox
-        imagePullPolicy: IfNotPresent
-        command:
-          - /bin/sh
-        args:
-          - -c
-          - echo "-Djdk.attach.allowAttachSelf=true" > /config/jvm11-clients.options &&
-            echo "--add-exports java.base/jdk.internal.misc=ALL-UNNAMED" >> /config/jvm11-clients.options &&
-            echo "--add-exports java.base/jdk.internal.ref=ALL-UNNAMED" >> /config/jvm11-clients.options &&
-            echo "--add-exports java.base/sun.nio.ch=ALL-UNNAMED" >> /config/jvm11-clients.options &&
-            echo "--add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED" >> /config/jvm11-clients.options &&
-            echo "--add-exports java.rmi/sun.rmi.server=ALL-UNNAMED" >> /config/jvm11-clients.options &&
-            echo "--add-exports java.sql/java.sql=ALL-UNNAMED" >> /config/jvm11-clients.options &&
-            echo "" >> /config/jvm11-clients.options &&
-            echo "--add-opens java.base/java.lang.module=ALL-UNNAMED" >> /config/jvm11-clients.options &&
-            echo "--add-opens java.base/jdk.internal.loader=ALL-UNNAMED" >> /config/jvm11-clients.options &&
-            echo "--add-opens java.base/jdk.internal.ref=ALL-UNNAMED" >> /config/jvm11-clients.options &&
-            echo "--add-opens java.base/jdk.internal.reflect=ALL-UNNAMED" >> /config/jvm11-clients.options &&
-            echo "--add-opens java.base/jdk.internal.math=ALL-UNNAMED" >> /config/jvm11-clients.options &&
-            echo "--add-opens java.base/jdk.internal.module=ALL-UNNAMED" >> /config/jvm11-clients.options &&
-            echo "--add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED" >> /config/jvm11-clients.options &&
-            echo "--add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED" >> /config/jvm11-clients.options &&
-            echo "" >> /config/jvm11-clients.options &&
-            echo "# The newline in the end of file is intentional" >> /config/jvm11-clients.options &&
-            echo "" >> /config/jvm11-clients.options &&
-            echo "# The newline in the end of file is intentional" > /config/jvm-clients.options &&
-            echo "" >> /config/jmv-clients.options
         volumeMounts:
           - mountPath: /config
             name: server-config
@@ -258,19 +236,21 @@ spec:
           - mountPath: /etc/medusa-secrets
             name: {{ .Values.medusa.storageSecret }}
           {{- end }}
+      {{- end }}
+      {{- end }}
       volumes:
+      - name: cassandra-config
+        emptyDir: {}
+      {{- if .Values.medusa.enabled }}
       - name: {{ include "medusa.configMapName" . }}
         configMap:
           name: {{ include "medusa.configMapName" . }}
           items:
             - key: medusa.ini
               path: medusa.ini
-      - name: cassandra-config
-        emptyDir: {}
       {{- if not (eq .Values.medusa.storage "local") }}
       - name:  {{ .Values.medusa.storageSecret }}
         secret:
           secretName: {{ .Values.medusa.storageSecret }}
       {{- end }}
-{{- end }}
 {{- end }}

--- a/tests/unit/utils/cassdc/volumes.go
+++ b/tests/unit/utils/cassdc/volumes.go
@@ -1,0 +1,16 @@
+package cassdc
+
+import (
+	cassop "github.com/datastax/cass-operator/operator/pkg/apis/cassandra/v1beta1"
+	. "github.com/k8ssandra/k8ssandra/tests/unit/utils/kubeapi"
+	. "github.com/onsi/gomega"
+)
+
+// AssertVolumeNamesMatch asserts that the names of the volumes defined in the podTemplateSpec
+// of the given CassandraDatacenter match the given names
+func AssertVolumeNamesMatch(cassdc *cassop.CassandraDatacenter, names ...string) {
+	podTemplateSpec := cassdc.Spec.PodTemplateSpec
+	actualNames := GetVolumeNames(podTemplateSpec)
+
+	ExpectWithOffset(1, actualNames).To(Equal(names))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This PR adds an init container that sets up the initial Cassandra config in `/etc/cassandra` from the base Cassandra image. Previously, when enabling Medusa, `/etc/cassandra` would be shadow mounted with an empty directory and only config-builder contents would be copied to `/etc/cassandra`, resulting in a fair amount of missing config.

**Which issue(s) this PR fixes**:
Fixes #475 

**Checklist**
- [x] Changes manually tested
- [x] Chart versions updated (if necessary)
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
