### PR TITLE
Add integration tests to verify proper restore completion [K8SSAND-921]

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -18,6 +18,7 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 
 ## unreleased
 * [CHANGE] Update to Managment API v0.1.33
+* [CHANGE] Update to Medusa 0.11.3
 * [CHANGE] Update to kube-prometheus-stack v20.0.1 with Prometheus 2.28.1 and Grafana 7.5.1
 * [CHANGE] Update to medusa-operator 0.4.0
 * [CHANGE] Update to Reaper 3.0.0
@@ -38,6 +39,7 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 * [ENHANCEMENT] #959 Root file system in Cassandra pod read only; security context for containers.
 * [ENHANCEMENT] #874 expose cass-operator AdditionalServiceConfig in k8ssandra helm chart values.yaml
 * [BUGFIX] Ensure Cassandra 4x is compatible with Stargate deployments by including `allow_alter_rf_during_range_movement` in config.
+* [BUGFIX] Fix restore operation triggering on each pod restart after the initial restore
 * [BUGFIX] #1129 CassOperator kills C* pods with due to incorrect memory
 * [BUGFIX] #1066 Azure backups are broken due to missing azure-cli deps
 * [BUGFIX] #1012 reaper-operator's role.yaml has more data than it should, causing role name conflicts

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -660,9 +660,9 @@ medusa:
     # -- Image registry for medusa
     registry: docker.io
     # -- Image repository for medusa
-    repository: k8ssandra/medusa
+    repository: adejanovski/medusa
     # -- Tag of the medusa image to pull from
-    tag: 0.11.1
+    tag: k8s-restore-fix
     # -- Pull policy for the medusa container
     pullPolicy: IfNotPresent
   # -- Configures the Cassandra user used by Medusa when authentication is

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -660,9 +660,9 @@ medusa:
     # -- Image registry for medusa
     registry: docker.io
     # -- Image repository for medusa
-    repository: adejanovski/medusa
+    repository: k8ssandra/medusa
     # -- Tag of the medusa image to pull from
-    tag: k8s-restore-fix
+    tag: 0.11.3
     # -- Pull policy for the medusa container
     pullPolicy: IfNotPresent
   # -- Configures the Cassandra user used by Medusa when authentication is

--- a/tests/integration/integration_suite_test.go
+++ b/tests/integration/integration_suite_test.go
@@ -237,6 +237,7 @@ func testMedusa(t *testing.T, namespace, backend, backupName string, useLocalCha
 	log.Println(Info("Restoring backup and checking row count"))
 	RestoreBackup(t, namespace, backupName)
 	CheckRowCountInTable(t, 10, namespace, medusaTestTable, medusaTestKeyspace)
+	CheckLastRestoreFilePresence(t, namespace)
 }
 
 func deployClusterForMedusa(t *testing.T, namespace, backend string, nodes int, useLocalCharts bool, version string) {

--- a/tests/integration/integration_suite_test.go
+++ b/tests/integration/integration_suite_test.go
@@ -1,10 +1,11 @@
 package integration
 
 import (
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"log"
 	"path/filepath"
 	"strings"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
 
 	"github.com/google/uuid"
 
@@ -13,6 +14,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+
 	. "github.com/onsi/gomega"
 )
 
@@ -238,6 +240,7 @@ func testMedusa(t *testing.T, namespace, backend, backupName string, useLocalCha
 	RestoreBackup(t, namespace, backupName)
 	CheckRowCountInTable(t, 10, namespace, medusaTestTable, medusaTestKeyspace)
 	CheckLastRestoreFilePresence(t, namespace)
+	CheckLastRestoreFileContainsKey(t, namespace)
 }
 
 func deployClusterForMedusa(t *testing.T, namespace, backend string, nodes int, useLocalCharts bool, version string) {

--- a/tests/integration/steps/medusa_steps.go
+++ b/tests/integration/steps/medusa_steps.go
@@ -1,6 +1,7 @@
 package steps
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -84,4 +85,22 @@ func restoreIsFinished(t *testing.T, namespace, backupName string) bool {
 		return true
 	}
 	return false
+}
+
+func CheckLastRestoreFilePresence(t *testing.T, namespace string) {
+	g(t).Expect(lastRestoreFileIsPresent(t, namespace)).Should(BeTrue())
+}
+
+func lastRestoreFileIsPresent(t *testing.T, namespace string) bool {
+	_, err := k8s.RunKubectlAndGetOutputE(
+		t,
+		getKubectlOptions(namespace),
+		"exec",
+		fmt.Sprintf("%s-%s-default-sts-0", releaseName, datacenterName),
+		"--",
+		"cat",
+		"/var/lib/cassandra/.last-restore",
+	)
+
+	return err == nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds an integration test to check that the `./last-restore` file is properly created after a restore to avoid restoring a backup on subsequent restarts of a Cassandra pod.

**Which issue(s) this PR fixes**:
Fixes #1112

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
