### PR TITLE
Remove the next repo and publish prereleases to the stable one

### DIFF
--- a/.github/workflows/release-next.yaml
+++ b/.github/workflows/release-next.yaml
@@ -1,5 +1,5 @@
 ---
-name: Release Next Charts
+name: Release Prerelease Charts
 on:
   push:
     branches:
@@ -110,17 +110,17 @@ jobs:
       - name: Download current index from Google Cloud
         env:
           GCP_HELM_BUCKET_NAME: ${{ secrets.GCP_HELM_BUCKET_NAME }}
-        run: gsutil cp gs://$GCP_HELM_BUCKET_NAME/next/index.yaml ./
+        run: gsutil cp gs://$GCP_HELM_BUCKET_NAME/stable/index.yaml ./
         working-directory: build
       - name: Regenerate Helm index
         env:
           GCP_HELM_BUCKET_NAME: ${{ secrets.GCP_HELM_BUCKET_NAME }}
-        run: helm repo index . --merge index.yaml --url "https://$GCP_HELM_BUCKET_NAME/next/"
+        run: helm repo index . --merge index.yaml --url "https://$GCP_HELM_BUCKET_NAME/stable/"
         working-directory: build
       - name: Upload packages and index
         env:
           GCP_HELM_BUCKET_NAME: ${{ secrets.GCP_HELM_BUCKET_NAME }}
         run: |
-          gsutil cp ./*.tgz gs://$GCP_HELM_BUCKET_NAME/next/
-          gsutil cp ./index.yaml gs://$GCP_HELM_BUCKET_NAME/next/
+          gsutil cp ./*.tgz gs://$GCP_HELM_BUCKET_NAME/stable/
+          gsutil cp ./index.yaml gs://$GCP_HELM_BUCKET_NAME/stable/
         working-directory: build


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Since Helm v3+ supports prereleases natively and hides them unless the `--devel` flag is used, we will stop maintaining the  `next` helm repo and publish prereleases to the `stable` repo.
Installing a prerelease requires then to use the `--devel` flag.

**Which issue(s) this PR fixes**:
Fixes #599

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
