### PR TITLE
Upgrade to reaper-operator 0.3.3 and Reaper 2.3.0

### DIFF
--- a/CHANGELOG-1.3.md
+++ b/CHANGELOG-1.3.md
@@ -18,12 +18,13 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 
 ## unreleased
 
-* [FEATURE] #890 Upgrade from Management API v0.1.25 to v0.1.26 to provide support for Cassandra 4.0.0-RC2
+* [CHANGE] Upgrade to reaper-operator 0.3.3 and Reaper 2.3.0
 * [CHANGE] Upgrade from Stargate 1.0.18 to 1.0.29
 * [CHANGE] Upgrade from Medusa 0.10.1 to 0.11.0
 * [CHANGE] Upgrade from Reaper 2.2.2 to 2.2.5
 * [CHANGE] #812 Integrate Fossa component/license scanning
 * [CHANGE] #905 Upgrade medusa-operator to v0.3.3
+* [FEATURE] #890 Upgrade from Management API v0.1.25 to v0.1.26 to provide support for Cassandra 4.0.0-RC2
 * [FEATURE] #617 Make affinity configurable for Stargate
 * [FEATURE] #847 Make affinity configurable for Reaper
 * [ENHANCEMENT] #844 Allow configuring the namespace of service monitors

--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
     condition: cass-operator.enabled
 
   - name: reaper-operator
-    version: 0.31.0
+    version: 0.32.0
     repository: file://../reaper-operator
     condition: reaper-operator.enabled
 

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -477,7 +477,7 @@ reaper:
     # -- Image repository for reaper
     repository: thelastpickle/cassandra-reaper
     # -- Tag of the reaper image to pull from
-    tag: 2.2.5
+    tag: 2.3.0
     # -- Pull policy for the reaper container
     pullPolicy: IfNotPresent
   # -- Configures the Cassandra user used by Reaper when authentication is

--- a/charts/reaper-operator/Chart.yaml
+++ b/charts/reaper-operator/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   Configures and installs the Reaper Operator for Apache Cassandra. This tool 
   manages an external repair process for Apache Cassandra clusters.
 type: application
-version: 0.31.0
+version: 0.32.0
 appVersion: 0.1.0
 dependencies:
   - name: k8ssandra-common

--- a/charts/reaper-operator/values.yaml
+++ b/charts/reaper-operator/values.yaml
@@ -21,7 +21,7 @@ image:
   # -- Pull policy for the operator container
   pullPolicy: IfNotPresent
   # -- Tag of the reaper-operator image to pull from image.repository
-  tag: v0.3.2
+  tag: v0.3.3
 
 # -- References to secrets to use when pulling images. ref:
 # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Upgrade to reaper-operator 0.3.3 and Reaper 2.3.0, which use an init-container to initialize the schema. This will make schema migration safer as they will not be subject to probes.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
