### PR TITLE
Detect IEC formatted c* heap.size and heap.newGenSize

### DIFF
--- a/CHANGELOG-1.3.md
+++ b/CHANGELOG-1.3.md
@@ -23,5 +23,6 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 * [CHANGE] #905 Upgrade medusa-operator to v0.3.3
 * [FEATURE] #617 Make affinity configurable for Stargate
 * [FEATURE] #847 Make affinity configurable for Reaper
+* [ENHANCEMENT] #29 Detect IEC formatted c* heap.size and heap.newGenSize; return error identifying issue  
 * [BUGFIX] #853 Fix property name in scaling docs
 * [BUGFIX] #412 Stargate metrics don't show up in the dashboards

--- a/charts/k8ssandra/templates/_helpers.tpl
+++ b/charts/k8ssandra/templates/_helpers.tpl
@@ -117,24 +117,41 @@ Return the ingress host that should be used for Stargate's Cassandra/CQL interfa
 
 {{/*
 Create the jvm options based on heap properties specified.
+Expecting that c* heap.size and heap.newGenSize are NOT in IEC format.
 */}}
 {{- define "k8ssandra.configureJvmHeap" -}}
 {{- $datacenter := (index .Values.cassandra.datacenters 0) -}}
 {{- if $datacenter.heap }}
   {{- if $datacenter.heap.size }}
-      initial_heap_size: {{ $datacenter.heap.size }}
-      max_heap_size: {{ $datacenter.heap.size }}
+      {{- if (regexMatch "^(([0]\\.\\d*)+|(^[1-9]\\d*)+(\\.\\d+)?)(?i)(k|m|g|e|p|t){1}$" (print $datacenter.heap.size) ) }}
+        {{- nindent 6 (print "initial_heap_size: " $datacenter.heap.size) }}
+        {{- nindent 6 (print "max_heap_size: " $datacenter.heap.size) }}
+      {{- else }}
+        {{- fail "Specify datacenter.heap.size using one of these suffixes: E, P, T, G, M, K. Format: <NUMBER>[.<NUMBER>]<SUFFIX>" }}
+      {{- end }}
   {{- end }}
   {{- if $datacenter.heap.newGenSize }}
-      heap_size_young_generation: {{ $datacenter.heap.newGenSize }}
+      {{- if (regexMatch "^(([0]\\.\\d*)+|(^[1-9]\\d*)+(\\.\\d+)?)(?i)(k|m|g|e|p|t){1}$" (print $datacenter.heap.newGenSize) ) }}
+        {{- nindent 6 (print "heap_size_young_generation: " $datacenter.heap.newGenSize) }}
+      {{- else }}
+        {{- fail "Specify datacenter.heap.newGenSize using one of these suffixes: E, P, T, G, M, K. Format: <NUMBER>[.<NUMBER>]<SUFFIX>" }}
+      {{- end }}
   {{- end }}
 {{- else if .Values.cassandra.heap }}
-  {{- if .Values.cassandra.heap.size  }}
-      initial_heap_size: {{ .Values.cassandra.heap.size }}
-      max_heap_size: {{ .Values.cassandra.heap.size }}
+  {{- if .Values.cassandra.heap.size }}
+    {{- if (regexMatch "^(([0]\\.\\d*)+|(^[1-9]\\d*)+(\\.\\d+)?)(?i)(k|m|g|e|p|t){1}$" (print .Values.cassandra.heap.size)) }}
+      {{- nindent 6 (print "initial_heap_size: " .Values.cassandra.heap.size) }}
+      {{- nindent 6 (print "max_heap_size: " .Values.cassandra.heap.size) }}
+    {{- else }}
+      {{- fail "Specify cassandra.heap.size using one of these suffixes: E, P, T, G, M, K. Format: <NUMBER>[.<NUMBER>]<SUFFIX>" }}
+    {{- end }}
   {{- end }}
