### PR TITLE
experimental support for init containers in cassandra pod

### DIFF
--- a/CHANGELOG-1.3.md
+++ b/CHANGELOG-1.3.md
@@ -26,6 +26,7 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 * [CHANGE] #905 Upgrade medusa-operator to v0.3.3
 * [FEATURE] #617 Make affinity configurable for Stargate
 * [FEATURE] #847 Make affinity configurable for Reaper
+* [FEATURE] #952 Experimental support for custom init containers
 * [ENHANCEMENT] #844 Allow configuring the namespace of service monitors
 * [ENHANCEMENT] #29 Detect IEC formatted c* heap.size and heap.newGenSize; return error identifying issue  
 * [ENHANCEMENT] #420 Add support for private registries

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -238,6 +238,9 @@ spec:
             mountPath: /mnt/backups
           {{- end }}
       {{- end }}
+      {{- if .Values.cassandra.initContainers }}
+      {{- toYaml .Values.cassandra.initContainers | nindent 6 }}
+      {{- end }}
       containers:
       - name: cassandra
         {{- if .Values.reaper.enabled }}

--- a/tests/unit/template_cassdc_test.go
+++ b/tests/unit/template_cassdc_test.go
@@ -245,6 +245,19 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 			Expect(cassdc.Spec.ServiceAccount).To(Equal("k8ssandra"))
 		})
 
+		It("using custom init containers", func() {
+			options := &helm.Options{
+				KubectlOptions: defaultKubeCtlOptions,
+				ValuesFiles:    []string{"./testdata/init-containers-values.yaml"},
+			}
+
+			Expect(renderTemplate(options)).To(Succeed())
+			initContainers := cassdc.Spec.PodTemplateSpec.Spec.InitContainers
+			Expect(len(initContainers)).To(Equal(5))
+			Expect(initContainers[3].Name).To(Equal("foo"))
+			Expect(initContainers[4].Name).To(Equal("bar"))
+		})
+
 		It("using multiple racks with no affinity labels", func() {
 			options := &helm.Options{
 				KubectlOptions: defaultKubeCtlOptions,

--- a/tests/unit/testdata/init-containers-values.yaml
+++ b/tests/unit/testdata/init-containers-values.yaml
@@ -1,0 +1,6 @@
+cassandra:
+  initContainers:
+    - name: foo
+      image: docker.io/foo:latest
+    - name: bar
+      image: docker.io/bar:latest


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds experimental support for custom init containers in Cassandra pods. Here is an example overrides file to demonstrate:

```yaml
cassandra:
  initContainers:
  - name: foo
    image: docker.io/foo:latest
  - name: bar
    image: docker.io/bar:latest
```

These containers will be added after all of the init containers that k8ssandra adds.

**Which issue(s) this PR fixes**:
Fixes #952 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
