### PR TITLE
make service accounts configurable for reaper, cleaner, and crd upgrader

### DIFF
--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -29,7 +29,7 @@ spec:
   configBuilderImage: {{ include "k8ssandra-common.flattenedImage" .Values.cassandra.configBuilder.image }}
   systemLoggerImage: {{ include "k8ssandra-common.flattenedImage" .Values.cassandra.loggingSidecar.image }}
   {{- if .Values.cassandra.serviceAccount }}
-  serviceAccount: {{ .Values.cassandra.serviceAccount }}
+  serviceAccount: {{ default "default" .Values.cassandra.serviceAccount }}
   {{- end }}
   managementApiAuth:
     insecure: {}

--- a/charts/k8ssandra/templates/cleaner/batch_job.yaml
+++ b/charts/k8ssandra/templates/cleaner/batch_job.yaml
@@ -13,7 +13,7 @@ spec:
       labels: {{ include "k8ssandra.labels" . | indent 8 }}
     spec:
       restartPolicy: OnFailure
-      serviceAccountName: {{ .Release.Name }}-cleaner-k8ssandra
+      serviceAccountName: {{ default (print .Release.Name "-cleaner-k8ssandra") .Values.cleaner.serviceAccount }}
       containers:
         - name: cleaner-job-k8ssandra
           image: {{ include "k8ssandra-common.flattenedImage" .Values.cleaner.image }}

--- a/charts/k8ssandra/templates/cleaner/service_account.yaml
+++ b/charts/k8ssandra/templates/cleaner/service_account.yaml
@@ -1,5 +1,7 @@
+{{- if not .Values.cleaner.serviceAccount }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}-cleaner-k8ssandra
   labels: {{ include "k8ssandra.labels" . | indent 4 }}
+{{- end }}

--- a/charts/k8ssandra/templates/crd/batch_job.yaml
+++ b/charts/k8ssandra/templates/crd/batch_job.yaml
@@ -14,7 +14,7 @@ spec:
       labels: {{ include "k8ssandra.labels" . | indent 8 }}
     spec:
       restartPolicy: OnFailure
-      serviceAccountName: {{ .Release.Name }}-crd-upgrader-k8ssandra
+      serviceAccountName: {{ default (print .Release.Name "-crd-upgrader-k8ssandra") .Values.client.serviceAccount }}
       containers:
         - name: crd-upgrade-job-k8ssandra
           image: {{ include "k8ssandra-common.flattenedImage" .Values.client.image }}

--- a/charts/k8ssandra/templates/crd/service_account.yaml
+++ b/charts/k8ssandra/templates/crd/service_account.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.cleaner.serviceAccount }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,3 +8,4 @@ metadata:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "0"
+{{- end }}

--- a/charts/k8ssandra/templates/reaper/reaper.yaml
+++ b/charts/k8ssandra/templates/reaper/reaper.yaml
@@ -6,6 +6,7 @@ metadata:
   labels: {{ include "k8ssandra.labels" . | indent 4 }}
 spec:
   image: {{ include "k8ssandra-common.flattenedImage" .Values.reaper.image }}
+  ServiceAccountName: {{ .Values.reaper.serviceAccount }}
   serverConfig:
     autoScheduling:
       enabled: {{ .Values.reaper.autoschedule }}

--- a/charts/k8ssandra/templates/reaper/reaper.yaml
+++ b/charts/k8ssandra/templates/reaper/reaper.yaml
@@ -6,7 +6,7 @@ metadata:
   labels: {{ include "k8ssandra.labels" . | indent 4 }}
 spec:
   image: {{ include "k8ssandra-common.flattenedImage" .Values.reaper.image }}
-  ServiceAccountName: {{ .Values.reaper.serviceAccount }}
+  ServiceAccountName: {{ default "default" .Values.reaper.serviceAccount }}
   serverConfig:
     autoScheduling:
       enabled: {{ .Values.reaper.autoschedule }}

--- a/charts/k8ssandra/templates/stargate/stargate.yaml
+++ b/charts/k8ssandra/templates/stargate/stargate.yaml
@@ -30,7 +30,7 @@ spec:
       labels:
         app: {{ .Release.Name }}-{{ include "k8ssandra.datacenterName" . }}-stargate
     spec:
