### PR TITLE
Temp relax read-only for containers

### DIFF
--- a/charts/cass-operator/values.yaml
+++ b/charts/cass-operator/values.yaml
@@ -58,15 +58,12 @@ podSecurityContext: {}
 securityContext:
   # -- Mark root filesystem as read only
   readOnlyRootFilesystem: false
-
   # -- Run cass-operator container as non-root user
-  # runAsNonRoot: true
-
+  runAsNonRoot: true
   # -- Group for the user running the cass-operator container / process
-  # runAsGroup: 65534
-
+  runAsGroup: 65534
   # -- User for running the cass-operator container / process
-  # runAsUser: 65534
+  runAsUser: 65534
 
 # -- Resources requests and limits for the cass-operator pod. We usually
 # recommend not to specify default resources and to leave this as a conscious

--- a/charts/k8ssandra-common/templates/_helpers.tpl
+++ b/charts/k8ssandra-common/templates/_helpers.tpl
@@ -29,7 +29,7 @@ SecurityContext helpers for pod and container scope.
 k8ssandra container securityContext defaults
 **/}}
 {{- define "k8ssandra-common.container.security-ctx-defaults" -}}
-readOnlyRootFilesystem: true
+readOnlyRootFilesystem: false
 {{- end }}
 
 {{/**

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -166,7 +166,6 @@ spec:
 {{- end }}
   podTemplateSpec:
     spec:
-      securityContext: {{- ternary ($defaultPodSecurityCtx) (.Values.cassandra.podSecurityContext | toYaml) (empty .Values.cassandra.podSecurityContext) | nindent 10 }}
       initContainers:
       - name: base-config-init
         image: {{ include "k8ssandra.cassandraImage" . }}

--- a/tests/unit/template_cassdc_test.go
+++ b/tests/unit/template_cassdc_test.go
@@ -159,7 +159,9 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 			AssertContainerSecurityContextExistsAndMatches(cassdc, CassandraContainer, expectedCtx)
 
 			// Default pod security context for cassdc
-			Expect(cassdc.Spec.PodTemplateSpec.Spec.SecurityContext).ToNot(BeNil())
+			// TODO - revisit as this was potentially causing issues by defaulting to {}
+			// with respect to running in GKE - see k8ssandra #1094
+			Expect(cassdc.Spec.PodTemplateSpec.Spec.SecurityContext).To(BeNil())
 		})
 
 		It("is not rendered if disabled", func() {
@@ -514,7 +516,7 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 		It("enabling reaper and medusa", func() {
 			// Simple verification that both have properties correctly applied
 			options := &helm.Options{
-				SetValues: map[string]string{"medusa.enabled": "true"},
+				SetValues:      map[string]string{"medusa.enabled": "true"},
 				KubectlOptions: defaultKubeCtlOptions,
 			}
 

--- a/tests/unit/utils/cassdc/containers.go
+++ b/tests/unit/utils/cassdc/containers.go
@@ -60,7 +60,9 @@ func AssertContainerSecurityContextExists(cassdc *cassop.CassandraDatacenter, na
 		Expect(container).ToNot(BeNil())
 		Expect(container.SecurityContext).ToNot(BeNil())
 		Expect(container.SecurityContext.ReadOnlyRootFilesystem).ToNot(BeNil())
-		Expect(*container.SecurityContext.ReadOnlyRootFilesystem).To(BeTrue())
+		// TODO - once images are adjusted that run as apps in these containers,
+		// this will be expecting read-only to be true.
+		Expect(*container.SecurityContext.ReadOnlyRootFilesystem).To(BeFalse())
 	}
 }
 


### PR DESCRIPTION
**What this PR does**:
Temporarily relax the default `securityContext` for containers to resolve issue reported with c* image failing `mkdir` as root in GKE.

**Which issue(s) this PR fixes**:
Fixes #1094 
[k8ssand-875](https://k8ssandra.atlassian.net/browse/K8SSAND-875)

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
