### PR TITLE
Add v1.21.1 to matrix

### DIFF
--- a/.github/workflows/k8s_matrix_test.yaml
+++ b/.github/workflows/k8s_matrix_test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: ["v1.17.17", "v1.18.19", "v1.19.11", "v1.20.7"]
+        k8s_version: ["v1.17.17", "v1.18.19", "v1.19.11", "v1.20.7", "v1.21.1"]
     steps:
       - name: Invoke integration tests
         uses: benc-uk/workflow-dispatch@v1


### PR DESCRIPTION
**What this PR does**:

Adds v1.21.1 back to the version matrix for k8s version testing.

Originally when the matrix was added we saw problems with kind starting a cluster running version 1.21.1 - both locally and within CI.  That now seems to be working.

You can see the run in my fork here:  https://github.com/jdonenine/k8ssandra/actions/runs/1031228580

**Which issue(s) this PR fixes**:
Fixes #923  

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