-  {{- if  .Values.cassandra.heap.newGenSize }}
-      heap_size_young_generation: {{ .Values.cassandra.heap.newGenSize }}
+  {{- if .Values.cassandra.heap.newGenSize }}
+     {{- if (regexMatch "^(([0]\\.\\d*)+|(^[1-9]\\d*)+(\\.\\d+)?)(?i)(k|m|g|e|p|t){1}$" (print .Values.cassandra.heap.newGenSize)) }}
+        {{- nindent 6 (print "heap_size_young_generation: " .Values.cassandra.heap.newGenSize) }}
+     {{- else }}
+        {{- fail "Specify cassandra.heap.newGenSize using one of these suffixes: E, P, T, G, M, K. Format: <NUMBER>[.<NUMBER>]<SUFFIX>" }}
+     {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -144,8 +144,8 @@ spec:
   {{- else }}
     jvm-server-options:
   {{- end }}
-  {{- include "k8ssandra.configureGc" . -}}
-{{- include "k8ssandra.configureJvmHeap" . }}
+    {{- include "k8ssandra.configureGc" . -}}
+    {{- include "k8ssandra.configureJvmHeap" . }}
       additional-jvm-opts:
 {{- if .Values.cassandra.auth.enabled }}
         - "-Dcassandra.system_distributed_replication_dc_names={{ $datacenter.name }}"

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/k8ssandra/k8ssandra
 go 1.15
 
 require (
+	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48
 	github.com/google/uuid v1.2.0
 	github.com/gruntwork-io/terratest v0.30.15

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,7 @@ github.com/Jeffail/gabs v1.4.0/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
@@ -110,9 +111,11 @@ github.com/Masterminds/semver/v3 v3.0.3/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
+github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Masterminds/sprig/v3 v3.0.2/go.mod h1:oesJ8kPONMONaZgtiHNzUShJbksypC5kWczhZAf6+aU=
 github.com/Masterminds/sprig/v3 v3.1.0/go.mod h1:ONGMf7UfYGAbMXCZmQLy8x3lCDIPrEZE/rU8pmrbihA=
+github.com/Masterminds/sprig/v3 v3.2.2 h1:17jRggJu518dr3QaafizSXOjKYp94wKfABxUmyxvxX8=
 github.com/Masterminds/sprig/v3 v3.2.2/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
 github.com/Masterminds/squirrel v1.5.0/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Masterminds/vcs v1.13.1/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=
@@ -771,6 +774,7 @@ github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6/go.mod h1:xGMAM8JLi7U
 github.com/helm/helm-2to3 v0.5.1/go.mod h1:AXFpQX2cSQpss+47ROPEeu7Sm4+CRJ1jKWCEQdHP3/c=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
+github.com/huandu/xstrings v1.3.1 h1:4jgBlKK6tLKFvO8u5pmYjG91cqytmDCDvGh7ECVFfFs=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
@@ -1215,6 +1219,7 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/shirou/gopsutil v0.0.0-20180427012116-c95755e4bcd7/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
+github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
@@ -1249,6 +1254,7 @@ github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.2.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.2/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=

--- a/tests/unit/template_function_test.go
+++ b/tests/unit/template_function_test.go
@@ -1,0 +1,107 @@
+package unit_test
+
+import (
+	"bytes"
+	"github.com/Masterminds/sprig/v3"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"strconv"
+	txtTemplate "text/template"
+)
+
+var _ = Describe("Helm template function verification", func() {
+
+	It("checks valid JVM formats", func() {
+
+		var v, e = checkTemplate(buildJvmRegexTemplate("1000m"))
+		Expect(e).To(BeNil())
+		Expect(v).To(BeTrue())
+
+		v, e = checkTemplate(buildJvmRegexTemplate("1000M"))
+		Expect(e).To(BeNil())
+		Expect(v).To(BeTrue())
+
+		v, e = checkTemplate(buildJvmRegexTemplate("110.2k"))
+		Expect(e).To(BeNil())
+		Expect(v).To(BeTrue())
+
+		v, e = checkTemplate(buildJvmRegexTemplate("110.2K"))
+		Expect(e).To(BeNil())
+		Expect(v).To(BeTrue())
+
+		v, e = checkTemplate(buildJvmRegexTemplate("0.1g"))
+		Expect(e).To(BeNil())
+		Expect(v).To(BeTrue())
+
+		v, e = checkTemplate(buildJvmRegexTemplate("0.1G"))
+		Expect(e).To(BeNil())
+		Expect(v).To(BeTrue())
+
+		v, e = checkTemplate(buildJvmRegexTemplate("0.1e"))
+		Expect(e).To(BeNil())
+		Expect(v).To(BeTrue())
+
+		v, e = checkTemplate(buildJvmRegexTemplate("0.1E"))
+		Expect(e).To(BeNil())
+		Expect(v).To(BeTrue())
+
+		v, e = checkTemplate(buildJvmRegexTemplate("0.1p"))
+		Expect(e).To(BeNil())
+		Expect(v).To(BeTrue())
+
+		v, e = checkTemplate(buildJvmRegexTemplate("0.1P"))
+		Expect(e).To(BeNil())
+		Expect(v).To(BeTrue())
+
+		v, e = checkTemplate(buildJvmRegexTemplate("0.1t"))
+		Expect(e).To(BeNil())
+		Expect(v).To(BeTrue())
+
+		v, e = checkTemplate(buildJvmRegexTemplate("0.1T"))
+		Expect(e).To(BeNil())
+		Expect(v).To(BeTrue())
+	})
+
+	It("checks invalid JVM formats", func() {
+
+		var v, e = checkTemplate(buildJvmRegexTemplate(".2k"))
+		Expect(e).To(BeNil())
+		Expect(v).To(BeFalse())
+
+		v, e = checkTemplate(buildJvmRegexTemplate("1024foomanchoo"))
+		Expect(e).To(BeNil())
+		Expect(v).To(BeFalse())
+
+		v, e = checkTemplate(buildJvmRegexTemplate("1024 M"))
+		Expect(e).To(BeNil())
+		Expect(v).To(BeFalse())
+
+		v, e = checkTemplate(buildJvmRegexTemplate("abcdM"))
+		Expect(e).To(BeNil())
+		Expect(v).To(BeFalse())
+
+		v, e = checkTemplate(buildJvmRegexTemplate("1024 G"))
+		Expect(e).To(BeNil())
+		Expect(v).To(BeFalse())
+
+		v, e = checkTemplate(buildJvmRegexTemplate("1024"))
+		Expect(e).To(BeNil())
+		Expect(v).To(BeFalse())
+	})
+})
+
+func buildJvmRegexTemplate(value string) (string, map[string]string) {
+	Expect(value).ToNot(BeEmpty())
+	jvmFormatRegex := `^(([0]\.\d*)+|(^[1-9]\d*)+(\.\d+)?)(?i)(k|m|g|e|p|t){1}$`
+	return `{{ regexMatch .exp .input }}`, map[string]string{"exp": jvmFormatRegex, "input": value}
+}
+
+func checkTemplate(tpl string, vars interface{}) (bool, error) {
+	t := txtTemplate.Must(txtTemplate.New("test-tpl-func-").Funcs(sprig.TxtFuncMap()).Parse(tpl))
+	var b bytes.Buffer
+	err := t.Execute(&b, vars)
+	if err != nil {
+		return false, err
+	}
+	return strconv.ParseBool(b.String())
+}

--- a/tests/unit/utils/helm/helm.go
+++ b/tests/unit/utils/helm/helm.go
@@ -1,21 +1,80 @@
 package helm
 
 import (
+	"fmt"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"io/ioutil"
+	"k8s.io/apimachinery/pkg/util/json"
+	"os"
+	"path/filepath"
 )
 
+const (
+	OPT_RENDER_TEMPLATE = "--rendertmpl"
+)
+
+type OutputDirective struct {
+	Name string `json:"name"`
+	Dir  string `json:"dir"`
+}
+
 // RenderAndUnmarshall renders a Helm template and invokes the provided function to unmarshal the result.
-func RenderAndUnmarshall(templatePath string, options *helm.Options, helmChartPath string, HelmReleaseName string, unmarshallFunction func(string) error) error {
+func RenderAndUnmarshall(templatePath string, options *helm.Options, helmChartPath string, HelmReleaseName string,
+	unmarshallFunction func(string) error) error {
+
 	renderedOutput, renderErr := helm.RenderTemplateE(
 		GinkgoT(), options, helmChartPath, HelmReleaseName,
 		[]string{templatePath},
 	)
+
+	// Use CLI option: --rendertmpl={"dir":"/tmp/foo", "name":"my-test.yaml"}
+	opt := options.SetValues
+	if opt != nil && opt[OPT_RENDER_TEMPLATE] != "" {
+
+		fmt.Println("opt[OPT_RENDER_TEMPLATE]: ", opt[OPT_RENDER_TEMPLATE])
+		var directive = OutputDirective{}
+		json.Unmarshal([]byte(opt[OPT_RENDER_TEMPLATE]), &directive)
+
+		fmt.Println("Render output directive found: ", directive.Name)
+		if renderedOutput != "" {
+			output(directive, []byte(renderedOutput))
+		}
+
+		if renderErr != nil {
+			output(directive, []byte(renderErr.Error()))
+		}
+	}
+
 	if renderErr == nil {
 		unmarshalErr := unmarshallFunction(renderedOutput)
-		ExpectWithOffset(1, unmarshalErr).ToNot(HaveOccurred(), "Unmarshall Error. There is probably a type incompatibility issue in the test code. Make sure you are passing a pointer to UnmarshalK8SYamlE in your unmarshall function.")
+		ExpectWithOffset(1, unmarshalErr).ToNot(HaveOccurred(), "Unmarshall Error. "+
+			"There is probably a type incompatibility issue in the test code. Make sure you are passing a pointer to "+
+			"UnmarshalK8SYamlE in your unmarshall function.")
 		return unmarshalErr
 	}
 	return renderErr
+}
+
+// Helper for test template diagnostics
+func output(directive OutputDirective, data []byte) {
+
+	outputDir, err := filepath.Abs(directive.Dir)
+	if err != nil {
+		Fail(fmt.Sprintf("Rendered output requested - invalid path: %s due to err: %s", outputDir, err.Error()))
+	}
+
+	err = os.MkdirAll(outputDir, 0700)
+	if err != nil {
+		Fail(fmt.Sprintf("Rendered output requested - unable to create: %s due to err: %s", outputDir, err.Error()))
+	}
+
+	outputFile := filepath.Join(directive.Dir, directive.Name)
+	err = ioutil.WriteFile(outputFile, data, 0700)
+	if err != nil {
+		Fail(fmt.Sprintf("Rendered output requested - unable to write output to "+
+			"file: %s due to err: %s", outputFile, err.Error()))
+	}
+	println(fmt.Sprintf("Rendered output requested - written to: %s ", directive))
 }


### PR DESCRIPTION

**What this PR does**:

Detection of IEC formatted (base 2) values used instead of SI (base 10) for C* `heap.size` and `heap.newGenSize` at both the c* cluster and dc levels.  E.g. no longer support 1MiB, but would need to be 1M.

**Which issue(s) this PR fixes**:
Fixes #701 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
