### PR TITLE
K8SSAND-187 - Add action to automate Fossa scanning

### DIFF
--- a/.github/workflows/license-scanning.yaml
+++ b/.github/workflows/license-scanning.yaml
@@ -1,0 +1,14 @@
+name: License Scanning
+on:
+  - pull_request
+  - push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Run FOSSA scan and upload build data
+        uses: fossa-contrib/fossa-action@v1
+        with:
+          fossa-api-key: 2d869069eb9c6957244ef3d28befb626


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:  Creates a GH action responsible for automating license/component scanning via Fossa.

This uses a push-only API token per Fossa's documentation:  https://github.com/fossa-contrib/fossa-action#push-only-api-token

**Which issue(s) this PR fixes**:
Fixes #812 
Fixes K8SSAND-187

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
