### PR TITLE
remove jolokia integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for K8ssandra, new PRs should update the `main / unreleased` section w
 When cutting a new release of the parent `k8ssandra` chart update the `main / unreleased` heading to the tag being generated and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `main / unreleased` entries.
 
 ## main / unreleased
+* [CHANGE] #533 Remove Jolokia integration
 * [ENHANCEMENT] #576 Add option to disable Cassandra logging sidecar
 * [ENHANCEMENT] #530 Upgrade Reaper to 2.2.2 and Medusa to 0.9.1
 * [ENHANCEMENT] #510 Add docs and examples in values.yaml

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -176,15 +176,6 @@ spec:
             name: server-config
       {{- end }}
       {{- if .Values.medusa.enabled }}
-      - name: get-jolokia
-        image: busybox
-        args:
-          - /bin/sh
-          - -c
-          - wget -O  /config/jolokia-jvm-1.6.2-agent.jar https://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-jvm/1.6.2/jolokia-jvm-1.6.2-agent.jar
-        volumeMounts:
-          - mountPath: /config
-            name: server-config
       - name: medusa-restore
         image: {{ $medusaImage }}
         imagePullPolicy: {{ .Values.medusa.image.pullPolicy }}
@@ -214,11 +205,7 @@ spec:
           - name: LOCAL_JMX
             value: "no"
           {{- end }}
-          {{- if .Values.medusa.enabled}}
-          - name: JVM_EXTRA_OPTS
-            value: -javaagent:/etc/cassandra/jolokia-jvm-1.6.2-agent.jar=port=7373,host=localhost
-          {{- end }}
-        {{- if .Values.medusa.enabled }}
+       {{- if .Values.medusa.enabled }}
         volumeMounts:
           - name: cassandra-config
             mountPath: /etc/cassandra

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -199,7 +199,6 @@ spec:
       {{- end }}
       containers:
       - name: cassandra
-{{/*       {{- if or .Values.reaper.enabled .Values.medusa.enabled }}*/}}
         {{- if .Values.reaper.enabled }}
         env:
           - name: LOCAL_JMX
@@ -242,7 +241,6 @@ spec:
             name: {{ .Values.medusa.storageSecret }}
           {{- end }}
       {{- end }}
-{{/*      {{- end }}*/}}
       volumes:
       - name: cassandra-config
         emptyDir: {}

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -199,12 +199,12 @@ spec:
       {{- end }}
       containers:
       - name: cassandra
-       {{- if or .Values.reaper.enabled .Values.medusa.enabled }}
+{{/*       {{- if or .Values.reaper.enabled .Values.medusa.enabled }}*/}}
+        {{- if .Values.reaper.enabled }}
         env:
-          {{- if .Values.reaper.enabled }}
           - name: LOCAL_JMX
             value: "no"
-          {{- end }}
+        {{- end }}
        {{- if .Values.medusa.enabled }}
         volumeMounts:
           - name: cassandra-config
@@ -242,7 +242,7 @@ spec:
             name: {{ .Values.medusa.storageSecret }}
           {{- end }}
       {{- end }}
-      {{- end }}
+{{/*      {{- end }}*/}}
       volumes:
       - name: cassandra-config
         emptyDir: {}

--- a/charts/k8ssandra/templates/medusa/medusa-config.yaml
+++ b/charts/k8ssandra/templates/medusa/medusa-config.yaml
@@ -49,7 +49,8 @@ data:
     enabled = 1
 
     [kubernetes]
-    cassandra_url = http://localhost:7373/jolokia/
+    cassandra_url = http://127.0.0.1:8080/api/v0/ops/node/snapshots
+    use_mgmt_api = 1
     enabled = 1
 
     [logging]

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -495,7 +495,7 @@ medusa:
     # -- Specifies the container repository for Medusa
     repository: docker.io/k8ssandra/medusa
     # -- Tag of an image within the specified repository
-    tag: 0.9.1
+    tag: 30ed2e15
     # -- The image pull policy
     pullPolicy: IfNotPresent
 

