### PR TITLE
Hot replace disallowed characters in generated secret names [K8SSAND-563]

### DIFF
--- a/CHANGELOG-1.3.md
+++ b/CHANGELOG-1.3.md
@@ -25,4 +25,5 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 * [FEATURE] #847 Make affinity configurable for Reaper
 * [ENHANCEMENT] #29 Detect IEC formatted c* heap.size and heap.newGenSize; return error identifying issue  
 * [BUGFIX] #853 Fix property name in scaling docs
+* [BUGFIX] #870 Hot replace disallowed characters in generated secret names
 * [BUGFIX] #412 Stargate metrics don't show up in the dashboards

--- a/charts/k8ssandra/templates/_helpers.tpl
+++ b/charts/k8ssandra/templates/_helpers.tpl
@@ -190,7 +190,7 @@ Gets the superuser secret name.
 {{- if .Values.cassandra.auth.superuser.secret -}}
 {{ .Values.cassandra.auth.superuser.secret }}
 {{- else }}
-{{- include "k8ssandra.clusterName" . }}-superuser
+{{- include "k8ssandra.clusterName" . | replace " " "-" | replace "_" "-" }}-superuser
 {{- end }}
 {{- end }}
 
@@ -201,7 +201,7 @@ Gets the reaper user secret name.
 {{- if .Values.reaper.cassandraUser.secret -}}
 {{ .Values.reaper.cassandraUser.secret }}
 {{- else }}
-{{- include "k8ssandra.clusterName" . }}-reaper
+{{- include "k8ssandra.clusterName" . | replace " " "-" | replace "_" "-" }}-reaper
 {{- end }}
 {{- end }}
 
@@ -212,7 +212,7 @@ Gets the reaper jmx user secret name.
 {{- if .Values.reaper.jmx.secret -}}
 {{ .Values.reaper.jmx.secret }}
 {{- else }}
-{{- include "k8ssandra.clusterName" . }}-reaper-jmx
+{{- include "k8ssandra.clusterName" . | replace " " "-" | replace "_" "-" }}-reaper-jmx
 {{- end }}
 {{- end }}
 
@@ -223,7 +223,7 @@ Gets the medus user secret name.
 {{- if .Values.medusa.cassandraUser.secret -}}
 {{ .Values.medusa.cassandraUser.secret }}
 {{- else }}
-{{- include "k8ssandra.clusterName" . }}-medusa
+{{- include "k8ssandra.clusterName" . | replace " " "-" | replace "_" "-" }}-medusa
 {{- end }}
 {{- end }}
 
@@ -234,7 +234,7 @@ Gets the stargate user secret name.
 {{- if .Values.stargate.cassandraUser.secret -}}
 {{ .Values.stargate.cassandraUser.secret }}
 {{- else }}
-{{- include "k8ssandra.clusterName" . }}-stargate
+{{- include "k8ssandra.clusterName" . | replace " " "-" | replace "_" "-" }}-stargate
 {{- end }}
 {{- end }}
 

--- a/tests/unit/template_stargate_user_secret_test.go
+++ b/tests/unit/template_stargate_user_secret_test.go
@@ -87,5 +87,23 @@ var _ = Describe("Verify stargate user secret template", func() {
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(ContainSubstring("could not find template"))
 		})
+
+		It("using disallowed chars in cluster name for stargate user secret", func() {
+			clusterName := "secret_test with_funny_chars"
+			expectedSecretName := "secret-test-with-funny-chars-stargate"
+			options := &helm.Options{
+				KubectlOptions: defaultKubeCtlOptions,
+				SetValues: map[string]string{
+					"cassandra.clusterName":  clusterName,
+					"cassandra.auth.enabled": "true",
+					"stargate.enabled":       "true",
+				},
+			}
+
+			Expect(renderTemplate(options)).To(Succeed())
+			Expect(secret.Name).To(Equal(expectedSecretName))
+			Expect(string(secret.Data["username"])).To(Equal("stargate"))
+			Expect(len(secret.Data["password"])).To(Equal(20))
+		})
 	})
 })

--- a/tests/unit/template_superuser_secret_test.go
+++ b/tests/unit/template_superuser_secret_test.go
@@ -1,8 +1,9 @@
 package unit_test
 
 import (
-	helmUtils "github.com/k8ssandra/k8ssandra/tests/unit/utils/helm"
 	"path/filepath"
+
+	helmUtils "github.com/k8ssandra/k8ssandra/tests/unit/utils/helm"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	. "github.com/onsi/ginkgo"
@@ -83,5 +84,22 @@ var _ = Describe("Verify superuser secret template", func() {
 			Expect(err.Error()).To(ContainSubstring("could not find template"))
 		})
 
+		Context("generating superuser secret", func() {
+			It("with a cluster name containing disallowed chars", func() {
+				clusterName := "secret_test with_funny_characters"
+				expectedUsername := "secret-test-with-funny-characters-superuser"
+				options := &helm.Options{
+					KubectlOptions: defaultKubeCtlOptions,
+					SetValues: map[string]string{
+						"cassandra.clusterName": clusterName,
+					},
+				}
+
+				Expect(renderTemplate(options)).To(Succeed())
+				Expect(secret.Name).To(Equal(expectedUsername))
+				Expect(string(secret.Data["username"])).To(Equal(expectedUsername))
+				Expect(len(secret.Data["password"])).To(Equal(20))
+			})
+		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Prevents cluster deployment from failing if the Cassandra cluster name contains underscores or spaces, which are not allowed for naming Kubernetes objects.

**Which issue(s) this PR fixes**:
Fixes #870

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
