### PR TITLE
Apply MCAC filters for table level metrics

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -17,6 +17,7 @@ When cutting a new release of the parent `k8ssandra` chart update the `unrelease
 and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
+* [ENHANCEMENT] Apply customizable filters on table level metrics in MCAC
 * [ENHANCEMENT] #1083 Add support for full query logging (Cassandra 4.0.0 feature)
 * [ENHANCEMENT] #1083 Add support for audit logging (Cassandra 4.0.0 feature)
 * [ENHANCEMENT] #1083 Add support for client backpressure (Cassandra 4.0.0 feature)

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -298,10 +298,16 @@ spec:
       containers:
       - name: cassandra
         securityContext: {{- ternary ($defaultSecurityCtx) (.Values.cassandra.securityContext | toYaml) (empty .Values.cassandra.securityContext) | nindent 10 }}
-        {{- if .Values.reaper.enabled }}
+        {{- if (or .Values.reaper.enabled .Values.cassandra.metric_filters) }}
         env:
+          {{- if .Values.reaper.enabled }}
           - name: LOCAL_JMX
             value: "no"
+          {{- end }}
+          {{- if .Values.cassandra.metric_filters }}
+          - name: METRIC_FILTERS
+            value: {{ printf "%s" (join " " .Values.cassandra.metric_filters) }}
+          {{- end }}
         {{- end }}
        {{- if .Values.medusa.enabled }}
         volumeMounts:

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -16,13 +16,13 @@ cassandra:
   # management-api images. If you do want to change one of these mappings, the new value
   # should be a management-api image.
   versionImageMap:
-    3.11.7: k8ssandra/cass-management-api:3.11.7-v0.1.31
-    3.11.8: k8ssandra/cass-management-api:3.11.8-v0.1.31
+    3.11.7: k8ssandra/cass-management-api:3.11.7-v0.1.32
+    3.11.8: k8ssandra/cass-management-api:3.11.8-v0.1.32
     3.11.9: k8ssandra/cass-management-api:3.11.9-v0.1.27
     3.11.10: k8ssandra/cass-management-api:3.11.10-v0.1.27
-    3.11.11: k8ssandra/cass-management-api:3.11.11-v0.1.31
-    4.0.0: k8ssandra/cass-management-api:4.0.0-v0.1.31
-    4.0.1: k8ssandra/cass-management-api:4.0.1-v0.1.31
+    3.11.11: k8ssandra/cass-management-api:3.11.11-v0.1.32
+    4.0.0: k8ssandra/cass-management-api:4.0.0-v0.1.32
+    4.0.1: k8ssandra/cass-management-api:4.0.1-v0.1.32
   # -- Overrides the default image mappings. This is intended for advanced use cases
   # like development or testing. By default the Cassandra version has to be one that is in
   # versionImageMap. Template rendering will fail if the version is not in the map. When
@@ -373,6 +373,23 @@ cassandra:
       #     - example.com
       #   # -- Secret containing the TLS certificate and key for the listener
       #   secretName: tls-secret
+  metric_filters:
+  - "deny:org.apache.cassandra.metrics.Table"
+  - "deny:org.apache.cassandra.metrics.table"
+  - "allow:org.apache.cassandra.metrics.table.live_ss_table_count"
+  - "allow:org.apache.cassandra.metrics.Table.LiveSSTableCount"
+  - "allow:org.apache.cassandra.metrics.table.live_disk_space_used"
+  - "allow:org.apache.cassandra.metrics.table.LiveDiskSpaceUsed"
+  - "allow:org.apache.cassandra.metrics.Table.Pending"
+  - "allow:org.apache.cassandra.metrics.Table.Memtable"
+  - "allow:org.apache.cassandra.metrics.Table.Compaction"
+  - "allow:org.apache.cassandra.metrics.table.read"
+  - "allow:org.apache.cassandra.metrics.table.write"
+  - "allow:org.apache.cassandra.metrics.table.range"
+  - "allow:org.apache.cassandra.metrics.table.coordinator"
+  - "allow:org.apache.cassandra.metrics.table.dropped_mutations"
+
+
 stargate:
   # -- Enable Stargate resources as part of this release
   enabled: true

--- a/tests/unit/template_cassdc_test.go
+++ b/tests/unit/template_cassdc_test.go
@@ -123,7 +123,7 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 			Expect(initContainers[2].Name).To(Equal(JmxCredentialsInitContainer))
 			// Verify LOCAL_JMX value
 			Expect(len(cassdc.Spec.PodTemplateSpec.Spec.Containers)).To(Equal(1))
-			Expect(len(cassdc.Spec.PodTemplateSpec.Spec.Containers[0].Env)).To(Equal(1))
+			Expect(len(cassdc.Spec.PodTemplateSpec.Spec.Containers[0].Env)).To(Equal(2))
 			Expect(cassdc.Spec.PodTemplateSpec.Spec.Containers[0].Env[0].Name).To(Equal("LOCAL_JMX"))
 			Expect(cassdc.Spec.PodTemplateSpec.Spec.Containers[0].Env[0].Value).To(Equal("no"))
 			Expect(cassdc.Spec.AllowMultipleNodesPerWorker).To(Equal(false))
@@ -345,8 +345,8 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 			Expect(cassdc.Annotations).ShouldNot(HaveKeyWithValue(ReaperInstanceAnnotation, reaperInstanceValue))
 
 			Expect(len(cassdc.Spec.PodTemplateSpec.Spec.Containers)).To(Equal(1))
-			// No env slice should be present
-			Expect(cassdc.Spec.PodTemplateSpec.Spec.Containers[0].Env).To(BeNil())
+			// The metrics filter env should be set
+			Expect(Expect(len(cassdc.Spec.PodTemplateSpec.Spec.Containers[0].Env)).To(Equal(1)))
 
 			AssertInitContainerNamesMatch(cassdc, BaseConfigInitContainer, ConfigInitContainer,
 				JmxCredentialsInitContainer)
@@ -1444,13 +1444,13 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 
 	Context("when configuring the Cassandra version and/or image", func() {
 		cassandraVersionImageMap := map[string]string{
-			"3.11.7":  "k8ssandra/cass-management-api:3.11.7-v0.1.31",
-			"3.11.8":  "k8ssandra/cass-management-api:3.11.8-v0.1.31",
+			"3.11.7":  "k8ssandra/cass-management-api:3.11.7-v0.1.32",
+			"3.11.8":  "k8ssandra/cass-management-api:3.11.8-v0.1.32",
 			"3.11.9":  "k8ssandra/cass-management-api:3.11.9-v0.1.27",
 			"3.11.10": "k8ssandra/cass-management-api:3.11.10-v0.1.27",
-			"3.11.11": "k8ssandra/cass-management-api:3.11.11-v0.1.31",
-			"4.0.0":   "k8ssandra/cass-management-api:4.0.0-v0.1.31",
-			"4.0.1":   "k8ssandra/cass-management-api:4.0.1-v0.1.31",
+			"3.11.11": "k8ssandra/cass-management-api:3.11.11-v0.1.32",
+			"4.0.0":   "k8ssandra/cass-management-api:4.0.0-v0.1.32",
+			"4.0.1":   "k8ssandra/cass-management-api:4.0.1-v0.1.32",
 		}
 
 		It("using the default version", func() {
@@ -1461,7 +1461,7 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 			Expect(renderTemplate(options)).To(Succeed())
 
 			Expect(cassdc.Spec.ServerVersion).To(Equal("4.0.1"))
-			Expect(cassdc.Spec.ServerImage).To(Equal("k8ssandra/cass-management-api:4.0.1-v0.1.31"))
+			Expect(cassdc.Spec.ServerImage).To(Equal("k8ssandra/cass-management-api:4.0.1-v0.1.32"))
 		})
 
 		It("using 3.11.7", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Introduces the ability to create filters for Cassandra metrics in Helm values files. The default filters fix the issues observed when 300+ tables were created in the Cassandra cluster, overwhelming collectd and/or scraping, resulting into all metrics being dropped.
They filter all table level metrics that are not used in our default dashboards.

**Which issue(s) this PR fixes**:
Fixes #1092

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
