### PR TITLE
Upgrade to Medusa 0.10.1 fixing failed backups after a restore

### DIFF
--- a/CHANGELOG-1.2.md
+++ b/CHANGELOG-1.2.md
@@ -13,4 +13,5 @@ When cutting a new release of the parent `k8ssandra` chart update the `unrelease
 
 ## unreleased
 
+* [BUGFIX] #678 Upgrade to Medusa 0.10.1 fixing failed backups after a restore
 * [ENHANCEMENT] #560 Add the ability to attach additional PVs for medusa backups

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -495,7 +495,7 @@ medusa:
     # -- Specifies the container repository for Medusa
     repository: docker.io/k8ssandra/medusa
     # -- Tag of an image within the specified repository
-    tag: 0.10.0
+    tag: 0.10.1
     # -- The image pull policy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Upgrade Medusa to 0.10.1 which contains a fix for using Minio with the default region and also removes the protocol version enforcement which created a bug in K8ssandra when taking backups after a restore.

**Which issue(s) this PR fixes**:
Fixes #678 
Fixes #705 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
