### PR TITLE
Reaper config volume & mountPath

### DIFF
--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -179,6 +179,10 @@ spec:
             mountPath: /opt/metrics-collector/config/
           - name: cassandra-tmp
             mountPath: /tmp/
+          {{- if .Values.reaper.enabled }}
+          - name: reaper-config
+            mountPath: /etc/reaper/
+          {{- end }}
       - name: server-config-init
         securityContext: {{- ternary ($defaultSecurityCtx) (.Values.cassandra.configBuilder.securityContext | toYaml) (empty .Values.cassandra.configBuilder.securityContext) | nindent 10 }}
      {{- if (or .Values.cassandra.auth.enabled .Values.reaper.enabled) }}
@@ -310,6 +314,10 @@ spec:
         emptyDir: {}
       - name: cassandra-tmp
         emptyDir: {}
+      {{- if .Values.reaper.enabled }}
+      - name: reaper-config
+        emptyDir: {}
+      {{- end }}
       {{- if .Values.medusa.enabled }}
       - name: podinfo
         downwardAPI:

--- a/tests/unit/template_cassdc_test.go
+++ b/tests/unit/template_cassdc_test.go
@@ -73,6 +73,7 @@ const (
 	CassandraConfigVolumeName            = "cassandra-config"
 	CassandraMetricsCollConfigVolumeName = "cassandra-metrics-coll-config"
 	CassandraTmpVolumeName               = "cassandra-tmp"
+	ReaperConfigVolumeName = "reaper-config"
 
 	MedusaBucketKeyVolumeName = "medusa-bucket-key"
 	PodInfoVolumeName         = "podinfo"
@@ -142,9 +143,9 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 
 			// Default set of volume and volume mounts
 			Expect(kubeapi.GetVolumeMountNames(&initContainers[0])).To(ConsistOf(CassandraConfigVolumeName,
-				CassandraMetricsCollConfigVolumeName, CassandraTmpVolumeName))
+				CassandraMetricsCollConfigVolumeName, CassandraTmpVolumeName, ReaperConfigVolumeName))
 			Expect(kubeapi.GetVolumeNames(cassdc.Spec.PodTemplateSpec)).To(ConsistOf(CassandraConfigVolumeName,
-				CassandraMetricsCollConfigVolumeName, CassandraTmpVolumeName))
+				CassandraMetricsCollConfigVolumeName, CassandraTmpVolumeName, ReaperConfigVolumeName))
 
 			// Default security context for containers
 			AssertContainerSecurityContextExists(cassdc, BaseConfigInitContainer, ConfigInitContainer,
@@ -513,7 +514,7 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 		It("enabling reaper and medusa", func() {
 			// Simple verification that both have properties correctly applied
 			options := &helm.Options{
-				SetValues: map[string]string{"medusa.enabled": "true"},
+				SetValues:      map[string]string{"medusa.enabled": "true"},
 				KubectlOptions: defaultKubeCtlOptions,
 			}
 


### PR DESCRIPTION
**What this PR does**:
Provides a reaper config volume & empty mount path that can be targeted for `securityContext` permissions.

**Which issue(s) this PR fixes**:
Support of:
* [k8ssand-700](https://k8ssandra.atlassian.net/browse/K8SSAND-700)
* [k8ssand-701](https://k8ssandra.atlassian.net/browse/K8SSAND-701) 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
