### PR TITLE
ShortCut link fixing for doc

### DIFF
--- a/docs/content/en/quickstarts/site-reliability-engineer/_index.md
+++ b/docs/content/en/quickstarts/site-reliability-engineer/_index.md
@@ -16,7 +16,7 @@ In this quickstart for Site Reliability Engineers (SREs), we'll cover:
 * [Accessing nodetool commands]({{< relref "#nodetool" >}}) like status, ring, and info.
 * [Configure port forwarding]({{< relref "#port-forwarding" >}}) for the Prometheus and Grafana monitoring utilities as well as Reaper for Apache Cassandra® (Reaper).
 * [Accessing the K8ssandra monitoring utilities]({{< relref "#monitoring" >}}), Prometheus and Grafana.
-* [Accessing Reaper]({{< relref "#monitoring" >}}), an easy to use repair interface.
+* [Accessing Reaper]({{< relref "#reaper" >}}), an easy to use repair interface.
 * [Upgrading a K8ssandra cluster]({{< relref "#upgrade" >}}): to ensure you're using the latest K8ssandra software, or to apply new settings.
 
 ## Access the Apache Cassandra® nodetool utility {#nodetool}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Hi, I found a missing shortcut link for [Reaper](https://docs.k8ssandra.io/quickstarts/site-reliability-engineer/#reaper) on the outline part when I read document: https://docs.k8ssandra.io/quickstarts/site-reliability-engineer. By the way, it's well documented and good practice for me. Thanks.
**Which issue(s) this PR fixes**:  
N/A

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
