### PR TITLE
[#623] wait for CassandraDatacenters to be gone before exiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ When cutting a new release of the parent `k8ssandra` chart update the `main / un
 * [BUGFIX] #475 Fix Cassandra config clobbering when enabling Medusa
 * [BUGIFX] #590 Create cass-operator webhook secret
 * [BUGFIX] #602 Fix indentation error in example backup-restore-values.yaml
+* [BUGFIX] #623 `helm uninstall` can leave CassandraDatacenter behind
 * [ENHANCEMENT] #547 Add support for additionalSeeds in the CassandraDatacenter
 * [ENHANCEMENT] #606 Support installation of operators only, disabling the Cassandra cluster creation
 * [CHANGE] #613 Mount Cassandra pod labels in volume

--- a/pkg/cleaner/cleaner_test.go
+++ b/pkg/cleaner/cleaner_test.go
@@ -65,11 +65,10 @@ var _ = Describe("Cleaning CassandraDatacenters", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      cassdcKeyManaged.Name,
 				Namespace: cassdcKeyManaged.Namespace,
-				Annotations: map[string]string{
-					releaseAnnotation: cleanerTestRelease,
-				},
 				Labels: map[string]string{
 					managedLabel: managedLabelValue,
+					instanceLabel: cleanerTestRelease,
+					nameLabel: nameLabelValue,
 				},
 			},
 			Spec: cassdcapi.CassandraDatacenterSpec{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Updates the cleaner job to block until CassandraDatacenters installed in the release are gone.

**Which issue(s) this PR fixes**:
Fixes #623

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
