### PR TITLE
do not change num_tokens when upgrading

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -20,3 +20,4 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 * [ENHANCEMENT] #959 Make root file system in Cassandra pod read only
 * [BUGFIX] #1012 reaper-operator's role.yaml has more data than it should, causing role name conflicts
 * [BUGFIX] #1018 reaper image registry typo and jvm typo fixed
+* [BUGFIX] #1029 Do not change num_tokens when upgrading

--- a/charts/k8ssandra/templates/_helpers.tpl
+++ b/charts/k8ssandra/templates/_helpers.tpl
@@ -197,7 +197,7 @@ Set default num_tokens based on the server version
   */}}
   {{- if $numTokens }}
     {{- if and $datacenter.num_tokens (ne (int $datacenter.num_tokens) (int $numTokens)) }}
-      {{- fail (printf "num_tokes cannot be changed once the CassandraDatacenter is created. The actual value is %d, but the specified value is %d" (int $datacenter.num_tokens) $numTokens) }}
+      {{- fail (printf "num_tokens cannot be changed once the CassandraDatacenter is created. The actual value is %d, but the specified value is %d" (int $datacenter.num_tokens) $numTokens) }}
     {{- end }}
     {{- nindent 6 (print "num_tokens: " $numTokens) }}
   {{- else }}

--- a/charts/k8ssandra/templates/_helpers.tpl
+++ b/charts/k8ssandra/templates/_helpers.tpl
@@ -163,21 +163,21 @@ Set default num_tokens based on the server version
 {{- $datacenter := (index .Values.cassandra.datacenters 0) -}}
 {{- if .Release.IsInstall }}
   {{- if $datacenter.num_tokens }}
-    num_tokens: {{ $datacenter.num_tokens }}
+    {{- nindent 6 (print "num_tokens: " $datacenter.num_tokens) }}
   {{- else }}
   {{- if hasPrefix "3.11" .Values.cassandra.version }}
-    num_tokens: 256
+    {{- nindent 6 (print "num_tokens: 256") }}
   {{- else }}
-    num_tokens: 16
+    {{- nindent 6 (print "num_tokens: 16") }}
   {{- end }}
 {{- end }}
 {{- else }}
   {{ $datacenterObj := (lookup "cassandra.datastax.com/v1beta1" "CassandraDatacenter" .Release.Namespace $datacenter.name) }}
   {{- if $datacenterObj }}
     {{- if hasPrefix "3.11" $datacenterObj.spec.serverVersion }}
-      num_tokens: 256
+      {{- nindent 6 (print "num_tokens: 256") }}
     {{- else }}
-      num_tokens: 16
+      {{- nindent 6 (print "num_tokens: 16") }}
     {{- end }}
   {{ end }}
 {{- end }}

--- a/charts/k8ssandra/templates/_helpers.tpl
+++ b/charts/k8ssandra/templates/_helpers.tpl
@@ -179,13 +179,15 @@ Set default num_tokens based on the server version
     {{- if $datacenterObj }}
       {{- $config := $datacenterObj.spec.config }}
       {{- $cassandraYaml := (get $config "cassandra-yaml") }}
-      {{- if not $cassandraYaml.num_tokens }}
+      {{- if $cassandraYaml.num_tokens }}
+        {{- nindent 6 (printf "num_tokens: %d" $cassandraYaml.num_tokens) }}
+      {{- else }}
         {{- if hasPrefix "3.11" $datacenterObj.spec.serverVersion }}
           {{- nindent 6 (print "num_tokens: 256") }}
         {{- else }}
           {{- nindent 6 (print "num_tokens: 16") }}
         {{- end }}
-      {{ end }}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/k8ssandra/templates/_helpers.tpl
+++ b/charts/k8ssandra/templates/_helpers.tpl
@@ -161,15 +161,26 @@ Set default num_tokens based on the server version
 */}}
 {{- define "k8ssandra.default_num_tokens" -}}
 {{- $datacenter := (index .Values.cassandra.datacenters 0) -}}
