### PR TITLE
Allow setting additional autoscheduling properties, fixes #224

### DIFF
--- a/CHANGELOG-1.2.md
+++ b/CHANGELOG-1.2.md
@@ -25,3 +25,4 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 * [ENHANCEMENT] #693 Update cass-operator to v1.7.0
 * [ENHANCEMENT] #732 Make allocate_tokens_for_replication_factor configurable
 * [BUGFIX] #678 Upgrade to Medusa 0.10.1 fixing failed backups after a restore
+* [FEATURE] #224 Allow defining additional settings for autoscheduling in Reaper, update reaper-operator to v0.3.1

--- a/charts/k8ssandra/templates/reaper/reaper.yaml
+++ b/charts/k8ssandra/templates/reaper/reaper.yaml
@@ -9,6 +9,11 @@ spec:
   serverConfig:
     autoScheduling:
       enabled: {{ .Values.reaper.autoschedule }}
+      {{- if .Values.reaper.autoschedule }}
+      {{- range $key, $value := .Values.reaper.autoschedule_properties }}
+      {{ $key }}: {{ $value }}
+      {{- end }}
+      {{- end }}
     storageType: cassandra
     jmxUserSecretName: {{ include "k8ssandra.reaperJmxUserSecretName" . }}
     cassandraBackend:

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -447,6 +447,10 @@ reaper:
   # added or removed repair schedules will be added or removed respectively.
   autoschedule: false
 
+  # -- Additional autoscheduling properties. Allows to customize the schedule rules
+  # for autoscheduling. Properties are the same as accepted by the Reaper.
+  autoschedule_properties: {}
+
   # -- Enable Reaper resources as part of this release. Note that Reaper uses
   # Cassandra's JMX APIs to perform repairs. When Reaper is enabled, Cassandra
   # will also be configured to allow remote JMX access. JMX authentication

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48
 	github.com/gruntwork-io/terratest v0.30.15
 	github.com/k8ssandra/cass-operator v1.7.0
-	github.com/k8ssandra/reaper-operator v0.2.0
+	github.com/k8ssandra/reaper-operator v0.3.1
 	github.com/onsi/ginkgo v1.14.2
 	github.com/onsi/gomega v1.10.3
 	github.com/traefik/traefik/v2 v2.3.7

--- a/go.sum
+++ b/go.sum
@@ -763,8 +763,8 @@ github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E
 github.com/k8ssandra/cass-operator v1.7.0 h1:xB6Va/H0rUYFr0Kd2sSTD0d5dVdbCD4IxoHoKKreSCo=
 github.com/k8ssandra/cass-operator v1.7.0/go.mod h1:mUZdlBasktWCgrYeCLiVNJCH0QjFF0bYxXWAdYyv3qg=
 github.com/k8ssandra/reaper-client-go v0.3.0/go.mod h1:1yol6YTcKcLOmPH9CfAdeFnVg/KCCTSbIUXMsF1cKII=
-github.com/k8ssandra/reaper-operator v0.2.0 h1:mbIBlaQOsZr+OJIXYTx5i6znZCNuTaxFPWBZ2O5ZigM=
-github.com/k8ssandra/reaper-operator v0.2.0/go.mod h1:Vf2RsyiWAbGemrhZ4TK8uA0040EeTaoQk+irR/E9zFg=
+github.com/k8ssandra/reaper-operator v0.3.1 h1:6UuzyFSxE7ur0+LRJYLA6PBXsl0OkkU8Q8Ua9ZQ8jS0=
+github.com/k8ssandra/reaper-operator v0.3.1/go.mod h1:Vf2RsyiWAbGemrhZ4TK8uA0040EeTaoQk+irR/E9zFg=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/karrick/godirwalk v1.7.5/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
 github.com/karrick/godirwalk v1.10.12/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=

--- a/tests/unit/template_reaper_test.go
+++ b/tests/unit/template_reaper_test.go
@@ -73,6 +73,20 @@ var _ = Describe("Verify Reaper template", func() {
 			Expect(reaper.Spec.ServerConfig.AutoScheduling).ToNot(BeNil())
 		})
 
+		It("modifying autoscheduling additional properties", func() {
+			options := &helm.Options{
+				SetStrValues: map[string]string{
+					"reaper.autoschedule":                               "true",
+					"reaper.autoschedule_properties.initialDelayPeriod": "PT10S",
+				},
+				KubectlOptions: defaultKubeCtlOptions,
+			}
+
+			renderTemplate(options)
+			Expect(reaper.Spec.ServerConfig.AutoScheduling).ToNot(BeNil())
+			Expect(reaper.Spec.ServerConfig.AutoScheduling.InitialDelay).To(Equal("PT10S"))
+		})
+
 		It("modifying secret options", func() {
 			options := &helm.Options{
 				SetStrValues: map[string]string{


### PR DESCRIPTION
**What this PR does**:
Adds support for additional autoscheduling properties. Requires updated reaper-operator version.

**Which issue(s) this PR fixes**:
Fixes #224

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
