### PR TITLE
k8ssandra-operator chart updates

### DIFF
--- a/charts/cass-operator/Chart.yaml
+++ b/charts/cass-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: cass-operator
 description: |
   Kubernetes operator which handles the provisioning and management of Apache Cassandra clusters.
 type: application
-version: 0.30.0
+version: 0.31.0
 appVersion: 1.8.0
 dependencies:
   - name: k8ssandra-common

--- a/charts/cass-operator/templates/configmap.yaml
+++ b/charts/cass-operator/templates/configmap.yaml
@@ -1,6 +1,6 @@
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-manager-config
+  name: {{ include "k8ssandra-common.fullname" . }}-manager-config
   labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
 apiVersion: v1
 data:

--- a/charts/cass-operator/templates/deployment.yaml
+++ b/charts/cass-operator/templates/deployment.yaml
@@ -83,5 +83,5 @@ spec:
             secretName: {{ .Release.Name }}-webhook
       {{- end }}
         - configMap:
-            name: {{ .Release.Name }}-manager-config
+            name: {{ include "k8ssandra-common.fullname" . }}-manager-config
           name: manager-config

--- a/charts/cass-operator/values.yaml
+++ b/charts/cass-operator/values.yaml
@@ -33,7 +33,7 @@ image:
   pullPolicy: IfNotPresent
 
   # -- Tag of the cass-operator image to pull from image.repository
-  tag: v1.8.0-rc.1
+  tag: v1.8.0-rc.2
 
   # -- Docker registry containing all cass-operator related images. Setting this
   # allows for usage of an internal registry without specifying serverImage,

--- a/charts/k8ssandra-operator/Chart.yaml
+++ b/charts/k8ssandra-operator/Chart.yaml
@@ -3,12 +3,15 @@ name: k8ssandra-operator
 description: |
   Kubernetes operator which handles the provisioning and management of K8ssandra clusters.
 type: application
-version: 0.30.1
+version: 0.31.0
 appVersion: 1.0.0
 dependencies:
   - name: k8ssandra-common
     version: 0.28.4
     repository: file://../k8ssandra-common
+  - name: cass-operator
+    version: 0.31.0
+    repository: file://../cass-operator
 home: https://github.com/k8ssandra/k8ssandra-operator
 sources:
   - https://github.com/k8ssandra/k8ssandra-operator

--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -7,7 +7,7 @@ version: 1.4.0-SNAPSHOT
 
 dependencies:
   - name: cass-operator
-    version: 0.30.0
+    version: 0.31.0
     repository: file://../cass-operator
     condition: cass-operator.enabled
 

--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -6,11 +6,6 @@ type: application
 version: 1.4.0-SNAPSHOT
 
 dependencies:
-  - name: k8ssandra-operator
-    version: 0.30.1
-    repository: file://../k8ssandra-operator
-    condition: k8ssandra-operator.enabled
-
   - name: cass-operator
     version: 0.30.0
     repository: file://../cass-operator

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -726,10 +726,6 @@ client:
     tag: latest
     # -- Pull policy for the client container
     pullPolicy: IfNotPresent
-k8ssandra-operator:
-  # -- Enables the k8ssandra-operator as part of this release. This is experimental deployment option, do not
-  # use in production.
-  enabled: false
 cass-operator:
   # -- Enables the cass-operator as part of this release. If this setting is
   # disabled no Cassandra resources will be deployed.


### PR DESCRIPTION
…gmap

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This PR addresses the forum discussion [here](https://forum.k8ssandra.io/t/k8ssandra-operator-and-helm-charts/332/9). It adds the cass-operator dependency to the k8ssandra-operator chart so that the latter can be used on its own.

I am not creating a separate issue for this. It can be logged under #1080.

**Which issue(s) this PR fixes**:
Fixes #1080

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
