### PR TITLE
Automate helm chart version management on releases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,6 @@ Fixes #<issue number>
 
 **Checklist**
 - [ ] Changes manually tested
-- [ ] Chart versions updated (if necessary)
 - [ ] Automated Tests added/updated
 - [ ] Documentation added/updated
 - [ ] CHANGELOG.md updated (not required for documentation PRs)

--- a/.github/workflows/release-next.yaml
+++ b/.github/workflows/release-next.yaml
@@ -8,24 +8,18 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     env:
-      HELM_VERSION: 3.4.0
-      YQ_VERSION: 3.4.1
+      HELM_VERSION: 3.5.3
+      YQ_VERSION: v4.6.3
     outputs:
       VERSION: ${{ steps.get_version.outputs.VERSION }}
       SHORT_VERSION: ${{ steps.get_short_version.outputs.SHORT_VERSION }}
       HELM_VERSION: ${{ env.HELM_VERSION}}
       YQ_VERSION: ${{ env.YQ_VERSION }}
     steps:
-      - name: Cache bin path
-        id: cache
-        uses: actions/cache@v2
-        with:
-          path: bin
-          key: ${{ runner.os }}-${{ env.HELM_VERSION }}-${{ env.YQ_VERSION }}
+      - name: Checkout
+        uses: actions/checkout@v2
       - run: scripts/install-helm.sh $HELM_VERSION
-        if: steps.cache.outputs.cache-hit != 'true'
       - run: scripts/install-yq.sh $YQ_VERSION
-        if: steps.cache.outputs.cache-hit != 'true'
       - name: Update PATH
         run: |
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
@@ -47,24 +41,29 @@ jobs:
       - setup
     runs-on: ubuntu-latest
     steps: 
-      - name: Cache bin path
-        id: cache
-        uses: actions/cache@v2
-        with:
-          path: ~/bin
-          key: ${{ runner.os }}-${{ needs.setup.outputs.HELM_VERSION }}-${{ needs.setup.outputs.YQ_VERSION }}
       - name: Checkout
         uses: actions/checkout@v2
-      - run: scripts/install-helm.sh $HELM_VERSION
-        if: steps.cache.outputs.cache-hit != 'true'
-      - run: scripts/install-yq.sh $YQ_VERSION
-        if: steps.cache.outputs.cache-hit != 'true'
+      - run: scripts/install-helm.sh ${{ needs.setup.outputs.HELM_VERSION }}
+      - run: scripts/install-yq.sh ${{ needs.setup.outputs.YQ_VERSION }}
       - name: Update PATH
         run: |
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
       - name: Update chart dependencies
         run: |
           scripts/update-helm-deps.sh
+      - name: Compute release chart version
+        id: compute_next_version
+        run: |
+          DATE_TIME=$(date '+%Y%m%d%H%M%S')
+          NEXT_VERSION=$(echo $(yq e '.version' charts/k8ssandra/Chart.yaml) | sed "s/-.*/-${DATE_TIME}-${GITHUB_SHA::8}/")
+          echo "Next version is: $NEXT_VERSION"
+          echo "::set-output name=NEXT_VERSION::${NEXT_VERSION}"
+      - name: Update Helm chart version
+        env:
+          NEXT_VERSION: ${{ steps.compute_next_version.outputs.NEXT_VERSION }}
+        run: |
+          yq eval ".version |= \"${NEXT_VERSION}\"" charts/k8ssandra/Chart.yaml -i
+          cat charts/k8ssandra/Chart.yaml
       - name: Create working directory and copy charts
         run: |
           mkdir build
@@ -88,19 +87,10 @@ jobs:
       - package
     runs-on: ubuntu-latest
     steps:
-      - name: Cache bin path
-        id: cache
-        uses: actions/cache@v2
-        with:
-          path: ~/bin
-          key: ${{ runner.os }}-${{ needs.setup.outputs.HELM_VERSION }}-${{ needs.setup.outputs.YQ_VERSION }}
       - name: Checkout
         uses: actions/checkout@v2
-        if: steps.cache.outputs.cache-hit != 'true'
-      - run: scripts/install-helm.sh $HELM_VERSION
-        if: steps.cache.outputs.cache-hit != 'true'
-      - run: scripts/install-yq.sh $YQ_VERSION
-        if: steps.cache.outputs.cache-hit != 'true'
+      - run: scripts/install-helm.sh ${{ needs.setup.outputs.HELM_VERSION }}
+      - run: scripts/install-yq.sh ${{ needs.setup.outputs.YQ_VERSION }}
       - name: Update PATH
         run: |
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -8,26 +8,18 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     env:
-      HELM_VERSION: 3.4.0
-      YQ_VERSION: 3.4.1
+      HELM_VERSION: 3.5.3
+      YQ_VERSION: v4.6.3
     outputs:
       VERSION: ${{ steps.get_version.outputs.VERSION }}
       SHORT_VERSION: ${{ steps.get_short_version.outputs.SHORT_VERSION }}
       HELM_VERSION: ${{ env.HELM_VERSION}}
       YQ_VERSION: ${{ env.YQ_VERSION }}
     steps:
