### PR TITLE
(#900) Allowed adding custom labels to Service Monitor

### DIFF
--- a/charts/k8ssandra/templates/prometheus/service_monitor.yaml
+++ b/charts/k8ssandra/templates/prometheus/service_monitor.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     release: {{ .Release.Name }}
 {{ include "k8ssandra.labels" . | indent 4 }}
+    {{- range $key, $val := .Values.monitoring.prometheus.serviceMonitorLabels }}
+    {{ $key }}: {{ $val }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/k8ssandra/templates/stargate/service_monitor.yaml
+++ b/charts/k8ssandra/templates/stargate/service_monitor.yaml
@@ -7,6 +7,9 @@ metadata:
     release: {{ .Release.Name }}
     app: {{ .Release.Name }}-{{ include "k8ssandra.datacenterName" . }}-stargate
 {{ include "k8ssandra.labels" . | indent 4 }}
+    {{- range $key, $val := .Values.monitoring.prometheus.serviceMonitorLabels }}
+    {{ $key }}: {{ $val }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -537,6 +537,11 @@ monitoring:
     # not have the ServiceMonitor CRD installed on your cluster, set this value
     # to `false`.
     provision_service_monitors: true
+    # -- Service Monitor Labels is use to add custom labels to Service Monitor.
+    # This would be helpful if you have a centralised Prometheus stack deployed
+    # and also benefitial if some other controller like Istio requires certain
+    # labels.
+    serviceMonitorLabels:
 # -- The cleaner is a pre-delete hook that that ensures objects with finalizers
 # get deleted. For example, cass-operator sets a finalizer on the
 # CassandraDatacenter. Kubernetes blocks deletion of an object until all of its


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
It allows to add custom labels to Service Monitor through values.

**Which issue(s) this PR fixes**:
Fixes #900 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
