### PR TITLE
Test new jvm opts settings to control system ks replication

### DIFF
--- a/.github/workflows/integration-tests-release.yaml
+++ b/.github/workflows/integration-tests-release.yaml
@@ -78,8 +78,10 @@ jobs:
       fail-fast: false
       matrix:
         k8s_version: ["${{ github.event.inputs.kubernetes_version }}"]
-        cassandra_version: ["3.11.10", "4.0.0"]
-        scenario: ["TestMedusaDeploymentScenario/\"S3\"", "TestMedusaDeploymentScenario/\"Minio\"", "TestMedusaDeploymentScenario/\"local\"", "TestMedusaDeploymentScenario/\"azure_blobs\"", "TestReaperDeploymentScenario", "TestMonitoringDeploymentScenario", "TestStargateDeploymentScenario", "TestRestoreAfterUpgrade", "TestUpgradeScenario"]
+        cassandra_version: ["3.11.11", "4.0.0"]
+        scenario: ["TestMedusaDeploymentScenario/\"S3\"", "TestMedusaDeploymentScenario/\"Minio\"", "TestMedusaDeploymentScenario/\"local\"", \ 
+          "TestMedusaDeploymentScenario/\"azure_blobs\"", "TestReaperDeploymentScenario", "TestMonitoringDeploymentScenario", "TestStargateDeploymentScenario", \ 
+          "TestRestoreAfterUpgrade", "TestUpgradeScenario", "TestCassandraDeployment"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -151,10 +151,15 @@ spec:
     {{- include "k8ssandra.configureGc" . -}}
     {{- include "k8ssandra.configureJvmHeap" . }}
       additional-jvm-opts:
-{{- if .Values.cassandra.auth.enabled }}
+      {{- if .Values.cassandra.additionalJvmOpts }}
+      {{- range .Values.cassandra.additionalJvmOpts }}
+        - {{ . }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.cassandra.auth.enabled }}
         - "-Dcassandra.system_distributed_replication_dc_names={{ $datacenter.name }}"
         - "-Dcassandra.system_distributed_replication_per_dc={{ min 5 $datacenter.size }}"
-{{- end }}
+      {{- end }}
 {{- end }}
 {{- if not .Values.cassandra.loggingSidecar.enabled }}
   disableSystemLoggerSidecar: true

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -19,8 +19,8 @@ cassandra:
     3.11.8: k8ssandra/cass-management-api:3.11.8-v0.1.28
     3.11.9: k8ssandra/cass-management-api:3.11.9-v0.1.27
     3.11.10: k8ssandra/cass-management-api:3.11.10-v0.1.27
-    3.11.11: k8ssandra/cass-management-api:3.11.11-v0.1.28
-    4.0.0: k8ssandra/cass-management-api:4.0.0-v0.1.28
+    3.11.11: adejanovski/cass-management-api:3.11.11-testing
+    4.0.0: adejanovski/cass-management-api:4.0.0-testing
   # -- Overrides the default image mappings. This is intended for advanced use cases
   # like development or testing. By default the Cassandra version has to be one that is in
   # versionImageMap. Template rendering will fail if the version is not in the map. When
@@ -345,6 +345,9 @@ cassandra:
       #     - example.com
       #   # -- Secret containing the TLS certificate and key for the listener
       #   secretName: tls-secret
+  
+  # Additional JVM options to pass to the Cassandra process
+  additionalJvmOpts: []
 stargate:
   # -- Enable Stargate resources as part of this release
   enabled: true

--- a/tests/integration/charts/cluster_with_cassandra_only.yaml
+++ b/tests/integration/charts/cluster_with_cassandra_only.yaml
@@ -1,0 +1,21 @@
+cassandra:
+  heap:
+   size: 500M
+   newGenSize: 200M
+  datacenters:
+  - name: dc1
+    size: 3
+  ingress:
+    enabled: false
+
+stargate:
+  enabled: false
+
+reaper:
+  enabled: false
+
+medusa:
+  enabled: false
+
+kube-prometheus-stack:
+  enabled: false

--- a/tests/integration/charts/cluster_with_stargate_and_monitoring.yaml
+++ b/tests/integration/charts/cluster_with_stargate_and_monitoring.yaml
@@ -5,6 +5,8 @@ cassandra:
   datacenters:
   - name: dc1
     size: 3
+  additionalJvmOpts:
+  - "-Dcassandra.system_distributed_replication=dc1:3,dc2:1"
   ingress:
     enabled: false
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Add support for passing jvm options to Cassandra and test the newly added option to override the replication settings of the system_* keyspaces.

**Which issue(s) this PR fixes**:


**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
