### PR TITLE
Add a scheduled workflow to run integration tests on a matrix of k8s versions

### DIFF
--- a/.github/workflows/integration-tests-release.yaml
+++ b/.github/workflows/integration-tests-release.yaml
@@ -20,6 +20,14 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      kubernetes_version:
+        description: 'Kubernetes version'     
+        required: true
+        default: 'v1.20.2'
+      tags:
+        description: 'Run integration tests with different versions of K8s' 
 
 jobs:
   build_docker_images:
@@ -69,6 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        k8s_version: ["${{ github.event.inputs.kubernetes_version }}"]
         cassandra_version: ["3.11.10", "4.0.0"]
         scenario: ["TestMedusaDeploymentScenario/\"S3\"", "TestMedusaDeploymentScenario/\"Minio\"", "TestMedusaDeploymentScenario/\"local\"", "TestReaperDeploymentScenario", "TestMonitoringDeploymentScenario", "TestStargateDeploymentScenario", "TestRestoreAfterUpgrade", "TestUpgradeScenario"]
     steps:
@@ -95,11 +104,21 @@ jobs:
         with:
           version: ${{ env.HELM_VERSION }}
 
+      - name: Get k8s version
+        env:
+          DEFAULT_K8S_VERSION: v1.20.2
+        run: |
+          if [[ -z "${{ github.event.inputs.kubernetes_version }}" ]]; then
+            echo "K8S_VERSION=$DEFAULT_K8S_VERSION" >> $GITHUB_ENV
+          else
+            echo "K8S_VERSION=${{ github.event.inputs.kubernetes_version }}" >> $GITHUB_ENV
+          fi
+
       - name: Create Kind Cluster
         uses: helm/kind-action@v1.1.0
         with: 
           version: v0.10.0
-          node_image: kindest/node:v1.20.2
+          node_image: kindest/node:${{ env.K8S_VERSION }}
           cluster_name: kind
           config: tests/integration/kind/kind_config_3_workers.yaml
 

--- a/.github/workflows/k8s_matrix_test.yaml
+++ b/.github/workflows/k8s_matrix_test.yaml
@@ -1,0 +1,23 @@
+---
+name: K8s version test
+
+on:
+  schedule:
+    # Runs weekly on sundays at noon UTC (I guess)
+    - cron:  '0 12 * * 6'
+  workflow_dispatch:
+
+jobs:
+  run-integration-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s_version: ["v1.17.17", "v1.18.19", "v1.19.11", "v1.20.7"]
+    steps:
+      - name: Invoke integration tests
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Integration Tests and Release
+          token: ${{ secrets.CREATE_PR_TOKEN }}
+          inputs: '{ "kubernetes_version": "${{ matrix.k8s_version }}" }'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds a GHA workflow that is scheduled weekly to test various versions of Kubernetes.
This workflow will trigger the integration tests workflow using a workflow_dispatch event and sending the k8s version to use as input parameter.

**Which issue(s) this PR fixes**:
Fixes #919

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