-    {{- if $datacenter.num_tokens }}
-      num_tokens: {{ $datacenter.num_tokens }}
-    {{- else }}
-    {{- if hasPrefix "3.11" .Values.cassandra.version }}
+{{- if .Release.IsInstall }}
+  {{- if $datacenter.num_tokens }}
+    num_tokens: {{ $datacenter.num_tokens }}
+  {{- else }}
+  {{- if hasPrefix "3.11" .Values.cassandra.version }}
+    num_tokens: 256
+  {{- else }}
+    num_tokens: 16
+  {{- end }}
+{{- end }}
+{{- else }}
+  {{ $datacenterObj := (lookup "cassandra.datastax.com/v1beta1" "CassandraDatacenter" .Release.Namespace $datacenter.name) }}
+  {{- if $datacenterObj }}
+    {{- if hasPrefix "3.11" $datacenterObj.spec.serverVersion }}
       num_tokens: 256
     {{- else }}
       num_tokens: 16
     {{- end }}
-    {{- end }}
+  {{ end }}
+{{- end }}
 {{- end }}
 
 {{- define "medusa.configMapName" -}}

--- a/charts/k8ssandra/templates/_helpers.tpl
+++ b/charts/k8ssandra/templates/_helpers.tpl
@@ -180,12 +180,15 @@ Set default num_tokens based on the server version
 {{- else }}
   {{ $numTokens := "" }}
   {{ $datacenterObj := (lookup "cassandra.datastax.com/v1beta1" "CassandraDatacenter" .Release.Namespace $datacenter.name) }}
-  {{- $config := $datacenterObj.spec.config }}
-  {{- $cassandraYaml := (get $config "cassandra-yaml") }}
-
-  {{- if $cassandraYaml }}
-    {{- if $cassandraYaml.num_tokens }}
-      {{- $numTokens = $cassandraYaml.num_tokens }}
+  {{- if $datacenterObj }}
+    {{- if $datacenterObj.spec }}
+      {{- $config := $datacenterObj.spec.config }}
+      {{- $cassandraYaml := (get $config "cassandra-yaml") }}
+      {{- if $cassandraYaml }}
+        {{- if $cassandraYaml.num_tokens }}
+          {{- $numTokens = $cassandraYaml.num_tokens }}
+        {{- end }}
+      {{- end }}
     {{- end }}
   {{- end }}
 

--- a/charts/k8ssandra/templates/_helpers.tpl
+++ b/charts/k8ssandra/templates/_helpers.tpl
@@ -172,14 +172,22 @@ Set default num_tokens based on the server version
   {{- end }}
 {{- end }}
 {{- else }}
-  {{ $datacenterObj := (lookup "cassandra.datastax.com/v1beta1" "CassandraDatacenter" .Release.Namespace $datacenter.name) }}
-  {{- if $datacenterObj }}
-    {{- if hasPrefix "3.11" $datacenterObj.spec.serverVersion }}
-      {{- nindent 6 (print "num_tokens: 256") }}
-    {{- else }}
-      {{- nindent 6 (print "num_tokens: 16") }}
+  {{- if $datacenter.num_tokens }}
+    {{- nindent 6 (print "num_tokens: " $datacenter.num_tokens) }}
+  {{- else }}
+    {{ $datacenterObj := (lookup "cassandra.datastax.com/v1beta1" "CassandraDatacenter" .Release.Namespace $datacenter.name) }}
+    {{- if $datacenterObj }}
+      {{- $config := $datacenterObj.spec.config }}
+      {{- $cassandraYaml := (get $config "cassandra-yaml") }}
+      {{- if not $cassandraYaml.num_tokens }}
+        {{- if hasPrefix "3.11" $datacenterObj.spec.serverVersion }}
+          {{- nindent 6 (print "num_tokens: 256") }}
+        {{- else }}
+          {{- nindent 6 (print "num_tokens: 16") }}
+        {{- end }}
+      {{ end }}
     {{- end }}