-      serviceAccountName: {{ .Values.stargate.serviceAccount }}
+      serviceAccountName: {{ default "default" .Values.stargate.serviceAccount }}
       initContainers:
           - name: wait-for-cassandra
             image: {{ include "k8ssandra-common.flattenedImage" .Values.stargate.waitForCassandra.image }}

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -468,6 +468,8 @@ reaper:
   # will be configured in Cassandra with credentials only created for Reaper
   # in order to limit access.
   enabled: true
+  # -- The name of the service account to use for Reaper pods.
+  serviceAccount: default
   # Configures the Reaper container image to use. Exercise care when changing
   # the Reaper image. Reaper is deployed and managed by reaper-operator. You
   # will need to make sure that the image is compatible with reaper-operator.
@@ -556,7 +558,7 @@ medusa:
   multiTenant: false
   # -- API interface used by the object store. Supported values include `s3`, 's3_compatible',
   # `google_storage` and 'azure_blobs'. For file system storage, i.e., a pod volume
-  # mount, use 'local' and set the podStorage properties. Note that 'local' does not necessarily 
+  # mount, use 'local' and set the podStorage properties. Note that 'local' does not necessarily
   # imply a local volume. It could also be network attached storage. It is simply accessed
   # through the file system.
   storage: s3
@@ -621,6 +623,9 @@ monitoring:
 # deployment could be deleted before the CassandraDatacenter. The cleaner
 # ensures that the CassandraDatacenter is deleted before cass-operator.
 cleaner:
+  # -- Uncomment to specify the name of the service account to use for the
+  # cleaner. Defaults to <release-name>-cleaner-k8ssandra
+  # serviceAccount:
   image:
     # -- Image registry for the cleaner
     registry: docker.io
@@ -630,9 +635,12 @@ cleaner:
     tag: latest
     # -- Pull policy for the cleaner container
     pullPolicy: IfNotPresent
-# k8ssandra-client provides CLI utilities, but also certain functions such as 
+# k8ssandra-client provides CLI utilities, but also certain functions such as
 # upgradecrds that allow modifying the running instances
 client:
+  # -- Uncomment to specify the name of the service account to use for the
+  # client tools image. Defaults to <release-name>-crd-upgrader-k8ssandra.
+  # serviceAccount:
   image:
     # -- Image registry for the client
     registry: docker.io

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -57,8 +57,9 @@ cassandra:
       tag: 1.33.1
       # -- Pull policy for the jmx-credentials image
       pullPolicy: IfNotPresent
-  # -- The ServiceAccount to use for Cassandra pods
-  serviceAccount: ""
+  # -- The ServiceAccount to use for Cassandra pods. If not defined, defaults
+  # to the default account for the namespace.
+  # serviceAccount:
   # -- Cluster name defaults to release name when not specified.
   clusterName: ""
   # -- Authentication and authorization related settings.
@@ -351,8 +352,9 @@ stargate:
       tag: 3.12.2
       # -- Pull policy for the wait-for-cassandra container
       pullPolicy: IfNotPresent
-  # -- The service account to use for Stargate pods
-  serviceAccount: default
+  # -- The service account to use for Stargate pods. Defaults to the default
+  # account for the namespace.
+  # serviceAccount:
   # -- Sets the heap size Stargate will use in megabytes. Memory request and
   # limit for the pod will be set to this value x2 and x4, respectively.
   heapMB: 256
@@ -468,8 +470,9 @@ reaper:
   # will be configured in Cassandra with credentials only created for Reaper
   # in order to limit access.
   enabled: true
-  # -- The name of the service account to use for Reaper pods.
-  serviceAccount: default
+  # -- The name of the service account to use for Reaper pods. Defaults to the
+  # the default account.
+  # serviceAccount:
   # Configures the Reaper container image to use. Exercise care when changing
   # the Reaper image. Reaper is deployed and managed by reaper-operator. You
   # will need to make sure that the image is compatible with reaper-operator.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Makes the service account to use configurable. It does not however allow you to configure the service account. This just give you the ability to point to the one you want to use.

I did not update the changelog for this since this PR really should have been part of #901.

Ideally, for the cleaner and crd upgrader, I would have liked to use the `k8ssandra-common.serviceAccount` template. It makes the service account name as well as image pull secrets available. It would require some refactoring to be able to safely use it for them though. The template assumes the scope of `.Values`. This would need to change and certainly beyond the scope of 1.3.0 at this point.

**Which issue(s) this PR fixes**:
Fixes #983, #984, #985

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
