### PR TITLE
speed up tests with faster C* pod termination

### DIFF
--- a/tests/integration/charts/one_node_cluster_with_medusa_minio.yaml
+++ b/tests/integration/charts/one_node_cluster_with_medusa_minio.yaml
@@ -7,12 +7,17 @@ cassandra:
     size: 1
   ingress:
     enabled: false
+  loggingSidecar:
+    enabled: false
 stargate:
   enabled: false
 reaper:
   enabled: false
 medusa:
   enabled: true
+  image:
+    repository: docker.io/jsanda/medusa
+    tag: grpc-sigterm-13d70bb2
 
   multiTenant: true
   storage: s3_compatible

--- a/tests/integration/charts/one_node_cluster_with_medusa_s3.yaml
+++ b/tests/integration/charts/one_node_cluster_with_medusa_s3.yaml
@@ -7,12 +7,17 @@ cassandra:
     size: 1
   ingress:
     enabled: false
+  loggingSidecar:
+    enabled: false
 stargate:
   enabled: false
 reaper:
   enabled: false
 medusa:
   enabled: true
+  image:
+    repository: docker.io/jsanda/medusa
+    tag: grpc-sigterm-13d70bb2
 
   multiTenant: true
   storage: s3

--- a/tests/integration/charts/three_nodes_cluster_full_stack.yaml
+++ b/tests/integration/charts/three_nodes_cluster_full_stack.yaml
@@ -7,6 +7,8 @@ cassandra:
     size: 3
   ingress:
     enabled: false
+  loggingSidecar:
+    enabled: false
 
 stargate:
   enabled: true
@@ -21,6 +23,9 @@ stargate:
 
 medusa:
   enabled: true
+  image:
+    repository: docker.io/jsanda/medusa
+    tag: grpc-sigterm-13d70bb2
 
   multiTenant: true
   storage: s3_compatible

--- a/tests/integration/charts/three_nodes_cluster_with_reaper.yaml
+++ b/tests/integration/charts/three_nodes_cluster_with_reaper.yaml
@@ -7,6 +7,8 @@ cassandra:
     size: 3
   ingress:
     enabled: false
+  loggingSidecar:
+    enabled: false
 
 stargate:
   # -- Enable Stargate resources as part of this release

--- a/tests/integration/charts/three_nodes_cluster_with_stargate.yaml
+++ b/tests/integration/charts/three_nodes_cluster_with_stargate.yaml
@@ -7,6 +7,8 @@ cassandra:
     size: 3
   ingress:
     enabled: false
+  loggingSidecar:
+    enabled: false
 
 stargate:
   # -- Enable Stargate resources as part of this release

--- a/tests/integration/charts/three_nodes_cluster_with_stargate_and_monitoring.yaml
+++ b/tests/integration/charts/three_nodes_cluster_with_stargate_and_monitoring.yaml
@@ -7,6 +7,8 @@ cassandra:
     size: 3
   ingress:
     enabled: false
+  loggingSidecar:
+    enabled: false
 
 stargate:
   # -- Enable Stargate resources as part of this release


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
A couple days ago we merged #544. Tests runs really slowly in large part due to Cassandra pods taking a long time to terminate. See the following for more details on why tests run slowly:

* https://github.com/datastax/cass-operator/issues/325
* https://github.com/thelastpickle/cassandra-medusa/pull/313

When I ran `TestFullStackScenario` from main it took 1462.983s. From this branch it took 1043.537s. That is more than a 7 minute difference! 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Changes manually tested
- [ ] Chart versions updated (if necessary)
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
