### PR TITLE
Make the service monitors namespace configurable

### DIFF
--- a/CHANGELOG-1.3.md
+++ b/CHANGELOG-1.3.md
@@ -23,6 +23,7 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 * [CHANGE] #905 Upgrade medusa-operator to v0.3.3
 * [FEATURE] #617 Make affinity configurable for Stargate
 * [FEATURE] #847 Make affinity configurable for Reaper
+* [ENHANCEMENT] #844 Allow configuring the namespace of service monitors
 * [ENHANCEMENT] #29 Detect IEC formatted c* heap.size and heap.newGenSize; return error identifying issue  
 * [ENHANCEMENT] #420 Add support for private registries
 * [BUGFIX] #853 Fix property name in scaling docs

--- a/charts/k8ssandra/templates/prometheus/service_monitor.yaml
+++ b/charts/k8ssandra/templates/prometheus/service_monitor.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     release: {{ .Release.Name }}
 {{ include "k8ssandra.labels" . | indent 4 }}
+{{- if .Values.monitoring.serviceMonitors }}
+  namespace: {{ default .Release.Namespace .Values.monitoring.serviceMonitors.namespace }}
+{{- end }}
 spec:
   selector:
     matchLabels:
@@ -14,6 +17,9 @@ spec:
     matchExpressions:
       - {key: cassandra.datastax.com/cluster, operator: In, values: [{{ include "k8ssandra.clusterName" . }}]}
       - {key: cassandra.datastax.com/datacenter, operator: In, values: [{{ include "k8ssandra.datacenterName" . }}]}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
   targetLabels:
   - cassandra.datastax.com/cluster
   - cassandra.datastax.com/datacenter

--- a/charts/k8ssandra/templates/stargate/service_monitor.yaml
+++ b/charts/k8ssandra/templates/stargate/service_monitor.yaml
@@ -7,10 +7,16 @@ metadata:
     release: {{ .Release.Name }}
     app: {{ .Release.Name }}-{{ include "k8ssandra.datacenterName" . }}-stargate
 {{ include "k8ssandra.labels" . | indent 4 }}
+{{- if .Values.monitoring.serviceMonitors }}
+  namespace: {{ default .Release.Namespace .Values.monitoring.serviceMonitors.namespace }}
+{{- end }}
 spec:
   selector:
     matchLabels:
       app: {{ .Release.Name }}-{{ include "k8ssandra.datacenterName" . }}-stargate
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
   endpoints:
   - port: health
     interval: 15s

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -618,6 +618,10 @@ monitoring:
     # not have the ServiceMonitor CRD installed on your cluster, set this value
     # to `false`.
     provision_service_monitors: true
+  # -- Deploy the service monitors on a different namespace than the release namespace.
+  # This should only be set if the kube-prometheus stack isn't installed in the release namespace
+  serviceMonitors:
+     namespace:
 # -- The cleaner is a pre-delete hook that that ensures objects with finalizers
 # get deleted. For example, cass-operator sets a finalizer on the
 # CassandraDatacenter. Kubernetes blocks deletion of an object until all of its

--- a/tests/unit/template_stargate_service_monitor_test.go
+++ b/tests/unit/template_stargate_service_monitor_test.go
@@ -1,0 +1,70 @@
+package unit_test
+
+import (
+	"path/filepath"
+
+	helmUtils "github.com/k8ssandra/k8ssandra/tests/unit/utils/helm"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Verify Service Monitor template", func() {
+	var (
+		helmChartPath     string
+		err               error
+		k8ssandraTemplate map[string]interface{}
+	)
+
+	BeforeEach(func() {
+		helmChartPath, err = filepath.Abs(ChartsPath)
+		Expect(err).To(BeNil())
+		k8ssandraTemplate = map[string]interface{}{}
+	})
+
+	AfterEach(func() {
+		err = nil
+	})
+
+	renderTemplate := func(options *helm.Options) error {
+		return helmUtils.RenderAndUnmarshall("templates/stargate/service_monitor.yaml",
+			options, helmChartPath, HelmReleaseName,
+			func(renderedYaml string) error {
+				return helm.UnmarshalK8SYamlE(GinkgoT(), renderedYaml, &k8ssandraTemplate)
+			})
+	}
+
+	Context("by rendering it with options", func() {
+		It("using only default options", func() {
+			options := &helm.Options{
+				KubectlOptions: defaultKubeCtlOptions,
+				SetValues: map[string]string{
+					"monitoring.serviceMonitors.namespace": "test",
+					"stargate.enabled":                     "true",
+				},
+			}
+
+			err = renderTemplate(options)
+
+			Expect(err).To(BeNil())
+			Expect(k8ssandraTemplate["metadata"].(map[string]interface{})["namespace"]).To(Equal("test"))
+		})
+	})
+
+	Context("by rendering it with options", func() {
+		It("using only default options", func() {
+			options := &helm.Options{
+				KubectlOptions: defaultKubeCtlOptions,
+				SetValues: map[string]string{
+					"stargate.enabled": "true",
+				},
+			}
+
+			err = renderTemplate(options)
+
+			Expect(err).To(BeNil())
+			Expect(k8ssandraTemplate["metadata"].(map[string]interface{})["namespace"]).To(Equal(DefaultTestNamespace))
+		})
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Allows to configure the namespace in which the service monitors are deployed.

**Which issue(s) this PR fixes**:
Fixes #844

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
