### PR TITLE
Fix Azure backups with an update to Medusa 0.11.1

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -18,6 +18,7 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 
 ## unreleased
 * [ENHANCEMENT] #959 Root file system in Cassandra pod read only; security context for containers.
+* [BUGFIX] #1066 Azure backups are broken due to missing azure-cli deps
 * [BUGFIX] #1012 reaper-operator's role.yaml has more data than it should, causing role name conflicts
 * [BUGFIX] #1018 reaper image registry typo and jvm typo fixed
 * [BUGFIX] #1029 Do not change num_tokens when upgrading

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -590,7 +590,7 @@ medusa:
     # -- Image repository for medusa
     repository: k8ssandra/medusa
     # -- Tag of the medusa image to pull from
-    tag: 0.11.0
+    tag: 0.11.1
     # -- Pull policy for the medusa container
     pullPolicy: IfNotPresent
   # -- Configures the Cassandra user used by Medusa when authentication is

--- a/tests/integration/charts/cluster_full_stack.yaml
+++ b/tests/integration/charts/cluster_full_stack.yaml
@@ -26,8 +26,9 @@ medusa:
   storage: s3_compatible
 
   storage_properties:
-      port: 9000
-      secure: "False"
+    port: 9000
+    secure: "False"
+    multi_part_upload_threshold: 1024
 
   bucketName: k8ssandra-medusa
   storageSecret: medusa-bucket-key

--- a/tests/integration/charts/cluster_with_medusa_azure_blobs.yaml
+++ b/tests/integration/charts/cluster_with_medusa_azure_blobs.yaml
@@ -20,6 +20,8 @@ medusa:
   # storageSecret will be created as part of the test from a ~/medusa_secret_azure.yaml file; to create this file,
   # follow the steps in docs/content/en/tasks/backup-restore/azure/_index.md
   storageSecret: medusa-bucket-key
+  storage_properties:
+    multi_part_upload_threshold: 1024
 
 reaper-operator:
   enabled: false

--- a/tests/integration/charts/cluster_with_medusa_minio.yaml
+++ b/tests/integration/charts/cluster_with_medusa_minio.yaml
@@ -18,8 +18,9 @@ medusa:
   storage: s3_compatible
 
   storage_properties:
-      port: 9000
-      secure: "False"
+    port: 9000
+    secure: "False"
+    multi_part_upload_threshold: 1024
 
   bucketName: k8ssandra-medusa
   storageSecret: medusa-bucket-key

--- a/tests/integration/charts/cluster_with_medusa_minio_upgraded.yaml
+++ b/tests/integration/charts/cluster_with_medusa_minio_upgraded.yaml
@@ -20,6 +20,7 @@ medusa:
   storage_properties:
     port: 9000
     secure: "False"
+    multi_part_upload_threshold: 1024
 
   bucketName: k8ssandra-medusa
   storageSecret: medusa-bucket-key

--- a/tests/integration/charts/cluster_with_medusa_s3.yaml
+++ b/tests/integration/charts/cluster_with_medusa_s3.yaml
@@ -18,7 +18,8 @@ medusa:
   storage: s3
 
   storage_properties:
-      region: us-east-1
+    region: us-east-1
+    multi_part_upload_threshold: 1024
 
   bucketName: k8ssandra-medusa
   storageSecret: medusa-bucket-key


### PR DESCRIPTION
**What this PR does**:
Upgrades Medusa to 0.11.1 and configure the integration tests to partially rely on the provider's cli for backup/restore, in order to reproduce the issue.

**Which issue(s) this PR fixes**:
Fixes #1066

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
