### PR TITLE
Add the ability to disable creation of Cassandra cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ When cutting a new release of the parent `k8ssandra` chart update the `main / un
 * [BUGIFX] #590 Create cass-operator webhook secret
 * [BUGFIX] #602 Fix indentation error in example backup-restore-values.yaml
 * [ENHANCEMENT] #547 Add support for additionalSeeds in the CassandraDatacenter
+* [ENHANCEMENT] #606 Support installation of operators only, disabling the Cassandra cluster creation
 
 ## v1.0.0 - 2021-02-26
 

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -5,6 +5,7 @@
   {{- fail (print .Values.cassandra.version " is not a supported Cassandra version") }}
 {{- end -}}
 
+{{- if .Values.cassandra.enabled -}}
 apiVersion: cassandra.datastax.com/v1beta1
 kind: CassandraDatacenter
 metadata:
@@ -262,4 +263,5 @@ spec:
         secret:
           secretName: {{ .Values.medusa.storageSecret }}
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/k8ssandra/templates/stargate/service.yaml
+++ b/charts/k8ssandra/templates/stargate/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.stargate.enabled }}
+{{- if and (.Values.stargate.enabled) (.Values.cassandra.enabled) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/k8ssandra/templates/stargate/stargate.yaml
+++ b/charts/k8ssandra/templates/stargate/stargate.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.stargate.enabled }}
+{{- if and (.Values.stargate.enabled) (.Values.cassandra.enabled) }}
   {{- $stargateVersion := .Values.stargate.version }}
   {{- $computedClusterVersion := "" }}
   {{- $computedImage := "" }}

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -1,4 +1,7 @@
 cassandra:
+  # -- Enables installation of Cassandra cluster. Set to false if you only wish to install operators.
+  enabled: true
+
   # -- The Cassandra version to use. The supported versions include the following:
   #    - 3.11.7
   #    - 3.11.8

--- a/tests/unit/template_cassdc_test.go
+++ b/tests/unit/template_cassdc_test.go
@@ -137,6 +137,17 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 			Expect(config.JvmOptions.YoungGenSize).To(BeEmpty())
 		})
 
+		It("is not rendered if disabled", func() {
+			options := &helm.Options{
+				KubectlOptions: defaultKubeCtlOptions,
+				SetValues: map[string]string{
+					"cassandra.enabled": "false",
+				},
+			}
+
+			Expect(renderTemplate(options)).ShouldNot(Succeed())
+		})
+
 		It("override clusterName", func() {
 			clusterName := "test"
 			options := &helm.Options{

--- a/tests/unit/template_stargate_test.go
+++ b/tests/unit/template_stargate_test.go
@@ -56,6 +56,15 @@ var _ = Describe("Verify Stargate template", func() {
 			}
 			Expect(renderTemplate(options)).ShouldNot(Succeed())
 		})
+		It("cassandra is explicitly disabled", func() {
+			options := &helm.Options{
+				KubectlOptions: defaultKubeCtlOptions,
+				SetValues: map[string]string{
+					"cassandra.enabled": "false",
+				},
+			}
+			Expect(renderTemplate(options)).ShouldNot(Succeed())
+		})
 	})
 
 	Context("by confirming it does render when", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds enabled flag under cassandra section in values.yaml which controls if the Cassandra cluster should be installed or not. This allows to install only operators for example, or even just cass-operator:

```
➜  k8ssandra git:(disable_cassandra) ✗ helm install demo charts/k8ssandra --create-namespace -n k8ssandra-1 --set cassandra.enabled=false --set kube-prometheus-stack.enabled=false --set reaper.enabled=false --set stargate.enabled=false --set reaper-operator.enabled=false
W0401 10:26:24.355313   59581 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0401 10:26:24.754009   59581 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0401 10:26:24.766212   59581 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0401 10:26:24.782249   59581 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
NAME: demo
LAST DEPLOYED: Thu Apr  1 10:26:27 2021
NAMESPACE: k8ssandra-1
STATUS: deployed
REVISION: 1
TEST SUITE: None
➜  k8ssandra git:(disable_cassandra) ✗ kubectl get all -n k8ssandra-1    NAME                                      READY   STATUS    RESTARTS   AGE
pod/demo-cass-operator-7c5648545c-b59g6   1/1     Running   0          28m

NAME                            TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)             AGE
service/cass-operator-metrics   ClusterIP   10.96.87.75   <none>        8383/TCP,8686/TCP   28m

NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/demo-cass-operator   1/1     1            1           28m

NAME                                            DESIRED   CURRENT   READY   AGE
replicaset.apps/demo-cass-operator-7c5648545c   1         1         1       28m
➜  k8ssandra git:(disable_cassandra) ✗
```

**Which issue(s) this PR fixes**:
Fixes #606 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
