### PR TITLE
Upgrade Reaper dependency 2.3.1 -> 3.0.0

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -29,6 +29,7 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 * [BUGFIX] #1018 reaper image registry typo and jvm typo fixed
 * [BUGFIX] #1029 Do not change num_tokens when upgrading
 * [ENHANCEMENT] #874 expose cass-operator AdditionalServiceConfig in k8ssandra helm chart values.yaml
+* [CHANGE] Update to Reaper 3.0.0
 * [CHANGE] #1118 Update to Stargate 1.0.35
 * [CHANGE] #950 Update to cass-operator 1.8.0-rc.1
 * [CHANGE] Update to cass-operator v1.8.0

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -288,14 +288,14 @@ cassandra:
           affinityLabels: {}
       # -- Optionally enable full query logging facility for this DC.
       fql: {}
-        # enabled: true
+      # enabled: true
       # -- Optionally enable audit logging for this DC.
       audit_logging: {}
-        # enabled: true
+      # enabled: true
       # -- Optionally enable client backpressure for this DC.
       client_backpressure: {}
-        # native_transport_max_concurrent_requests_in_bytes_per_ip: 1
-        # native_transport_max_concurrent_requests_in_bytes: 1
+      # native_transport_max_concurrent_requests_in_bytes_per_ip: 1
+      # native_transport_max_concurrent_requests_in_bytes: 1
       # -- Optional datacenter-level heap setting, overrides cluster-level setting
       # `cassandra.heap`. Options are commented out for reference. Note that
       # k8ssandra does not automatically apply default values for heap size. It
@@ -374,22 +374,20 @@ cassandra:
       #   # -- Secret containing the TLS certificate and key for the listener
       #   secretName: tls-secret
   metric_filters:
-  - "deny:org.apache.cassandra.metrics.Table"
-  - "deny:org.apache.cassandra.metrics.table"
-  - "allow:org.apache.cassandra.metrics.table.live_ss_table_count"
-  - "allow:org.apache.cassandra.metrics.Table.LiveSSTableCount"
-  - "allow:org.apache.cassandra.metrics.table.live_disk_space_used"
-  - "allow:org.apache.cassandra.metrics.table.LiveDiskSpaceUsed"
-  - "allow:org.apache.cassandra.metrics.Table.Pending"
-  - "allow:org.apache.cassandra.metrics.Table.Memtable"
-  - "allow:org.apache.cassandra.metrics.Table.Compaction"
-  - "allow:org.apache.cassandra.metrics.table.read"
-  - "allow:org.apache.cassandra.metrics.table.write"
-  - "allow:org.apache.cassandra.metrics.table.range"
-  - "allow:org.apache.cassandra.metrics.table.coordinator"
-  - "allow:org.apache.cassandra.metrics.table.dropped_mutations"
-
-
+    - "deny:org.apache.cassandra.metrics.Table"
+    - "deny:org.apache.cassandra.metrics.table"
+    - "allow:org.apache.cassandra.metrics.table.live_ss_table_count"
+    - "allow:org.apache.cassandra.metrics.Table.LiveSSTableCount"
+    - "allow:org.apache.cassandra.metrics.table.live_disk_space_used"
+    - "allow:org.apache.cassandra.metrics.table.LiveDiskSpaceUsed"
+    - "allow:org.apache.cassandra.metrics.Table.Pending"
+    - "allow:org.apache.cassandra.metrics.Table.Memtable"
+    - "allow:org.apache.cassandra.metrics.Table.Compaction"
+    - "allow:org.apache.cassandra.metrics.table.read"
+    - "allow:org.apache.cassandra.metrics.table.write"
+    - "allow:org.apache.cassandra.metrics.table.range"
+    - "allow:org.apache.cassandra.metrics.table.coordinator"
+    - "allow:org.apache.cassandra.metrics.table.dropped_mutations"
 stargate:
   # -- Enable Stargate resources as part of this release
   enabled: true
@@ -562,7 +560,7 @@ reaper:
     # -- Image repository for reaper
     repository: thelastpickle/cassandra-reaper
     # -- Tag of the reaper image to pull from
-    tag: 2.3.1
+    tag: 3.0.0
     # -- Pull policy for the reaper container
     pullPolicy: IfNotPresent
   # -- Configures the Cassandra user used by Reaper when authentication is


### PR DESCRIPTION
This is auto-generated update from the K8ssandra upgrade GHA workflow.
Check that CI passes correctly before merging this PR.