### PR TITLE
Configure SonarCloud Scanning

### DIFF
--- a/.github/workflows/pr-main.yaml
+++ b/.github/workflows/pr-main.yaml
@@ -102,3 +102,16 @@ jobs:
         run: |
           export PATH=$GOROOT/bin:$GOPATH/bin:$PATH
           make test
+
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/pr-main.yaml
+++ b/.github/workflows/pr-main.yaml
@@ -114,4 +114,4 @@ jobs:
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ env.SONAR_TOKEN }}

--- a/.github/workflows/pr-main.yaml
+++ b/.github/workflows/pr-main.yaml
@@ -17,6 +17,8 @@ jobs:
     outputs:
       HELM_VERSION: ${{ env.HELM_VERSION}}
       YQ_VERSION: ${{ env.YQ_VERSION }}
+      SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
+      
     steps:
       - name: Cache bin path
         id: cache

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,12 @@
+sonar.projectKey=k8ssandra_k8ssandra
+sonar.organization=k8ssandra
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=k8ssandra
+#sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Enables SonarCloud scanning within the project.

You can see an example of the new check on a PR here:  https://github.com/jdonenine/k8ssandra/pull/1

The scan results will be published to our project here:  https://sonarcloud.io/dashboard?id=k8ssandra_k8ssandra

There won't be anything present on that dashboard until a scan happens on our main branch here in k8ssandra/k8ssandra, but with the branch dropdown, you can also see the scans of separate branches as PRs happen.

Since the k8ssandra/k8ssandra repo is not purely code - or even mostly code, we will likely have to tweak the configuration a bit here as we go, but this gets the basic scanning portion in place.

**Which issue(s) this PR fixes**:
Fixes #569 

**Checklist**
- [x] Changes manually tested
- [ ] Chart versions updated (if necessary)
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)