### PR TITLE
Upgrade from Management API v0.1.26 to v0.1.27 to provide support for…

### DIFF
--- a/CHANGELOG-1.3.md
+++ b/CHANGELOG-1.3.md
@@ -18,6 +18,7 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 
 ## unreleased
 
+* [FEATURE] #949 Upgrade from Management API v0.1.26 to v0.1.27 to provide support for Cassandra 4.0.0 GA, make 4.0.0 the default
 * [CHANGE] Upgrade to reaper-operator 0.3.3 and Reaper 2.3.0
 * [CHANGE] Upgrade from Stargate 1.0.18 to 1.0.29
 * [CHANGE] Upgrade from Medusa 0.10.1 to 0.11.0

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -7,18 +7,18 @@ cassandra:
   #    - 3.11.9
   #    - 3.11.10
   #    - 4.0.0
-  version: "3.11.10"
+  version: "4.0.0"
   # -- Specifies the image to use for a particular Cassandra version. Exercise
   # care and caution with changing these values! cass-operator is not designed to work with
   # arbitrary Cassandra images. It expects the cassandra container to be running
   # management-api images. If you do want to change one of these mappings, the new value
   # should be a management-api image.
   versionImageMap:
-    3.11.7: k8ssandra/cass-management-api:3.11.7-v0.1.26
-    3.11.8: k8ssandra/cass-management-api:3.11.8-v0.1.26
-    3.11.9: k8ssandra/cass-management-api:3.11.9-v0.1.26
-    3.11.10: k8ssandra/cass-management-api:3.11.10-v0.1.26
-    4.0.0: k8ssandra/cass-management-api:4.0.0-v0.1.26
+    3.11.7: k8ssandra/cass-management-api:3.11.7-v0.1.27
+    3.11.8: k8ssandra/cass-management-api:3.11.8-v0.1.27
+    3.11.9: k8ssandra/cass-management-api:3.11.9-v0.1.27
+    3.11.10: k8ssandra/cass-management-api:3.11.10-v0.1.27
+    4.0.0: k8ssandra/cass-management-api:4.0.0-v0.1.27
   # -- Overrides the default image mappings. This is intended for advanced use cases
   # like development or testing. By default the Cassandra version has to be one that is in
   # versionImageMap. Template rendering will fail if the version is not in the map. When

--- a/tests/unit/template_cassdc_test.go
+++ b/tests/unit/template_cassdc_test.go
@@ -3,10 +3,11 @@ package unit_test
 import (
 	"encoding/json"
 	"fmt"
-	helmUtils "github.com/k8ssandra/k8ssandra/tests/unit/utils/helm"
-	"github.com/k8ssandra/k8ssandra/tests/unit/utils/kubeapi"
 	"path/filepath"
 	"strconv"
+
+	helmUtils "github.com/k8ssandra/k8ssandra/tests/unit/utils/helm"
+	"github.com/k8ssandra/k8ssandra/tests/unit/utils/kubeapi"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	cassdcv1beta1 "github.com/k8ssandra/cass-operator/operator/pkg/apis/cassandra/v1beta1"
@@ -1285,11 +1286,11 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 
 	Context("when configuring the Cassandra version and/or image", func() {
 		cassandraVersionImageMap := map[string]string{
-			"3.11.7":  "k8ssandra/cass-management-api:3.11.7-v0.1.26",
-			"3.11.8":  "k8ssandra/cass-management-api:3.11.8-v0.1.26",
-			"3.11.9":  "k8ssandra/cass-management-api:3.11.9-v0.1.26",
-			"3.11.10": "k8ssandra/cass-management-api:3.11.10-v0.1.26",
-			"4.0.0":   "k8ssandra/cass-management-api:4.0.0-v0.1.26",
+			"3.11.7":  "k8ssandra/cass-management-api:3.11.7-v0.1.27",
+			"3.11.8":  "k8ssandra/cass-management-api:3.11.8-v0.1.27",
+			"3.11.9":  "k8ssandra/cass-management-api:3.11.9-v0.1.27",
+			"3.11.10": "k8ssandra/cass-management-api:3.11.10-v0.1.27",
+			"4.0.0":   "k8ssandra/cass-management-api:4.0.0-v0.1.27",
 		}
 
 		It("using the default version", func() {
@@ -1300,7 +1301,7 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 			Expect(renderTemplate(options)).To(Succeed())
 
 			Expect(cassdc.Spec.ServerVersion).To(Equal("3.11.10"))
-			Expect(cassdc.Spec.ServerImage).To(Equal("k8ssandra/cass-management-api:3.11.10-v0.1.26"))
+			Expect(cassdc.Spec.ServerImage).To(Equal("k8ssandra/cass-management-api:3.11.10-v0.1.27"))
 		})
 
 		It("using 3.11.7", func() {


### PR DESCRIPTION
… Cassandra 4.0.0 GA, make 4.0.0 the default

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
* Bump to the latest version of the management-api w/ support for C* 4.0.0 GA
* Bump to 4.0.0 as the default deployed version for the stack

**Which issue(s) this PR fixes**:
Fixes #949 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
