### PR TITLE
Fix doc builds [K8SSAND-566]

### DIFF
--- a/.github/workflows/publish-website.yaml
+++ b/.github/workflows/publish-website.yaml
@@ -28,8 +28,6 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('docs/package-lock.json') }}-${{ env.HUGO_VERSION }}
       - run: scripts/install-hugo.sh
         if: steps.cache.outputs.cache-hit != 'true'
-      - run: scripts/install-npm-tools.sh
-        if: steps.cache.outputs.cache-hit != 'true'
       - run: scripts/install-npm-dependencies.sh
         if: steps.cache.outputs.cache-hit != 'true'
       - name: Update PATH

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "autoprefixer": "^10.2.5",
+        "postcss": "^8.3.1",
         "postcss-cli": "^8.3.1"
       }
     },
@@ -463,9 +464,9 @@
       }
     },
     "node_modules/glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -706,7 +707,6 @@
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
       "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -796,11 +796,10 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.0.tgz",
-      "integrity": "sha512-+ogXpdAjWGa+fdYY5BQ96V/6tAo+TdSSIMP5huJBIygdWwKtVoB5JWZ7yUd4xZ8r+8Kvvx4nyg/PQ071H4UtcQ==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.1.tgz",
+      "integrity": "sha512-9qH0MGjsSm+fjxOi3GnwViL1otfi7qkj+l/WX5gcRGmZNGsIcqc+A5fBkE6PUobEQK4APqYVaES+B3Uti98TCw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "colorette": "^1.2.2",
         "nanoid": "^3.1.23",
@@ -1032,7 +1031,6 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
       "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1532,9 +1530,9 @@
       "dev": true
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -1728,8 +1726,7 @@
       "version": "3.1.23",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
       "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node-releases": {
       "version": "1.1.72",
@@ -1789,11 +1786,10 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.0.tgz",
-      "integrity": "sha512-+ogXpdAjWGa+fdYY5BQ96V/6tAo+TdSSIMP5huJBIygdWwKtVoB5JWZ7yUd4xZ8r+8Kvvx4nyg/PQ071H4UtcQ==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.1.tgz",
+      "integrity": "sha512-9qH0MGjsSm+fjxOi3GnwViL1otfi7qkj+l/WX5gcRGmZNGsIcqc+A5fBkE6PUobEQK4APqYVaES+B3Uti98TCw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "colorette": "^1.2.2",
         "nanoid": "^3.1.23",
@@ -1959,8 +1955,7 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
       "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "string-width": {
       "version": "4.2.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/k8ssandra/k8ssandra-io#readme",
   "devDependencies": {
     "autoprefixer": "^10.2.5",
+    "postcss": "^8.3.1",
     "postcss-cli": "^8.3.1"
   }
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -50,11 +50,6 @@ Performs installation of `Hugo` (a static site generator) from the [releases](ht
 ### [install-npm-dependencies.sh](https://github.com/k8ssandra/k8ssandra/tree/main/scripts/install-npm-dependencies.sh)
 Performs a directory change to the `docs` directory and issues an `npm install` command.
 
-### [install-npm-tools.sh](https://github.com/k8ssandra/k8ssandra/tree/main/scripts/install-npm-tools.sh)
-Used for document management with installation of the following `nodejs` packages:
-* [autoprefixer](https://www.npmjs.com/package/autoprefixer)
-* [postcss-cli](https://www.npmjs.com/package/postcss-cli)
-
 ## Misc.
 
 ### [open-grafana.sh](https://github.com/k8ssandra/k8ssandra/tree/main/scripts/open-grafana.sh)

--- a/scripts/install-npm-tools.sh
+++ b/scripts/install-npm-tools.sh
@@ -1,6 +1,0 @@
-#! /bin/bash
-
-cd docs
-
-npm install -D --save autoprefixer
-npm install -D --save postcss-cli


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Corrects the failing doc builds by adding in the missing peer dependency of the newer libraries being used.

This also removes the intermediate `install-npm-tools` script in favor of declaration within the package.json file for the docs module.

I tested the workflow in my fork and you can see [here](https://github.com/jdonenine/k8ssandra/runs/2794902349?check_suite_focus=true) that it built successfully.  The deploy fails because it was in my fork without the required secrets.

**Which issue(s) this PR fixes**:
Fixes #873  

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
