### PR TITLE
Stargate/Cassandra 4x compatibility

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -17,6 +17,7 @@ When cutting a new release of the parent `k8ssandra` chart update the `unrelease
 and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
+* [BUGFIX] Ensure Cassandra 4x is compatible with Stargate deployments by including `allow_alter_rf_during_range_movement` in config.
 * [ENHANCEMENT] Apply customizable filters on table level metrics in MCAC
 * [ENHANCEMENT] #1083 Add support for full query logging (Cassandra 4.0.0 feature)
 * [ENHANCEMENT] #1083 Add support for audit logging (Cassandra 4.0.0 feature)

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -193,6 +193,7 @@ spec:
         - "-Dcassandra.system_distributed_replication_dc_names={{ $datacenter.name }}"
         - "-Dcassandra.system_distributed_replication_per_dc={{ min 5 $datacenter.size }}"
 {{- end }}
+        - "-Dcassandra.allow_alter_rf_during_range_movement=true"
 {{- end }}
 {{- if not .Values.cassandra.loggingSidecar.enabled }}
   disableSystemLoggerSidecar: true

--- a/tests/unit/template_cassdc_test.go
+++ b/tests/unit/template_cassdc_test.go
@@ -1138,7 +1138,7 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 			Expect(config.CassandraConfig.PermissionsUpdateMillis).To(Equal(cacheUpdateInterval))
 			Expect(config.CassandraConfig.CredentialsValidityMillis).To(Equal(cacheValidityPeriod))
 			Expect(config.CassandraConfig.CredentialsUpdateMillis).To(Equal(cacheUpdateInterval))
-			Expect(config.JvmServerOptions.AdditionalJvmOptions).To(ConsistOf(
+			Expect(config.JvmServerOptions.AdditionalJvmOptions).To(ContainElements(
 				"-Dcassandra.system_distributed_replication_dc_names="+dcName,
 				"-Dcassandra.system_distributed_replication_per_dc="+strconv.Itoa(clusterSize),
 			))


### PR DESCRIPTION
**What this PR does**:

Adds `allow_alter_rf_during_range_movement` option in additional-jvm-options to ensure that Cassandra 4x's can mutate schemas when Stargate is in operation.

**Which issue(s) this PR fixes**:

#1026 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
