### PR TITLE
Reduce initial delay of Stargate readiness probe

### DIFF
--- a/CHANGELOG-1.2.md
+++ b/CHANGELOG-1.2.md
@@ -1,6 +1,7 @@
 # Changelog
 
-Changelog for K8ssandra, new PRs should update the ` unreleased` section with entries in the order:
+Changelog for K8ssandra, new PRs should update the `unreleased` section below with entries sorted by type, in the 
+following order:
 
 ```markdown
 * [CHANGE]
@@ -9,12 +10,17 @@ Changelog for K8ssandra, new PRs should update the ` unreleased` section with en
 * [BUGFIX]
 ```
 
-When cutting a new release of the parent `k8ssandra` chart update the `unreleased` heading to the tag being generated and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
+If two entries have the same type, they should be sorted from newest to oldest (the newest comes first, the oldest comes 
+last).
+
+When cutting a new release of the parent `k8ssandra` chart update the `unreleased` heading to the tag being generated 
+and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
 
-* [BUGFIX] #678 Upgrade to Medusa 0.10.1 fixing failed backups after a restore
 * [CHANGE] #726 Upgrade to Cassandra 4.0-rc1
+* [ENHANCEMENT] #654 Reduce initial delay of Stargate readiness probe
 * [ENHANCEMENT] #560 Add the ability to attach additional PVs for medusa backups
 * [ENHANCEMENT] #693 Update cass-operator to v1.7.0
 * [ENHANCEMENT] #732 Make allocate_tokens_for_replication_factor configurable
+* [BUGFIX] #678 Upgrade to Medusa 0.10.1 fixing failed backups after a restore

--- a/charts/k8ssandra/templates/stargate/stargate.yaml
+++ b/charts/k8ssandra/templates/stargate/stargate.yaml
@@ -111,13 +111,13 @@ spec:
               path: /checker/liveness
               port: health
             timeoutSeconds: 10
-            initialDelaySeconds: 30
+            initialDelaySeconds: {{ .Values.stargate.livenessInitialDelaySeconds }}
             failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /checker/readiness
               port: health
             timeoutSeconds: 10
-            initialDelaySeconds: 30
+            initialDelaySeconds: {{ .Values.stargate.readinessInitialDelaySeconds }}
             failureThreshold: 5
 {{- end }}

--- a/charts/k8ssandra/templates/stargate/stargate.yaml
+++ b/charts/k8ssandra/templates/stargate/stargate.yaml
@@ -39,8 +39,8 @@ spec:
             args:
               - -c
               - |
-                echo "Waiting for at least one cassandra node to finish bootstrapping..."
-                while ! nslookup {{ include "k8ssandra.clusterName" . }}-seed-service.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain | default "cluster.local" }}; do
+                echo "Waiting for all Cassandra nodes in {{ include "k8ssandra.datacenterName" . }} to finish bootstrapping..."
+                while [ "$(nslookup {{ include "k8ssandra.clusterName" . }}-{{ include "k8ssandra.datacenterName" . }}-service.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain | default "cluster.local" }} | grep Name | wc -l)" != "{{ include "k8ssandra.datacenterSize" . }}" ]; do
                     sleep 5
                 done
                 echo "Cassandra is ready. Starting Stargate..."

--- a/charts/k8ssandra/templates/stargate/stargate.yaml
+++ b/charts/k8ssandra/templates/stargate/stargate.yaml
@@ -111,11 +111,13 @@ spec:
               path: /checker/liveness
               port: health
             timeoutSeconds: 10
-            initialDelaySeconds: 240
+            initialDelaySeconds: 30
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /checker/readiness
               port: health
-            timeoutSeconds: 3
-            initialDelaySeconds: 240
+            timeoutSeconds: 10
+            initialDelaySeconds: 30
+            failureThreshold: 5
 {{- end }}

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -334,6 +334,12 @@ stargate:
   # -- Sets the CPU limit for the Stargate pod in millicores.
   cpuLimMillicores: 1000
 
+  # -- Sets the initial delay in seconds for the Stargate liveness probe.
+  livenessInitialDelaySeconds: 30
+
+  # -- Sets the initial delay in seconds for the Stargate readiness probe.
+  readinessInitialDelaySeconds: 30
+
   # -- Configures the Cassandra user used by Stargate when authentication is
   # enabled. If neither `cassandraUser.secret` nor `casandraUser.username` are
   # set, then a Cassandra user and a secret will be created. The username will