-      - name: Cache bin path
-        id: cache
-        uses: actions/cache@v2
-        with:
-          path: bin
-          key: ${{ runner.os }}-${{ env.HELM_VERSION }}-${{ env.YQ_VERSION }}
       - name: Checkout
         uses: actions/checkout@v2
       - run: scripts/install-helm.sh $HELM_VERSION
-        if: steps.cache.outputs.cache-hit != 'true'
       - run: scripts/install-yq.sh $YQ_VERSION
-        if: steps.cache.outputs.cache-hit != 'true'
       - name: Update PATH
         run: |
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
@@ -49,24 +41,23 @@ jobs:
       - setup
     runs-on: ubuntu-latest
     steps: 
-      - name: Cache bin path
-        id: cache
-        uses: actions/cache@v2
-        with:
-          path: ~/bin
-          key: ${{ runner.os }}-${{ needs.setup.outputs.HELM_VERSION }}-${{ needs.setup.outputs.YQ_VERSION }}'
       - name: Checkout
         uses: actions/checkout@v2
-      - run: scripts/install-helm.sh $HELM_VERSION
-        if: steps.cache.outputs.cache-hit != 'true'
-      - run: scripts/install-yq.sh $YQ_VERSION
-        if: steps.cache.outputs.cache-hit != 'true'
+      - run: scripts/install-helm.sh ${{ needs.setup.outputs.HELM_VERSION }}
+      - run: scripts/install-yq.sh ${{ needs.setup.outputs.YQ_VERSION }}
       - name: Update PATH
         run: |
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
       - name: Update chart dependencies
         run: |
           scripts/update-helm-deps.sh
+      - name: Check chart version matches tag
+        run: |
+          RELEASE_VERSION=$(yq e '.version' charts/k8ssandra/Chart.yaml)
+          if [[ "v$RELEASE_VERSION" != "${{ needs.setup.output.VERSION }}" ]]; then
+            echo "Tag version ${{ needs.setup.output.VERSION }} does not match Helm chart version $RELEASE_VERSION"
+            exit 1
+          fi
       - name: Create working directory and copy charts
         run: |
           mkdir build
@@ -132,16 +123,10 @@ jobs:
       - package
     runs-on: ubuntu-latest
     steps:
-      - name: Cache bin path
-        id: cache
-        uses: actions/cache@v2
-        with:
-          path: ~/bin
-          key: ${{ runner.os }}-${{ needs.setup.outputs.HELM_VERSION }}-${{ needs.setup.outputs.YQ_VERSION }}
-      - run: scripts/install-helm.sh $HELM_VERSION
-        if: steps.cache.outputs.cache-hit != 'true'
-      - run: scripts/install-yq.sh $YQ_VERSION
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Checkout
+        uses: actions/checkout@v2
+      - run: scripts/install-helm.sh ${{ needs.setup.outputs.HELM_VERSION }}
+      - run: scripts/install-yq.sh ${{ needs.setup.outputs.YQ_VERSION }}
       - name: Update PATH
         run: |
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH

--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -3,7 +3,7 @@ name: k8ssandra
 description: |
   Provisions and configures an instance of the entire K8ssandra stack. This includes Apache Cassandra, Stargate, Reaper, Medusa, Prometheus, and Grafana.
 type: application
-version: 1.0.5-3
+version: 1.1.0-SNAPSHOT
 
 dependencies:
   - name: cass-operator


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Automates Helm chart version number management for the next channel.
We're moving to using a fixed `x.x.x-SNAPSHOT` Helm chart version as long as it is unreleased. Pushes to main trigger a helm release on the next channel, and this PR implements a hot replacement of the version with `x.x.x-<datetime>-<git sha>`.

A check was added to the stable release workflow which verifies that the helm chart version (which should be manually updated before release) and the tag name match.

A problem was spotted with the cache that's being used for the `helm` and `yq` binaries: since the install uses a script, we need to perform a checkout in case we get a cache miss. It wasn't the case in the next workflow, which led to some failures.
The install being very fast (checkout + install helm + install yq takes about 3 seconds), I removed the cache everywhere in favor of performing the installs each time. This will also help us spot bugs that could be introduced in the install scripts.

I also bumped the yq and helm version numbers to the latest.

Obviously, I could only partially check that these changes were working as expected: https://github.com/adejanovski/k8ssandra/runs/2191981991?check_suite_focus=true#step:8:12

**Which issue(s) this PR fixes**:
Fixes #557 

**Checklist**
- [x] Changes manually tested
- [ ] Chart versions updated (if necessary)
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
