### PR TITLE
Enable Medusa local storage option to store the backups

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         cassandra_version: ["3.11.10", "4.0.0"]
-        scenario: ["TestMedusaDeploymentScenario/\"S3\"", "TestMedusaDeploymentScenario/\"Minio\"", "TestReaperDeploymentScenario", "TestMonitoringDeploymentScenario", "TestStargateDeploymentScenario"]
+        scenario: ["TestMedusaDeploymentScenario/\"S3\"", "TestMedusaDeploymentScenario/\"Minio\"", "TestMedusaDeploymentScenario/\"local\"", "TestReaperDeploymentScenario", "TestMonitoringDeploymentScenario", "TestStargateDeploymentScenario"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/CHANGELOG-1.2.md
+++ b/CHANGELOG-1.2.md
@@ -12,3 +12,5 @@ Changelog for K8ssandra, new PRs should update the ` unreleased` section with en
 When cutting a new release of the parent `k8ssandra` chart update the `unreleased` heading to the tag being generated and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
+
+* [ENHANCEMENT] #560 Add the ability to attach additional PVs for medusa backups

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -5,7 +5,12 @@
   {{- fail (print .Values.cassandra.version " is not a supported Cassandra version") }}
 {{- end -}}
 
+{{- if and (eq .Values.medusa.storage "local") (not (and (.Values.medusa.podStorage.storageClass) (.Values.medusa.podStorage.size))) -}}
+  {{- fail (print "If medusa storage type is set to local, the podStorage storageClass and size must be set") }}
+{{- end -}}
 {{- if .Values.cassandra.enabled -}}
+
+
 apiVersion: cassandra.datastax.com/v1beta1
 kind: CassandraDatacenter
 metadata:
@@ -41,13 +46,25 @@ spec:
       resources:
         requests:
           storage: {{ .Values.cassandra.cassandraLibDirVolume.size | default "5Gi" }}
+    {{- if and (eq .Values.medusa.storage "local") ( .Values.medusa.podStorage ) }}
+    additionalVolumes:
+      - mountPath: /mnt/backups
+        name: medusa-backups
+        pvcSpec:
+          storageClassName: {{ .Values.medusa.podStorage.storageClass }}
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: {{ .Values.medusa.podStorage.size }}
+    {{- end }}
 {{- if .Values.cassandra.additionalSeeds }}
   additionalSeeds:
   {{- range .Values.cassandra.additionalSeeds }}
     - {{ . }}
   {{- end }}
 {{- end }}
-  allowMultipleNodesPerWorker: {{ .Values.cassandra.allowMultipleNodesPerWorker | default false}}  
+  allowMultipleNodesPerWorker: {{ .Values.cassandra.allowMultipleNodesPerWorker | default false}}
 {{- if .Values.cassandra.allowMultipleNodesPerWorker}}
   resources:
     limits:
@@ -195,6 +212,9 @@ spec:
           {{- if not (eq .Values.medusa.storage "local") }}
           - name:  {{ .Values.medusa.storageSecret }}
             mountPath: /etc/medusa-secrets
+          {{- else }}
+          - name:  medusa-backups
+            mountPath: /mnt/backups
           {{- end }}
       {{- end }}
       containers:
@@ -239,6 +259,9 @@ spec:
           {{- if not (eq .Values.medusa.storage "local") }}
           - mountPath: /etc/medusa-secrets
             name: {{ .Values.medusa.storageSecret }}
+          {{- else }}
+          - name:  medusa-backups
+            mountPath: /mnt/backups
           {{- end }}
       {{- end }}
       volumes:

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -53,7 +53,13 @@ spec:
         pvcSpec:
           storageClassName: {{ .Values.medusa.podStorage.storageClass }}
           accessModes:
+          {{- if .Values.medusa.podStorage.accessModes }}
+          {{- range .Values.medusa.podStorage.accessModes }}
+            - {{ . }}
+          {{- end }}
+          {{- else }}
             - ReadWriteOnce
+          {{- end }}
           resources:
             requests:
               storage: {{ .Values.medusa.podStorage.size }}

--- a/charts/k8ssandra/templates/medusa/medusa-config.yaml
+++ b/charts/k8ssandra/templates/medusa/medusa-config.yaml
@@ -27,7 +27,7 @@ data:
     {{ $key }} = {{ $value }}
   {{- end }}
   {{- if eq "local" .Values.medusa.storage }}
-    base_path = {{ .Values.medusa.bucketName }}
+    base_path = /mnt/backups
     {{- /*
       Medusa requires the bucket_name property to be set even when using local storage.
       See https://github.com/thelastpickle/cassandra-medusa/issues/299.

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -557,6 +557,10 @@ medusa:
     # to keep new backups as well as retained older backups.
     # size: 25Gi
 
+    # The volume can be mounted to pod with different access modes. The available modes depend on the provider and
+    # how they're exported in the PersistentVolume definition. The default for these mounts is ReadWriteOnce.
+    # accessModes: []
+
 monitoring:
   grafana:
     # -- Enables the creation of configmaps containing Grafana dashboards. If

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -518,8 +518,8 @@ medusa:
 
   # -- API interface used by the object store. Supported values include `s3`,
   # 's3_compatible' and `gcs`. For file system storage, i.e., a pod volume
-  # mount, use 'local'. Note that 'local' does not necessarily imply a local
-  # volume. It could also be network attached storage. It is simply accessed
+  # mount, use 'local' and set the podStorage properties. Note that 'local' does not necessarily 
+  # imply a local volume. It could also be network attached storage. It is simply accessed
   # through the file system.
   storage: s3
 
@@ -534,16 +534,28 @@ medusa:
     # For s3_compatible option, port is optional
     # port: 9000
 
-  # Is SSL used or not for s3_compatible connection
-  # secure: false
+    # Is SSL used or not for s3_compatible connection
+    # secure: false
 
-  # -- Name of the remote storage bucket where backups will be stored. If using 'local' storage, set the
-  # path of the local storage here.
+  # -- Name of the remote storage bucket where backups will be stored. If using 'local' storage, this
+  # value is ignored.
   bucketName: awstest
 
   # -- Name of the Kubernetes `Secret` that stores the key file for the
-  # storage provider's API
+  # storage provider's API. If using 'local' storage, this value is ignored.
   storageSecret: medusa-bucket-key
+
+  # -- To use a locally mounted volumes for backups, the Cassandra pods must have a PVC where to write
+  # the backups to.
+  podStorage: {}
+    # Storage class for persistent volume claims (PVCs) used for the medusa backups.
+    # Run `kubectl get storageclass` to identify what is available in your environment.
+    # This storageClass can be different than what is used by the Cassandra itself.
+    # storageClass: standard
+
+    # Size of the provisioned persistent volume per node. The available storage must be enough
+    # to keep new backups as well as retained older backups.
+    # size: 25Gi
 
 monitoring:
   grafana:

--- a/tests/integration/charts/cluster_with_medusa_local.yaml
+++ b/tests/integration/charts/cluster_with_medusa_local.yaml
@@ -15,9 +15,6 @@ reaper:
   enabled: false
 medusa:
   enabled: true
-  image:
-    repository: docker.io/k8ssandra/medusa
-    tag: 0.10.0
 
   multiTenant: true
   storage: local

--- a/tests/integration/charts/one_node_cluster_with_medusa_local.yaml
+++ b/tests/integration/charts/one_node_cluster_with_medusa_local.yaml
@@ -1,0 +1,33 @@
+cassandra:
+  heap:
+   size: 500M
+   newGenSize: 200M
+  datacenters:
+  - name: dc1
+    size: 1
+  ingress:
+    enabled: false
+  loggingSidecar:
+    enabled: false
+stargate:
+  enabled: false
+reaper:
+  enabled: false
+medusa:
+  enabled: true
+  image:
+    repository: docker.io/jsanda/medusa
+    tag: grpc-sigterm-13d70bb2
+
+  multiTenant: true
+  storage: local
+
+  podStorage:
+    storageClass: standard
+    size: 1Gi
+
+reaper-operator:
+  enabled: false
+
+kube-prometheus-stack:
+  enabled: false

--- a/tests/integration/charts/one_node_cluster_with_medusa_local.yaml
+++ b/tests/integration/charts/one_node_cluster_with_medusa_local.yaml
@@ -16,8 +16,8 @@ reaper:
 medusa:
   enabled: true
   image:
-    repository: docker.io/jsanda/medusa
-    tag: grpc-sigterm-13d70bb2
+    repository: docker.io/k8ssandra/medusa
+    tag: 0.10.0
 
   multiTenant: true
   storage: local

--- a/tests/integration/integration_suite_test.go
+++ b/tests/integration/integration_suite_test.go
@@ -185,7 +185,7 @@ func waitForSegmentDoneAndCancel(t *testing.T, repairId string) {
 // - Terminate the namespace and delete the cluster
 func TestMedusaDeploymentScenario(t *testing.T) {
 	const backupName = "backup1"
-	backends := []string{"Minio", "S3"}
+	backends := []string{"Minio", "S3", "local"}
 	for _, backend := range backends {
 		t.Run(fmt.Sprintf("Medusa on %s", backend), func(t *testing.T) {
 			namespace := initializeCluster(t)
@@ -232,7 +232,9 @@ func loadRowsAndCheckCount(t *testing.T, namespace string, rowsToLoad, rowsExpec
 
 func createMedusaSecretAndInstallDeps(t *testing.T, namespace, backend string) {
 	log.Println(Info("Creating medusa secret to access the backend"))
-	if backend == "Minio" {
+	if backend == "local" {
+		return
+	} else if backend == "Minio" {
 		DeployMinioAndCreateBucket(t, "k8ssandra-medusa")
 		CreateMedusaSecretWithFile(t, namespace, "secret/medusa_minio_secret.yaml")
 	} else {

--- a/tests/unit/template_medusa_config_test.go
+++ b/tests/unit/template_medusa_config_test.go
@@ -34,10 +34,12 @@ var _ = Describe("Verify medusa config template", func() {
 				options := &helm.Options{
 					KubectlOptions: defaultKubeCtlOptions,
 					SetValues: map[string]string{
-						"medusa.enabled":       "true",
-						"medusa.storage":       storageType,
-						"medusa.bucketName":    "testbucket",
-						"medusa.storageSecret": "secretkey",
+						"medusa.enabled":                 "true",
+						"medusa.storage":                 storageType,
+						"medusa.bucketName":              "testbucket",
+						"medusa.storageSecret":           "secretkey",
+						"medusa.podStorage.size":         "30Gi",
+						"medusa.podStorage.storageClass": "nfs",
 					},
 				}
 				Expect(renderTemplate(options)).To(Equal(expected))


### PR DESCRIPTION
**What this PR does**:
Adds the ability to create additional PersistentVolumes to Cassandra pods for the medusa's local storage option.

**Which issue(s) this PR fixes**:
Fixes #560 

**Checklist**
- [x] Changes manually tested
- [ ] Chart versions updated (if necessary)
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
