### PR TITLE
Fixes #807 - Triggers docs regeneration on pushes to main

### DIFF
--- a/.github/workflows/publish-website.yaml
+++ b/.github/workflows/publish-website.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - johnsmart-infoarch
     paths:
       - 'docs/**'
   workflow_dispatch:

--- a/.github/workflows/regenerate-reference-docs.yaml
+++ b/.github/workflows/regenerate-reference-docs.yaml
@@ -1,6 +1,12 @@
 name: Regenerate Reference Docs
 on: 
-  - workflow_dispatch
+  push:
+    branches:
+      - main
+    paths:
+      - 'charts/**/Chart.yaml'
+      - 'charts/**/values.yaml'
+  workflow_dispatch:
 jobs:
   regenerate-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What this PR does**: Enables the regeneration of chart reference docs

**Which issue(s) this PR fixes**:
Fixes #807

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
