### PR TITLE
Re-introduce table level metrics which were mistakenly removed in 1.3.2

### DIFF
--- a/CHANGELOG-1.3.md
+++ b/CHANGELOG-1.3.md
@@ -18,6 +18,8 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 
 ## unreleased
 
+* [BUGFIX] Re-introduce table level metrics that were mistakenly removed in 1.3.2
+
 ## v1.3.2 - 2021-10-14
 
 * [BUGFIX] Allow usage of Traefik charts above 10.0.0

--- a/charts/k8ssandra/templates/prometheus/service_monitor.yaml
+++ b/charts/k8ssandra/templates/prometheus/service_monitor.yaml
@@ -84,6 +84,11 @@ spec:
       sourceLabels:
       - mcac
       targetLabel: keyspace
+    - regex: org\.apache\.cassandra\.metrics\.table\.(\w+)\.(\w+)\.(\w+)
+      replacement: mcac_table_${1}
+      sourceLabels:
+      - mcac
+      targetLabel: __name__
     - regex: org\.apache\.cassandra\.metrics\.keyspace\.(\w+)\.(\w+)
       replacement: ${2}
       sourceLabels:

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/k8ssandra/reaper-operator v0.3.2
 	github.com/onsi/ginkgo v1.14.2
 	github.com/onsi/gomega v1.10.3
+	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/traefik/traefik/v2 v2.3.7
 	helm.sh/helm/v3 v3.5.4
 	k8s.io/api v0.20.4

--- a/go.sum
+++ b/go.sum
@@ -1282,6 +1282,7 @@ github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/tests/integration/integration_suite_test.go
+++ b/tests/integration/integration_suite_test.go
@@ -321,6 +321,7 @@ func testPrometheus(t *testing.T, namespace string) {
 	expectedActiveTargets := CountMonitoredItems(t, namespace)
 	CheckPrometheusActiveTargets(t, expectedActiveTargets) // We're monitoring 3 Cassandra nodes and 1 Stargate instance
 	CheckNoOutOfOrderMetrics(t, namespace)
+	CheckTableLevelMetricsArePresent(t)
 }
 
 // Grafana tests


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Re-introduces the table level metrics by fixing the relabelling rules.
Adds a check for table level metrics in the monitoring integration tests.

**Which issue(s) this PR fixes**:
Fixes #1137

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