-  {{ end }}
+  {{- end }}
 {{- end }}
 {{- end }}
 

--- a/tests/integration/steps/integration_steps.go
+++ b/tests/integration/steps/integration_steps.go
@@ -105,13 +105,6 @@ func deployCluster(t *testing.T, namespace, customValues string, helmValues map[
 	g(t).Expect(err).To(BeNil())
 
 	if os.Getenv("K8SSANDRA_CASSANDRA_VERSION") != "" {
-		//if !useLocalCharts && strings.HasPrefix(os.Getenv("K8SSANDRA_CASSANDRA_VERSION"), "3.11") {
-		//	// We should not set the 3.11 version when using the stable repo as we may end up with a patch version that's not available
-		//	log.Println(Info("Using the default 3.11 Cassandra version available for this K8ssandra release"))
-		//} else {
-		//	log.Println(Info(fmt.Sprintf("Using Cassandra version %s", os.Getenv("K8SSANDRA_CASSANDRA_VERSION"))))
-		//	helmValues["cassandra.version"] = os.Getenv("K8SSANDRA_CASSANDRA_VERSION")
-		//}
 		log.Println(Info(fmt.Sprintf("Using Cassandra version %s", os.Getenv("K8SSANDRA_CASSANDRA_VERSION"))))
 		helmValues["cassandra.version"] = os.Getenv("K8SSANDRA_CASSANDRA_VERSION")
 	}

--- a/tests/integration/steps/integration_steps.go
+++ b/tests/integration/steps/integration_steps.go
@@ -105,13 +105,15 @@ func deployCluster(t *testing.T, namespace, customValues string, helmValues map[
 	g(t).Expect(err).To(BeNil())
 
 	if os.Getenv("K8SSANDRA_CASSANDRA_VERSION") != "" {
-		if !useLocalCharts && strings.HasPrefix(os.Getenv("K8SSANDRA_CASSANDRA_VERSION"), "3.11") {
-			// We should not set the 3.11 version when using the stable repo as we may end up with a patch version that's not available
-			log.Println(Info("Using the default 3.11 Cassandra version available for this K8ssandra release"))
-		} else {
-			log.Println(Info(fmt.Sprintf("Using Cassandra version %s", os.Getenv("K8SSANDRA_CASSANDRA_VERSION"))))
-			helmValues["cassandra.version"] = os.Getenv("K8SSANDRA_CASSANDRA_VERSION")
-		}
+		//if !useLocalCharts && strings.HasPrefix(os.Getenv("K8SSANDRA_CASSANDRA_VERSION"), "3.11") {
+		//	// We should not set the 3.11 version when using the stable repo as we may end up with a patch version that's not available
+		//	log.Println(Info("Using the default 3.11 Cassandra version available for this K8ssandra release"))
+		//} else {
+		//	log.Println(Info(fmt.Sprintf("Using Cassandra version %s", os.Getenv("K8SSANDRA_CASSANDRA_VERSION"))))
+		//	helmValues["cassandra.version"] = os.Getenv("K8SSANDRA_CASSANDRA_VERSION")
+		//}
+		log.Println(Info(fmt.Sprintf("Using Cassandra version %s", os.Getenv("K8SSANDRA_CASSANDRA_VERSION"))))
+		helmValues["cassandra.version"] = os.Getenv("K8SSANDRA_CASSANDRA_VERSION")
 	}
 
 	helmOptions := &helm.Options{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Changes the `k8ssandra.default_num_tokens` template to check if it is an upgrade. If it is an upgrade and `num_tokens` is not set then we make sure that `num_tokens` has the correct default based on the current version of Cassandra. So if the upgrade goes from 3.11.10 to 4.0 for example, then `num_tokens` will remain set to 256.

**Which issue(s) this PR fixes**:
Fixes #1029, #1020

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
