### PR TITLE
Use personal access token to trigger CI

### DIFF
--- a/.github/workflows/dependency-upgrade.yaml
+++ b/.github/workflows/dependency-upgrade.yaml
@@ -67,6 +67,7 @@ jobs:
         if: ${{ env.PR_EXISTS == 'no' && env.CURRENT_VERSION != env.LATEST_VERSION }}
         uses: peter-evans/create-pull-request@v3
         with:
+          token: ${{ secrets.CREATE_PR_TOKEN }}
           commit-message: Upgrade ${{ matrix.dependency }} dependency from ${{ env.CURRENT_VERSION }} to ${{ env.LATEST_VERSION }}
           delete-branch: true
           branch: upgrade-${{ matrix.dependency }}-${{ env.CURRENT_VERSION }}-${{ env.LATEST_VERSION }}


### PR DESCRIPTION
Using the repository default token will not trigger CI as intended by GH.
Switching to a Personal Access Token will trigger CI on PR creation by the dependency upgrade workflow.
