### PR TITLE
Make stargate unit tests not dependent on specific versions

### DIFF
--- a/.github/workflows/integration-tests-release.yaml
+++ b/.github/workflows/integration-tests-release.yaml
@@ -113,11 +113,13 @@ jobs:
           else
             echo "K8S_VERSION=${{ github.event.inputs.kubernetes_version }}" >> $GITHUB_ENV
           fi
+      - name: Kind kube-proxy issue workaround
+        run: sudo sysctl net/netfilter/nf_conntrack_max=524288
 
       - name: Create Kind Cluster
         uses: helm/kind-action@v1.1.0
         with: 
-          version: v0.10.0
+          version: v0.11.1
           node_image: kindest/node:${{ env.K8S_VERSION }}
           cluster_name: kind
           config: tests/integration/kind/kind_config_3_workers.yaml

--- a/tests/unit/template_stargate_test.go
+++ b/tests/unit/template_stargate_test.go
@@ -2,8 +2,9 @@ package unit_test
 
 import (
 	. "fmt"
-	corev1 "k8s.io/api/core/v1"
 	"path/filepath"
+
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	helmUtils "github.com/k8ssandra/k8ssandra/tests/unit/utils/helm"
@@ -14,11 +15,11 @@ import (
 )
 
 const (
-	DefaultStargate3Image          = "stargateio/stargate-3_11:v1.0.18"
-	DefaultStargate4Image          = "stargateio/stargate-4_0:v1.0.18"
+	DefaultStargate3ImagePrefix    = "stargateio/stargate-3_11:"
+	DefaultStargate4ImagePrefix    = "stargateio/stargate-4_0:"
 	DefaultStargate3ClusterVersion = "3.11"
 	DefaultStargate4ClusterVersion = "4.0"
-	DefaultStargateImage           = DefaultStargate3Image
+	DefaultStargateImagePrefix     = DefaultStargate3ImagePrefix
 	DefaultStargateClusterVersion  = DefaultStargate3ClusterVersion
 )
 
@@ -110,7 +111,7 @@ var _ = Describe("Verify Stargate template", func() {
 
 			Expect(len(templateSpec.Containers)).To(Equal(1))
 			container := templateSpec.Containers[0]
-			Expect(container.Image).To(Equal(DefaultStargateImage))
+			Expect(container.Image).To(HavePrefix(DefaultStargateImagePrefix))
 			Expect(container.Name).To(Equal(Sprintf("%s-dc1-stargate", HelmReleaseName)))
 			Expect(string(container.ImagePullPolicy)).To(Equal("IfNotPresent"))
 
@@ -179,7 +180,7 @@ var _ = Describe("Verify Stargate template", func() {
 			templateSpec := deployment.Spec.Template.Spec
 			Expect(len(templateSpec.Containers)).To(Equal(1))
 			container := templateSpec.Containers[0]
-			Expect(container.Image).To(Equal(DefaultStargateImage))
+			Expect(container.Image).To(HavePrefix(DefaultStargateImagePrefix))
 			clusterVersionEnv := kubeapi.FindEnvVarByName(container, "CLUSTER_VERSION")
 			Expect(clusterVersionEnv.Value).To(Equal(DefaultStargateClusterVersion))
 		})
@@ -197,7 +198,7 @@ var _ = Describe("Verify Stargate template", func() {
 			templateSpec := deployment.Spec.Template.Spec
 			Expect(len(templateSpec.Containers)).To(Equal(1))
 			container := templateSpec.Containers[0]
-			Expect(container.Image).To(Equal(DefaultStargate4Image))
+			Expect(container.Image).To(HavePrefix(DefaultStargate4ImagePrefix))
 			clusterVersionEnv := kubeapi.FindEnvVarByName(container, "CLUSTER_VERSION")
 			Expect(clusterVersionEnv.Value).To(Equal(DefaultStargate4ClusterVersion))
 		})
@@ -215,7 +216,7 @@ var _ = Describe("Verify Stargate template", func() {
 			templateSpec := deployment.Spec.Template.Spec
 			Expect(len(templateSpec.Containers)).To(Equal(1))
 			container := templateSpec.Containers[0]
-			Expect(container.Image).To(Equal(DefaultStargate3Image))
+			Expect(container.Image).To(HavePrefix(DefaultStargate3ImagePrefix))
 			clusterVersionEnv := kubeapi.FindEnvVarByName(container, "CLUSTER_VERSION")
 			Expect(clusterVersionEnv.Value).To(Equal(DefaultStargate3ClusterVersion))
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Makes Stargate unit tests not dependent on a specific Stargate version.
Also applies a workaround to some kernel related issues with Kind, and upgrades Kind to v0.11.1

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
