### PR TITLE
NewGenSize: 5G instead of 31G per Michael

### DIFF
--- a/docs/content/en/install/doks/doks.values.yaml
+++ b/docs/content/en/install/doks/doks.values.yaml
@@ -12,7 +12,7 @@ cassandra:
 
   heap:
    size: 31G
-   newGenSize: 31G
+   newGenSize: 5G
 
   resources:
     requests:


### PR DESCRIPTION
Briefly discussed with Michael B, newGenSize shouldn’t equal heap size. Part of addressing issue #866.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