--- a/tests/unit/template_cassdc_test.go
+++ b/tests/unit/template_cassdc_test.go
@@ -64,7 +64,6 @@ const (
 	BaseConfigInitContainer     = "base-config-init"
 	MedusaInitContainer         = "medusa-restore"
 	JmxCredentialsInitContainer = "jmx-credentials"
-	GetJolokiaInitContainer     = "get-jolokia"
 
 	CassandraContainer = "cassandra"
 	MedusaContainer    = "medusa"
@@ -306,13 +305,10 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 
 			Expect(renderTemplate(options)).To(Succeed())
 
-			AssertInitContainerNamesMatch(cassdc, BaseConfigInitContainer, ConfigInitContainer, JmxCredentialsInitContainer, GetJolokiaInitContainer, MedusaInitContainer)
+			AssertInitContainerNamesMatch(cassdc, BaseConfigInitContainer, ConfigInitContainer, JmxCredentialsInitContainer, MedusaInitContainer)
 
 			// Two containers, medusa and cassandra
 			Expect(len(cassdc.Spec.PodTemplateSpec.Spec.Containers)).To(Equal(2))
-			// Cassandra container should have JVM_EXTRA_OPTS for jolokia
-			Expect(len(cassdc.Spec.PodTemplateSpec.Spec.Containers[0].Env)).To(Equal(1))
-			Expect(cassdc.Spec.PodTemplateSpec.Spec.Containers[0].Env[0].Name).To(Equal("JVM_EXTRA_OPTS"))
 			// Second container should be medusa
 			Expect(cassdc.Spec.PodTemplateSpec.Spec.Containers[1].Name).To(Equal(MedusaContainer))
 
@@ -335,13 +331,10 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 
 			Expect(renderTemplate(options)).To(Succeed())
 
-			AssertInitContainerNamesMatch(cassdc, BaseConfigInitContainer, ConfigInitContainer, JmxCredentialsInitContainer, GetJolokiaInitContainer, MedusaInitContainer)
+			AssertInitContainerNamesMatch(cassdc, BaseConfigInitContainer, ConfigInitContainer, JmxCredentialsInitContainer, MedusaInitContainer)
 
 			// Two containers, medusa and cassandra
 			Expect(len(cassdc.Spec.PodTemplateSpec.Spec.Containers)).To(Equal(2))
-			// Cassandra container should have JVM_EXTRA_OPTS for jolokia
-			Expect(len(cassdc.Spec.PodTemplateSpec.Spec.Containers[0].Env)).To(Equal(1))
-			Expect(cassdc.Spec.PodTemplateSpec.Spec.Containers[0].Env[0].Name).To(Equal("JVM_EXTRA_OPTS"))
 			// Second container should be medusa
 			Expect(cassdc.Spec.PodTemplateSpec.Spec.Containers[1].Name).To(Equal(MedusaContainer))
 
@@ -361,7 +354,7 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 
 			Expect(renderTemplate(options)).To(Succeed())
 
-			AssertInitContainerNamesMatch(cassdc, BaseConfigInitContainer, ConfigInitContainer, JmxCredentialsInitContainer, GetJolokiaInitContainer, MedusaInitContainer)
+			AssertInitContainerNamesMatch(cassdc, BaseConfigInitContainer, ConfigInitContainer, JmxCredentialsInitContainer, MedusaInitContainer)
 			AssertContainerNamesMatch(cassdc, CassandraContainer, MedusaContainer)
 		})
 
@@ -708,7 +701,7 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 
 			Expect(cassdc.Spec.Users).To(ContainElement(cassdcv1beta1.CassandraUser{Superuser: true, SecretName: clusterName + "-medusa"}))
 
-			AssertInitContainerNamesMatch(cassdc, BaseConfigInitContainer, ConfigInitContainer, JmxCredentialsInitContainer, GetJolokiaInitContainer, MedusaInitContainer)
+			AssertInitContainerNamesMatch(cassdc, BaseConfigInitContainer, ConfigInitContainer, JmxCredentialsInitContainer, MedusaInitContainer)
 
 			initContainer := GetInitContainer(cassdc, "medusa-restore")
 			Expect(initContainer).To(Not(BeNil()))
@@ -749,9 +742,6 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 
 			cassandraContainer := GetContainer(cassdc, CassandraContainer)
 			Expect(cassandraContainer).To(Not(BeNil()))
-			// Cassandra container should have JVM_EXTRA_OPTS for jolokia
-			Expect(len(cassandraContainer.Env)).To(Equal(1))
-			Expect(cassandraContainer.Env[0].Name).To(Equal("JVM_EXTRA_OPTS"))
 
 			medusaContainer := GetContainer(cassdc, MedusaContainer)
 			Expect(medusaContainer).To(Not(BeNil()))
@@ -790,7 +780,7 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 			Expect(renderTemplate(options)).To(Succeed())
 			Expect(cassdc.Spec.Users).To(ContainElement(cassdcv1beta1.CassandraUser{Superuser: true, SecretName: secretName}))
 
-			AssertInitContainerNamesMatch(cassdc, BaseConfigInitContainer, ConfigInitContainer, JmxCredentialsInitContainer, GetJolokiaInitContainer, MedusaInitContainer)
+			AssertInitContainerNamesMatch(cassdc, BaseConfigInitContainer, ConfigInitContainer, JmxCredentialsInitContainer, MedusaInitContainer)
 
 			initContainer := GetInitContainer(cassdc, MedusaInitContainer)
 			Expect(initContainer).To(Not(BeNil()))
@@ -831,9 +821,6 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 
 			cassandraContainer := GetContainer(cassdc, CassandraContainer)
 			Expect(cassandraContainer).To(Not(BeNil()))
-			// Cassandra container should have JVM_EXTRA_OPTS for jolokia
-			Expect(len(cassandraContainer.Env)).To(Equal(1))
-			Expect(cassandraContainer.Env[0].Name).To(Equal("JVM_EXTRA_OPTS"))
 
 			medusaContainer := GetContainer(cassdc, MedusaContainer)
 			Expect(medusaContainer).To(Not(BeNil()))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Removes the Jolokia integration. Jolokia is no longer needed since Medusa now supports management-api for creating snapshots. This PR allows us to get rid of the `get-jolokia` init container as well as remove the jolokia agent from Cassandra.

The Changes in Medusa are in master but not yet released. This PR updates the default Medusa image to one build from the master branch in Medusa. As soon we have a new release of Medusa we can update the default image again. That shouldn't hold up this PR though.

**Which issue(s) this PR fixes**:
Fixes #533

**Checklist**
- [x] Changes manually tested
- [x] Chart versions updated (if necessary)
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
