### PR TITLE
Change install directory for Fossa CLI in license-check workflow

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install Fossa CLI
         run: |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash -s -- -b .
       - name: Scan for dependencies and licenses
         run: |
-          FOSSA_API_KEY=${{ secrets.FOSSA_PUSH_ONLY_API_KEY }} fossa analyze
+          FOSSA_API_KEY=${{ secrets.FOSSA_PUSH_ONLY_API_KEY }} ./fossa analyze


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
1. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Fixes issue where all of the sudden the Fossa CLI tool was failing to install during workflow actions because of permissions issues on their default install directory.

It now installs into the local working directory and executes from there.

Tested changes here: https://github.com/jdonenine/cass-operator/runs/3124668353

**Which issue(s) this PR fixes**:
N/A

**Checklist**


* [x] Changes manually tested
* [ ] Automated Tests added/updated
* [ ] Documentation added/updated
* [ ] CHANGELOG.md updated (not required for documentation PRs)
* [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)



┆Issue is synchronized with this [Jiraserver Task](https://k8ssandra.atlassian.net/browse/K8SSAND-766) by [Unito](https://www.unito.io)
┆Issue Number: K8SSAND-766
┆Priority: Medium