--- a/tests/unit/template_stargate_test.go
+++ b/tests/unit/template_stargate_test.go
@@ -357,5 +357,21 @@ var _ = Describe("Verify Stargate template", func() {
 			container := deployment.Spec.Template.Spec.Containers[0]
 			Expect(container.Image).To(Equal(alternateImage))
 		})
+
+		It("changing probe initial delay", func() {
+			options := &helm.Options{
+				KubectlOptions: defaultKubeCtlOptions,
+				SetValues: map[string]string{
+					"stargate.enabled":                      "true",
+					"stargate.livenessInitialDelaySeconds":  "60",
+					"stargate.readinessInitialDelaySeconds": "90",
+				},
+			}
+
+			Expect(renderTemplate(options)).To(Succeed())
+			container := deployment.Spec.Template.Spec.Containers[0]
+			Expect(container.LivenessProbe.InitialDelaySeconds).To(Equal(int32(60)))
+			Expect(container.ReadinessProbe.InitialDelaySeconds).To(Equal(int32(90)))
+		})
 	})
 })

--- a/tests/unit/template_stargate_test.go
+++ b/tests/unit/template_stargate_test.go
@@ -104,7 +104,8 @@ var _ = Describe("Verify Stargate template", func() {
 			Expect(string(initContainer.ImagePullPolicy)).To(Equal("IfNotPresent"))
 
 			Expect(initContainer.Args[0]).To(Equal("-c"))
-			Expect(initContainer.Args[1]).To(ContainSubstring(Sprintf("nslookup %s-seed-service.%s.svc.cluster.local;", HelmReleaseName, DefaultTestNamespace)))
+			Expect(initContainer.Args[1]).To(ContainSubstring(
+				Sprintf("nslookup %s-dc1-service.%s.svc.cluster.local", HelmReleaseName, DefaultTestNamespace)))
 
 			Expect(len(templateSpec.Containers)).To(Equal(1))
 			container := templateSpec.Containers[0]
@@ -231,11 +232,13 @@ var _ = Describe("Verify Stargate template", func() {
 
 			initContainer := deployment.Spec.Template.Spec.InitContainers[0]
 			Expect(initContainer.Args[0]).To(Equal("-c"))
-			Expect(initContainer.Args[1]).To(ContainSubstring(Sprintf("nslookup %s-seed-service.%s.svc.cluster.local;", clusterName, DefaultTestNamespace)))
+			Expect(initContainer.Args[1]).To(ContainSubstring(
+				Sprintf("nslookup %s-dc1-service.%s.svc.cluster.local", clusterName, DefaultTestNamespace)))
 
 			container := deployment.Spec.Template.Spec.Containers[0]
 			seed := kubeapi.FindEnvVarByName(container, "SEED")
-			Expect(seed.Value).To(Equal(Sprintf("%s-seed-service.%s.svc.cluster.local", clusterName, DefaultTestNamespace)))
+			Expect(seed.Value).To(Equal(
+				Sprintf("%s-seed-service.%s.svc.cluster.local", clusterName, DefaultTestNamespace)))
 		})
 
 		It("changing datacenter name", func() {
@@ -255,6 +258,13 @@ var _ = Describe("Verify Stargate template", func() {
 			container := deployment.Spec.Template.Spec.Containers[0]
 			datacenterName := kubeapi.FindEnvVarByName(container, "DATACENTER_NAME")
 			Expect(datacenterName.Value).To(Equal(targetDcName))
+
+			clusterName := kubeapi.FindEnvVarByName(container, "CLUSTER_NAME")
+			initContainer := deployment.Spec.Template.Spec.InitContainers[0]
+			Expect(initContainer.Args[0]).To(Equal("-c"))
+			Expect(initContainer.Args[1]).To(ContainSubstring(
+				Sprintf("nslookup %s-%s-service.%s.svc.cluster.local",
+					clusterName.Value, targetDcName, DefaultTestNamespace)))
 		})
 
 		It("changing memory allocation", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

* Modifies Stargate init container to wait not for one, but for all nodes in datacenter 0.
* Modifies the initial delay for Stargate probes

**Which issue(s) this PR fixes**:

Fixes #654

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
