### PR TITLE
Allow manual triggering of dependency check workflow

### DIFF
--- a/.github/workflows/dependency-upgrade.yaml
+++ b/.github/workflows/dependency-upgrade.yaml
@@ -5,6 +5,7 @@ on:
   schedule:
     # Runs daily at noon UTC (I guess)
     - cron:  '0 12 * * *'
+  workflow_dispatch:
 
 jobs:
   check-upgrades:


### PR DESCRIPTION
The dependency upgrade check workflow is a scheduled one, which can't be manually triggered.
This commit adds workflow_dispatch as trigger for the workflow, which allows manual start.
