### PR TITLE
add volume with pod labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ When cutting a new release of the parent `k8ssandra` chart update the `main / un
 * [BUGFIX] #602 Fix indentation error in example backup-restore-values.yaml
 * [ENHANCEMENT] #547 Add support for additionalSeeds in the CassandraDatacenter
 * [ENHANCEMENT] #606 Support installation of operators only, disabling the Cassandra cluster creation
+* [CHANGE] #613 Mount Cassandra pod labels in volume
 
 ## v1.0.0 - 2021-02-26
 

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -199,6 +199,8 @@ spec:
             mountPath: /etc/cassandra
           - mountPath: /var/lib/cassandra
             name: server-data
+          - name: podinfo
+            mountPath: /etc/podinfo
           {{- if not (eq .Values.medusa.storage "local") }}
           - name:  {{ .Values.medusa.storageSecret }}
             mountPath: /etc/medusa-secrets
@@ -212,12 +214,18 @@ spec:
           - name: LOCAL_JMX
             value: "no"
           {{- end }}
-       {{- if .Values.medusa.enabled }}
+          {{- if .Values.medusa.enabled}}
           - name: JVM_EXTRA_OPTS
             value: -javaagent:/etc/cassandra/jolokia-jvm-1.6.2-agent.jar=port=7373,host=localhost
+          {{- end }}
+        {{- if .Values.medusa.enabled }}
         volumeMounts:
           - name: cassandra-config
             mountPath: /etc/cassandra
+          - name: podinfo
+            mountPath: /etc/podinfo
+        {{- end }}
+      {{- if .Values.medusa.enabled }}
       - name: medusa
         image: {{ $medusaImage }}
         imagePullPolicy: {{ .Values.medusa.image.pullPolicy }}
@@ -252,6 +260,12 @@ spec:
       - name: cassandra-config
         emptyDir: {}
       {{- if .Values.medusa.enabled }}
+      - name: podinfo
+        downwardAPI:
+          items:
+            - path: "labels"
+              fieldRef:
+                fieldPath: metadata.labels
       - name: {{ include "medusa.configMapName" . }}
         configMap:
           name: {{ include "medusa.configMapName" . }}

--- a/tests/unit/template_cassdc_test.go
+++ b/tests/unit/template_cassdc_test.go
@@ -71,6 +71,7 @@ const (
 
 	CassandraConfigVolumeName = "cassandra-config"
 	MedusaBucketKeyVolumeName = "medusa-bucket-key"
+	PodInfoVolumeName         = "podinfo"
 )
 
 var _ = Describe("Verify CassandraDatacenter template", func() {
@@ -319,7 +320,7 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 			medusaConfigMap := HelmReleaseName + "-medusa"
 
 			Expect(kubeapi.GetVolumeMountNames(medusaContainer)).To(ConsistOf(medusaConfigMap, "cassandra-config", "server-data", storageSecret))
-			Expect(kubeapi.GetVolumeNames(cassdc.Spec.PodTemplateSpec)).To(ConsistOf(medusaConfigMap, "cassandra-config", storageSecret))
+			Expect(kubeapi.GetVolumeNames(cassdc.Spec.PodTemplateSpec)).To(ConsistOf(medusaConfigMap, "cassandra-config", storageSecret, PodInfoVolumeName))
 		})
 
 		It("enabling only medusa with local storage", func() {
@@ -348,7 +349,7 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 			medusaConfigMap := HelmReleaseName + "-medusa"
 
 			Expect(kubeapi.GetVolumeMountNames(medusaContainer)).To(ConsistOf(medusaConfigMap, "cassandra-config", "server-data"))
-			Expect(kubeapi.GetVolumeNames(cassdc.Spec.PodTemplateSpec)).To(ConsistOf(medusaConfigMap, "cassandra-config"))
+			Expect(kubeapi.GetVolumeNames(cassdc.Spec.PodTemplateSpec)).To(ConsistOf(medusaConfigMap, "cassandra-config", PodInfoVolumeName))
 		})
 
 		It("enabling reaper and medusa", func() {
@@ -766,8 +767,8 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 
 			verifyMedusaVolumeMounts(medusaContainer)
 
-			Expect(len(cassdc.Spec.PodTemplateSpec.Spec.Volumes)).To(Equal(3))
-			AssertVolumeNamesMatch(cassdc, CassandraConfigVolumeName, medusaConfigVolumeName, MedusaBucketKeyVolumeName)
+			Expect(len(cassdc.Spec.PodTemplateSpec.Spec.Volumes)).To(Equal(4))
+			AssertVolumeNamesMatch(cassdc, CassandraConfigVolumeName, medusaConfigVolumeName, MedusaBucketKeyVolumeName, PodInfoVolumeName)
 
 			Expect(cassdc.Spec.Users).To(ContainElement(cassdcv1beta1.CassandraUser{SecretName: secretName, Superuser: true}))
 		})
@@ -848,8 +849,8 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 
 			verifyMedusaVolumeMounts(medusaContainer)
 
-			Expect(len(cassdc.Spec.PodTemplateSpec.Spec.Volumes)).To(Equal(3))
-			AssertVolumeNamesMatch(cassdc, CassandraConfigVolumeName, medusaConfigVolumeName, MedusaBucketKeyVolumeName)
+			Expect(len(cassdc.Spec.PodTemplateSpec.Spec.Volumes)).To(Equal(4))
+			AssertVolumeNamesMatch(cassdc, CassandraConfigVolumeName, medusaConfigVolumeName, MedusaBucketKeyVolumeName, PodInfoVolumeName)
 
 			Expect(cassdc.Spec.Users).To(ContainElement(cassdcv1beta1.CassandraUser{SecretName: secretName, Superuser: true}))
 		})

--- a/tests/unit/utils/cassdc/volumes.go
+++ b/tests/unit/utils/cassdc/volumes.go
@@ -12,5 +12,5 @@ func AssertVolumeNamesMatch(cassdc *cassop.CassandraDatacenter, names ...string)
 	podTemplateSpec := cassdc.Spec.PodTemplateSpec
 	actualNames := GetVolumeNames(podTemplateSpec)
 
-	ExpectWithOffset(1, actualNames).To(Equal(names))
+	ExpectWithOffset(1, actualNames).To(ConsistOf(names))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds a new volume named `podinfo` which creates a file with the pod's labels. I have added a volume mount for the new `podinfo` volume in the `cassandra` container primarily for manual testing and verification. We really only need it for the `medusa-restore` container though.

The file that is created is /etc/podinfo/labels and looks like this:

```
app.kubernetes.io/managed-by="cass-operator"
cassandra.datastax.com/cluster="test"
cassandra.datastax.com/datacenter="dc1"
cassandra.datastax.com/node-state="Started"
cassandra.datastax.com/rack="default"
cassandra.datastax.com/seed-node="true"
controller-revision-hash="test-dc1-default-sts-6f859cfd9"
statefulset.kubernetes.io/pod-name="test-dc1-default-sts-0"
```

**Which issue(s) this PR fixes**:
Fixes #613
**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
