### PR TITLE
We should not run integration tests on PRs that do not involve code changes

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -2,6 +2,11 @@
 name: Integration Tests
 on: 
   pull_request:
+    paths:
+      - 'pkg/**'
+      - 'cmd/**'
+      - 'charts/**'
+      - 'tests/integration/**'
   push:
     branches:
       - 'main'


### PR DESCRIPTION
I already submitted a PR for this, but it looks like the behavior was not completely fixed. I still see integration tests running on PRs that do not include code changes.