### PR TITLE
check how many dc updates there are via status condition

### DIFF
--- a/charts/medusa-operator/crds/restore.yaml
+++ b/charts/medusa-operator/crds/restore.yaml
@@ -1,9 +1,8 @@
----
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: cassandrarestores.cassandra.k8ssandra.io
 spec:
@@ -14,83 +13,85 @@ spec:
     plural: cassandrarestores
     singular: cassandrarestore
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: CassandraRestore is the Schema for the cassandrarestores API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CassandraRestoreSpec defines the desired state of CassandraRestore
-          properties:
-            backup:
-              description: The name of the CassandraBackup to restore
-              type: string
-            cassandraDatacenter:
-              properties:
-                clusterName:
-                  description: The name to give the C* cluster.
-                  type: string
-                name:
-                  description: The name to give the new, restored CassandraDatacenter
-                  type: string
-              required:
-                - clusterName
-                - name
-              type: object
-            inPlace:
-              description: When true the restore will be performed on the source cluster from which the backup was taken. There will be a rolling restart of the source cluster.
-              type: boolean
-            shutdown:
-              description: When set to true, the cluster is shutdown before the restore is applied. This is necessary process if there are schema changes between the backup and current schema. Recommended.
-              type: boolean
-          required:
-            - backup
-            - cassandraDatacenter
-            - inPlace
-            - shutdown
-          type: object
-        status:
-          description: CassandraRestoreStatus defines the observed state of CassandraRestore
-          properties:
-            failed:
-              items:
-                type: string
-              type: array
-            finishTime:
-              format: date-time
-              type: string
-            finished:
-              items:
-                type: string
-              type: array
-            inProgress:
-              items:
-                type: string
-              type: array
-            restoreKey:
-              description: A unique key that identifies the restore operation.
-              type: string
-            startTime:
-              format: date-time
-              type: string
-          required:
-            - restoreKey
-          type: object
-      type: object
-  version: v1alpha1
   versions:
     - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: CassandraRestore is the Schema for the cassandrarestores API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: CassandraRestoreSpec defines the desired state of CassandraRestore
+              properties:
+                backup:
+                  description: The name of the CassandraBackup to restore
+                  type: string
+                cassandraDatacenter:
+                  properties:
+                    clusterName:
+                      description: The name to give the C* cluster.
+                      type: string
+                    name:
+                      description: The name to give the new, restored CassandraDatacenter
+                      type: string
+                  required:
+                    - clusterName
+                    - name
+                  type: object
+                inPlace:
+                  description: When true the restore will be performed on the source cluster from which the backup was taken. There will be a rolling restart of the source cluster.
+                  type: boolean
+                shutdown:
+                  description: When set to true, the cluster is shutdown before the restore is applied. This is necessary process if there are schema changes between the backup and current schema. Recommended.
+                  type: boolean
+              required:
+                - backup
+                - cassandraDatacenter
+                - inPlace
+                - shutdown
+              type: object
+            status:
+              description: CassandraRestoreStatus defines the observed state of CassandraRestore
+              properties:
+                datacenterStopped:
+                  format: date-time
+                  type: string
+                failed:
+                  items:
+                    type: string
+                  type: array
+                finishTime:
+                  format: date-time
+                  type: string
+                finished:
+                  items:
+                    type: string
+                  type: array
+                inProgress:
+                  items:
+                    type: string
+                  type: array
+                restoreKey:
+                  description: A unique key that identifies the restore operation.
+                  type: string
+                startTime:
+                  format: date-time
+                  type: string
+              required:
+                - restoreKey
+              type: object
+          type: object
       served: true
       storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/medusa-operator/templates/deployment.yaml
+++ b/charts/medusa-operator/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: medusa-operator
         resources: {{- toYaml .Values.resources | nindent 10 }}
       terminationGracePeriodSeconds: 10

--- a/charts/medusa-operator/templates/role.yaml
+++ b/charts/medusa-operator/templates/role.yaml
@@ -22,6 +22,14 @@ rules:
       - get
       - list
       - update
+      - patch
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - list
       - watch
   - apiGroups:
       - cassandra.k8ssandra.io

--- a/charts/medusa-operator/values.yaml
+++ b/charts/medusa-operator/values.yaml
@@ -14,13 +14,13 @@ replicaCount: 1
 
 image:
   # -- Container repository where the medusa-operator resides
-  repository: docker.io/k8ssandra/medusa-operator
+  repository: docker.io/jsanda/medusa-operator
 
   # -- Pull policy for the operator container
   pullPolicy: IfNotPresent
   
   # -- Tag of the medusa-operator image to pull from image.repository
-  tag: v0.2.0
+  tag: 3f42919e807d
 
 # -- References to secrets to use when pulling images. ref:
 # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/tests/integration/steps/medusa_steps.go
+++ b/tests/integration/steps/medusa_steps.go
@@ -85,7 +85,7 @@ func RestoreBackup(t *testing.T, namespace, backupName string) {
 
 func checkDatacenterUpdates(t *testing.T, namespace string, start time.Time, updates map[time.Time]bool) {
 	dc := &cassdcapi.CassandraDatacenter{}
-	if err := testClient.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: datacenterName}, dc); err == nil {
+	if err := testClient.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: datacenterName}, dc); err != nil {
 		t.Logf("Failed to get CassandraDatacenter while waiting for restore to finish: %s", err)
 		return
 	}


### PR DESCRIPTION
The CassandraDatacenter has a status condition called `Updating`. This is condition has its status set to `true` whenever the underlying StatefulSets are updated. This happens multiple times during a restore operation, but it should only happen once. My expectation therefore is that this change will cause the backup/restore tests to fail.



┆Issue is synchronized with this [Jira Bug](https://k8ssandra.atlassian.net/browse/K8SSAND-549) by [Unito](https://www.unito.io)
