### PR TITLE
Fix relabelings to avoid out of order metrics error

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -18,6 +18,7 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 
 ## unreleased
 * [ENHANCEMENT] #959 Root file system in Cassandra pod read only; security context for containers.
+* [BUGFIX] #969 Prometheus "out-of-order timestamp" error due to metrics relabeling conflict 
 * [BUGFIX] #1066 Azure backups are broken due to missing azure-cli deps
 * [BUGFIX] #1012 reaper-operator's role.yaml has more data than it should, causing role name conflicts
 * [BUGFIX] #1018 reaper image registry typo and jvm typo fixed

--- a/charts/k8ssandra/templates/prometheus/service_monitor.yaml
+++ b/charts/k8ssandra/templates/prometheus/service_monitor.yaml
@@ -31,6 +31,11 @@ spec:
     scrapeTimeout: 15s
     targetPort: 9103
     metricRelabelings:
+    - regex: collectd_mcac_(meter|histogram).*
+      sourceLabels:
+      - __name__
+      replacement: ${1}
+      targetLabel: kind
     - action: drop
       regex: .*rate_(mean|1m|5m|15m)
       sourceLabels:
@@ -79,11 +84,6 @@ spec:
       sourceLabels:
       - mcac
       targetLabel: keyspace
-    - regex: org\.apache\.cassandra\.metrics\.table\.(\w+)\.(\w+)\.(\w+)
-      replacement: mcac_table_${1}
-      sourceLabels:
-      - mcac
-      targetLabel: __name__
     - regex: org\.apache\.cassandra\.metrics\.keyspace\.(\w+)\.(\w+)
       replacement: ${2}
       sourceLabels:

--- a/tests/integration/integration_suite_test.go
+++ b/tests/integration/integration_suite_test.go
@@ -1,9 +1,10 @@
 package integration
 
 import (
-	"github.com/google/uuid"
 	"log"
 	"strings"
+
+	"github.com/google/uuid"
 
 	. "github.com/k8ssandra/k8ssandra/tests/integration/steps"
 
@@ -319,6 +320,7 @@ func testPrometheus(t *testing.T, namespace string) {
 	CheckPrometheusMetricExtraction(t)
 	expectedActiveTargets := CountMonitoredItems(t, namespace)
 	CheckPrometheusActiveTargets(t, expectedActiveTargets) // We're monitoring 3 Cassandra nodes and 1 Stargate instance
+	CheckNoOutOfOrderMetrics(t, namespace)
 }
 
 // Grafana tests

--- a/tests/integration/steps/integration_steps.go
+++ b/tests/integration/steps/integration_steps.go
@@ -299,7 +299,7 @@ func resourceWithLabelIsPresent(t *testing.T, namespace, resourceType string, la
 	return false
 }
 
-func getPodsWithLabels(t *testing.T, namespace string, labels map[string]string) *v1.PodList {
+func GetPodsWithLabels(t *testing.T, namespace string, labels map[string]string) *v1.PodList {
 	pods := &v1.PodList{}
 	err := testClient.List(context.Background(), pods, client.InNamespace(namespace), client.MatchingLabels(labels))
 	g(t).Expect(err).To(BeNil(), fmt.Sprintf("Failed listing pods with labels %s", labels))
@@ -314,7 +314,7 @@ func getServicesWithLabels(t *testing.T, namespace string, labels map[string]str
 }
 
 func CountPodsWithLabels(t *testing.T, namespace string, labels map[string]string) int {
-	pods := getPodsWithLabels(t, namespace, labels)
+	pods := GetPodsWithLabels(t, namespace, labels)
 	return len(pods.Items)
 }
 
@@ -323,7 +323,7 @@ func PodWithLabelsIsReady(t *testing.T, namespace string, label map[string]strin
 		return resourceWithLabelIsPresent(t, namespace, "pod", label)
 	}, retryTimeout, retryInterval).Should(BeTrue())
 
-	pods := getPodsWithLabels(t, namespace, label)
+	pods := GetPodsWithLabels(t, namespace, label)
 	if len(pods.Items) == 1 {
 		return strings.ToLower(string(pods.Items[0].Status.Phase)) == "running"
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Fix "out of order" metrics being scraped by Prometheus. A new `kind` label is introduced to distinguish histograms and meters being sent by MCAC for the current same set of labels.

I've added an integration test which failed without the fix: https://github.com/adejanovski/k8ssandra/runs/3533754080?check_suite_focus=true

**Which issue(s) this PR fixes**:
Fixes #969 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
