### PR TITLE
expose properties from cassandra.yaml [K8SSAND-793]

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -22,6 +22,7 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 * [ENHANCEMENT] #1083 Add support for client backpressure (Cassandra 4.0.0 feature)
 * [ENHANCEMENT] #1083 Add support for deployment of Cassandra 4.0.1
 * [ENHANCEMENT] #959 Root file system in Cassandra pod read only; security context for containers.
+* [ENHANCEMENT] #1023 Expose more properties from casssandra.yaml
 * [BUGFIX] #1129 CassOperator kills C* pods with due to incorrect memory
 * [BUGFIX] #1066 Azure backups are broken due to missing azure-cli deps
 * [BUGFIX] #1012 reaper-operator's role.yaml has more data than it should, causing role name conflicts

--- a/charts/k8ssandra/templates/_helpers.tpl
+++ b/charts/k8ssandra/templates/_helpers.tpl
@@ -411,3 +411,74 @@ Cassandra image (Management API image and version tag).
 {{- (printf (get .Values.cassandra.versionImageMap .Values.cassandra.version)) }}
 {{- end }}
 {{- end }}
+
+{{/*
+Generates properties specified in the .Values.cassandra.cassandraYaml properties.
+*/}}
+{{- define "k8ssandra.cassandraYaml" -}}
+{{- if . }}
+{{- if .concurrent_reads }}
+  {{ indent 4 (cat "concurrent_reads:" .concurrent_reads) }}
+{{- end }}
+{{- if .concurrent_writes }}
+  {{ indent 4 (cat "concurrent_writes:" .concurrent_writes) }}
+{{- end }}
+{{- if .concurrent_counter_writes }}
+  {{ indent 4 (cat "concurrent_counter_writes:" .concurrent_counter_writes) }}
+{{- end }}
+{{- if .row_cache_size_in_mb }}
+  {{ indent 4 (cat "row_cache_size_in_mb:" .row_cache_size_in_mb) }}
+{{- end }}
+{{- if .memtable_allocation_type }}
+  {{ indent 4 (cat "memtable_allocation_type:" .memtable_allocation_type) }}
+{{- end }}
+{{- if .memtable_flush_writers }}
+  {{ indent 4 (cat "memtable_flush_writers:" .memtable_flush_writers) }}
+{{- end }}
+{{- if .auto_snapshot }}
+  {{ indent 4 (cat "auto_snapshot:" .auto_snapshot) }}
+{{- end }}
+{{- if .concurrent_compactors }}
+  {{ indent 4 (cat "concurrent_compactors:" .concurrent_compactors) }}
+{{- end }}
+{{- if .slow_query_log_timeout_in_ms }}
+  {{ indent 4 (cat "slow_query_log_timeout_in_ms:" .slow_query_log_timeout_in_ms) }}
+{{- end }}
+{{- if .batch_size_warn_threshold_in_kb }}
+  {{ indent 4 (cat "batch_size_warn_threshold_in_kb:" .batch_size_warn_threshold_in_kb) }}
+{{- end }}
+{{- if .batch_size_fail_threshold_in_kb }}
+  {{ indent 4 (cat "batch_size_fail_threshold_in_kb:" .batch_size_fail_threshold_in_kb) }}
+{{- end }}
+{{- if .unlogged_batch_across_partitions_warn_threshold }}
+  {{ indent 4 (cat "unlogged_batch_across_partitions_warn_threshold:" .unlogged_batch_across_partitions_warn_threshold) }}
+{{- end }}
+{{- if .compaction_large_partition_warning_threshold_mb }}
+  {{ indent 4 (cat "compaction_large_partition_warning_threshold_mb:" .compaction_large_partition_warning_threshold_mb) }}
+{{- end }}
+{{- if .read_request_timeout_in_ms }}
+  {{ indent 4 (cat "read_request_timeout_in_ms:" .read_request_timeout_in_ms) }}
+{{- end }}
+{{- if .range_request_timeout_in_ms }}
+  {{ indent 4 (cat "range_request_timeout_in_ms:" .range_request_timeout_in_ms) }}
+{{- end }}
+{{- if .write_request_timeout_in_ms }}
+  {{ indent 4 (cat "write_request_timeout_in_ms:" .write_request_timeout_in_ms) }}
+{{- end }}
+{{- if .counter_write_request_timeout_in_ms }}
+  {{ indent 4 (cat "counter_write_request_timeout_in_ms:" .counter_write_request_timeout_in_ms) }}
+{{- end }}
+{{- if .cas_contention_timeout_in_ms }}
+  {{ indent 4 (cat "cas_contention_timeout_in_ms:" .cas_contention_timeout_in_ms) }}
+{{- end }}
+{{- if .truncate_request_timeout_in_ms }}
+  {{ indent 4 (cat "truncate_request_timeout_in_ms:" .truncate_request_timeout_in_ms) }}
+{{- end }}
+{{- if .request_timeout_in_ms }}
+  {{ indent 4 (cat "request_timeout_in_ms:" .request_timeout_in_ms) }}
+{{- end }}
+{{- if .file_cache_size_in_mb }}
+  {{ indent 4 (cat "file_cache_size_in_mb:" .file_cache_size_in_mb) }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -148,6 +148,69 @@ spec:
       permissions_update_interval_in_ms: {{ .Values.cassandra.auth.cacheUpdateIntervalMillis }}
       credentials_validity_in_ms: {{ .Values.cassandra.auth.cacheValidityPeriodMillis }}
       credentials_update_interval_in_ms: {{ .Values.cassandra.auth.cacheUpdateIntervalMillis }}
+    {{- if .Values.cassandra.cassandraYaml.concurrent_reads }}
+      concurrent_reads: {{ .Values.cassandra.cassandraYaml.concurrent_reads }}
+    {{- end }}
+    {{- if .Values.cassandra.cassandraYaml.concurrent_writes }}
+      concurrent_writes: {{ .Values.cassandra.cassandraYaml.concurrent_writes }}
+    {{- end }}
+    {{- if .Values.cassandra.cassandraYaml.concurrent_counter_writes }}
+      concurrent_counter_writes: {{ .Values.cassandra.cassandraYaml.concurrent_counter_writes }}
+    {{- end }}
+    {{- if .Values.cassandra.cassandraYaml.row_cache_size_in_mb }}
+      row_cache_size_in_mb: {{ .Values.cassandra.cassandraYaml.row_cache_size_in_mb }}
+    {{- end }}
+    {{- if .Values.cassandra.cassandraYaml.memtable_allocation_type }}
+      memtable_allocation_type: {{ .Values.cassandra.cassandraYaml.memtable_allocation_type }}
+    {{- end }}
+    {{- if .Values.cassandra.cassandraYaml.memtable_flush_writers }}
+      memtable_flush_writers: {{ .Values.cassandra.cassandraYaml.memtable_flush_writers }}
+    {{- end }}
+    {{- if .Values.cassandra.cassandraYaml.auto_snapshot }}
+      auto_snapshot: {{ .Values.cassandra.cassandraYaml.auto_snapshot }}
+    {{- end }}
+    {{- if .Values.cassandra.cassandraYaml.concurrent_compactors }}
+      concurrent_compactors: {{ .Values.cassandra.cassandraYaml.concurrent_compactors }}
+    {{- end }}
+    {{- if .Values.cassandra.cassandraYaml.slow_query_log_timeout_in_ms }}
+      slow_query_log_timeout_in_ms: {{ .Values.cassandra.cassandraYaml.slow_query_log_timeout_in_ms }}
+    {{- end }}
+    {{- if .Values.cassandra.cassandraYaml.batch_size_warn_threshold_in_kb }}
+      batch_size_warn_threshold_in_kb: {{ .Values.cassandra.cassandraYaml.batch_size_warn_threshold_in_kb }}
+    {{- end }}
+    {{- if .Values.cassandra.cassandraYaml.batch_size_fail_threshold_in_kb }}
+      batch_size_fail_threshold_in_kb: {{ .Values.cassandra.cassandraYaml.batch_size_fail_threshold_in_kb }}
+    {{- end }}
+    {{- if .Values.cassandra.cassandraYaml.unlogged_batch_across_partitions_warn_threshold }}
+      unlogged_batch_across_partitions_warn_threshold: {{ .Values.cassandra.cassandraYaml.unlogged_batch_across_partitions_warn_threshold }}
+    {{- end }}
+    {{- if .Values.cassandra.cassandraYaml.compaction_large_partition_warning_threshold_mb }}
+      compaction_large_partition_warning_threshold_mb: {{ .Values.cassandra.cassandraYaml.compaction_large_partition_warning_threshold_mb }}
+    {{- end }}
+    {{- if .Values.cassandra.cassandraYaml.read_request_timeout_in_ms }}
+      read_request_timeout_in_ms: {{ .Values.cassandra.cassandraYaml.read_request_timeout_in_ms }}
+    {{- end }}
+    {{- if .Values.cassandra.cassandraYaml.range_request_timeout_in_ms }}
+      range_request_timeout_in_ms: {{ .Values.cassandra.cassandraYaml.range_request_timeout_in_ms }}
+    {{- end }}
+    {{- if .Values.cassandra.cassandraYaml.write_request_timeout_in_ms }}
+      write_request_timeout_in_ms: {{ .Values.cassandra.cassandraYaml.write_request_timeout_in_ms }}
+    {{- end }}
+    {{- if .Values.cassandra.cassandraYaml.counter_write_request_timeout_in_ms }}
+      counter_write_request_timeout_in_ms: {{ .Values.cassandra.cassandraYaml.counter_write_request_timeout_in_ms }}
+    {{- end }}
+    {{- if .Values.cassandra.cassandraYaml.cas_contention_timeout_in_ms }}
+      cas_contention_timeout_in_ms: {{ .Values.cassandra.cassandraYaml.cas_contention_timeout_in_ms }}
+    {{- end }}
+    {{- if .Values.cassandra.cassandraYaml.truncate_request_timeout_in_ms }}
+      truncate_request_timeout_in_ms: {{ .Values.cassandra.cassandraYaml.truncate_request_timeout_in_ms }}
+    {{- end }}
+    {{- if .Values.cassandra.cassandraYaml.request_timeout_in_ms }}
+      request_timeout_in_ms: {{ .Values.cassandra.cassandraYaml.request_timeout_in_ms }}
+    {{- end }}
+    {{- if .Values.cassandra.cassandraYaml.file_cache_size_in_mb }}
+      file_cache_size_in_mb: {{ .Values.cassandra.cassandraYaml.file_cache_size_in_mb }}
+    {{- end }}
   {{- if $datacenter.fql }}
     {{- if $datacenter.fql.enabled }}
       {{- if (hasPrefix "3" .Values.cassandra.version) }}

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -148,69 +148,7 @@ spec:
       permissions_update_interval_in_ms: {{ .Values.cassandra.auth.cacheUpdateIntervalMillis }}
       credentials_validity_in_ms: {{ .Values.cassandra.auth.cacheValidityPeriodMillis }}
       credentials_update_interval_in_ms: {{ .Values.cassandra.auth.cacheUpdateIntervalMillis }}
-    {{- if .Values.cassandra.cassandraYaml.concurrent_reads }}
-      concurrent_reads: {{ .Values.cassandra.cassandraYaml.concurrent_reads }}
-    {{- end }}
-    {{- if .Values.cassandra.cassandraYaml.concurrent_writes }}
-      concurrent_writes: {{ .Values.cassandra.cassandraYaml.concurrent_writes }}
-    {{- end }}
-    {{- if .Values.cassandra.cassandraYaml.concurrent_counter_writes }}
-      concurrent_counter_writes: {{ .Values.cassandra.cassandraYaml.concurrent_counter_writes }}
-    {{- end }}
-    {{- if .Values.cassandra.cassandraYaml.row_cache_size_in_mb }}
-      row_cache_size_in_mb: {{ .Values.cassandra.cassandraYaml.row_cache_size_in_mb }}
-    {{- end }}
-    {{- if .Values.cassandra.cassandraYaml.memtable_allocation_type }}
-      memtable_allocation_type: {{ .Values.cassandra.cassandraYaml.memtable_allocation_type }}
-    {{- end }}
-    {{- if .Values.cassandra.cassandraYaml.memtable_flush_writers }}
-      memtable_flush_writers: {{ .Values.cassandra.cassandraYaml.memtable_flush_writers }}
-    {{- end }}
-    {{- if .Values.cassandra.cassandraYaml.auto_snapshot }}
-      auto_snapshot: {{ .Values.cassandra.cassandraYaml.auto_snapshot }}
-    {{- end }}
-    {{- if .Values.cassandra.cassandraYaml.concurrent_compactors }}
-      concurrent_compactors: {{ .Values.cassandra.cassandraYaml.concurrent_compactors }}
-    {{- end }}
-    {{- if .Values.cassandra.cassandraYaml.slow_query_log_timeout_in_ms }}
-      slow_query_log_timeout_in_ms: {{ .Values.cassandra.cassandraYaml.slow_query_log_timeout_in_ms }}
-    {{- end }}
-    {{- if .Values.cassandra.cassandraYaml.batch_size_warn_threshold_in_kb }}
-      batch_size_warn_threshold_in_kb: {{ .Values.cassandra.cassandraYaml.batch_size_warn_threshold_in_kb }}
-    {{- end }}
-    {{- if .Values.cassandra.cassandraYaml.batch_size_fail_threshold_in_kb }}
-      batch_size_fail_threshold_in_kb: {{ .Values.cassandra.cassandraYaml.batch_size_fail_threshold_in_kb }}
-    {{- end }}
-    {{- if .Values.cassandra.cassandraYaml.unlogged_batch_across_partitions_warn_threshold }}
-      unlogged_batch_across_partitions_warn_threshold: {{ .Values.cassandra.cassandraYaml.unlogged_batch_across_partitions_warn_threshold }}
-    {{- end }}
-    {{- if .Values.cassandra.cassandraYaml.compaction_large_partition_warning_threshold_mb }}
-      compaction_large_partition_warning_threshold_mb: {{ .Values.cassandra.cassandraYaml.compaction_large_partition_warning_threshold_mb }}
-    {{- end }}
-    {{- if .Values.cassandra.cassandraYaml.read_request_timeout_in_ms }}
-      read_request_timeout_in_ms: {{ .Values.cassandra.cassandraYaml.read_request_timeout_in_ms }}
-    {{- end }}
-    {{- if .Values.cassandra.cassandraYaml.range_request_timeout_in_ms }}
-      range_request_timeout_in_ms: {{ .Values.cassandra.cassandraYaml.range_request_timeout_in_ms }}
-    {{- end }}
-    {{- if .Values.cassandra.cassandraYaml.write_request_timeout_in_ms }}
-      write_request_timeout_in_ms: {{ .Values.cassandra.cassandraYaml.write_request_timeout_in_ms }}
-    {{- end }}
-    {{- if .Values.cassandra.cassandraYaml.counter_write_request_timeout_in_ms }}
-      counter_write_request_timeout_in_ms: {{ .Values.cassandra.cassandraYaml.counter_write_request_timeout_in_ms }}
-    {{- end }}
-    {{- if .Values.cassandra.cassandraYaml.cas_contention_timeout_in_ms }}
-      cas_contention_timeout_in_ms: {{ .Values.cassandra.cassandraYaml.cas_contention_timeout_in_ms }}
-    {{- end }}
-    {{- if .Values.cassandra.cassandraYaml.truncate_request_timeout_in_ms }}
-      truncate_request_timeout_in_ms: {{ .Values.cassandra.cassandraYaml.truncate_request_timeout_in_ms }}
-    {{- end }}
-    {{- if .Values.cassandra.cassandraYaml.request_timeout_in_ms }}
-      request_timeout_in_ms: {{ .Values.cassandra.cassandraYaml.request_timeout_in_ms }}
-    {{- end }}
-    {{- if .Values.cassandra.cassandraYaml.file_cache_size_in_mb }}
-      file_cache_size_in_mb: {{ .Values.cassandra.cassandraYaml.file_cache_size_in_mb }}
-    {{- end }}
+    {{- include "k8ssandra.cassandraYaml" .Values.cassandra.cassandraYaml }}
   {{- if $datacenter.fql }}
     {{- if $datacenter.fql.enabled }}
       {{- if (hasPrefix "3" .Values.cassandra.version) }}

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -173,6 +173,27 @@ cassandra:
       tag: 6c64f9c4
       # -- Pull policy for the system-logger image
       pullPolicy: IfNotPresent
+  # -- cassandraYaml directly configures properties in cassandra.yaml.
+  cassandraYaml:
+    # concurrent_reads:
+    # concurrent_writes:
+    # concurrent_counter_writes:
+    # row_cache_size_in_mb:
+    # memtable_allocation_type:
+    # memtable_flush_writers:
+    # auto_snapshot:
+    # concurrent_compactors:
+    # slow_query_log_timeout_in_ms:
+    # batch_size_warn_threshold_in_kb:
+    # unlogged_batch_across_partitions_warn_threshold:
+    # compaction_large_partition_warning_threshold_mb:
+    # read_request_timeout_in_ms:
+    # range_request_timeout_in_ms:
+    # counter_write_request_timeout_in_ms:
+    # cas_contention_timeout_in_ms:
+    # truncate_request_timeout_in_ms:
+    # request_timeout_in_ms:
+    # file_cache_size_in_mb:
   # -- Optional cluster-level heap configuration, can be overridden at `datacenters` level.
   # Options are commented out for reference. Note that k8ssandra does not
   # automatically apply default values for heap size. It instead defers to


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds a new chart property, `cassandraYaml` which exposes the following properties in cassandra.yaml:

* concurrent_reads
* concurrent_writes
* concurrent_counter_writes
* row_cache_size_in_mb
* memtable_allocation_type
* memtable_flush_writers
* auto_snapshot
* concurrent_compactors
* slow_query_log_timeout_in_ms
* batch_size_warn_threshold_in_kb
* unlogged_batch_across_partitions_warn_threshold
* compaction_large_partition_warning_threshold_mb
* read_request_timeout_in_ms
* range_request_timeout_in_ms
* counter_write_request_timeout_in_ms
* cas_contention_timeout_in_ms
* truncate_request_timeout_in_ms
* request_timeout_in_ms
* file_cache_size_in_mb

I chose the cassandra.yaml properties to include based off of what was requested in the issues. Not all properties requested in the issues are currently included. The PR only includes simple properties. Some properties like `commitlog_dir` will require a bit more work as we need to configure an additional PVC.

I have decided to only expose the `cassandraYaml` property at the cluster level since the chart will only ever support a single-DC install. Not sure if this will cause any confusion.

Some cassandra.yaml properties are set by other chart properties such as `cassandra.auth.enabled`, and the `fql`, and `audit_logging`. Should the corresponding cassandra.yaml properties also be configurable via the `cassandraYaml` chart property?

**Which issue(s) this PR fixes**:
Fixes #1023, #1166

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
