### PR TITLE
Custom cassandra.yaml for Cassandra and Stargate [K8SSAND-793][K8SSAND-1036][K8SSAND-1038][K8SSAND-1044]

### DIFF
--- a/.github/workflows/integration-tests-release.yaml
+++ b/.github/workflows/integration-tests-release.yaml
@@ -79,7 +79,17 @@ jobs:
       matrix:
         k8s_version: ["${{ github.event.inputs.kubernetes_version }}"]
         cassandra_version: ["3.11.10", "4.0.0"]
-        scenario: ["TestMedusaDeploymentScenario/\"S3\"", "TestMedusaDeploymentScenario/\"Minio\"", "TestMedusaDeploymentScenario/\"local\"", "TestMedusaDeploymentScenario/\"azure_blobs\"", "TestReaperDeploymentScenario", "TestMonitoringDeploymentScenario", "TestStargateDeploymentScenario", "TestRestoreAfterUpgrade", "TestUpgradeScenario"]
+        scenario:
+          - "TestMedusaDeploymentScenario/\"S3\""
+          - "TestMedusaDeploymentScenario/\"Minio\""
+          - "TestMedusaDeploymentScenario/\"local\""
+          - "TestMedusaDeploymentScenario/\"azure_blobs\""
+          - "TestReaperDeploymentScenario"
+          - "TestMonitoringDeploymentScenario"
+          - "TestStargateDeploymentScenario"
+          - "TestRestoreAfterUpgrade"
+          - "TestUpgradeScenario"
+          - "TestCustomCassandraConfiguration"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -19,8 +19,7 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 ## unreleased
 * [CHANGE] Update to Reaper 3.0.0
 * [CHANGE] #1118 Update to Stargate 1.0.40
-* [CHANGE] #950 Update to cass-operator 1.8.0-rc.1
-* [CHANGE] Update to cass-operator v1.8.0
+* [CHANGE] #1119 Update to cass-operator v1.8.0
 * [FEATURE] #1023, #1166, #1169, #1177 Allow custom cassandra.yaml ConfigMap for Cassandra and Stargate
 * [ENHANCEMENT] Apply customizable filters on table level metrics in MCAC
 * [ENHANCEMENT] #1140 securityContext defaults for operators and security foundations 
@@ -32,14 +31,10 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 * [ENHANCEMENT] #1083 Add support for deployment of Cassandra 4.0.1
 * [ENHANCEMENT] #874 expose cass-operator AdditionalServiceConfig in k8ssandra helm chart values.yaml
 * [ENHANCEMENT] #959 Root file system in Cassandra pod read only; security context for containers.
+* [ENHANCEMENT] #874 expose cass-operator AdditionalServiceConfig in k8ssandra helm chart values.yaml
 * [BUGFIX] Ensure Cassandra 4x is compatible with Stargate deployments by including `allow_alter_rf_during_range_movement` in config.
 * [BUGFIX] #1129 CassOperator kills C* pods with due to incorrect memory
 * [BUGFIX] #1066 Azure backups are broken due to missing azure-cli deps
 * [BUGFIX] #1012 reaper-operator's role.yaml has more data than it should, causing role name conflicts
 * [BUGFIX] #1018 reaper image registry typo and jvm typo fixed
 * [BUGFIX] #1029 Do not change num_tokens when upgrading
-* [ENHANCEMENT] #874 expose cass-operator AdditionalServiceConfig in k8ssandra helm chart values.yaml
-* [CHANGE] Update to Reaper 3.0.0
-* [CHANGE] #1118 Update to Stargate 1.0.40
-* [CHANGE] #950 Update to cass-operator 1.8.0-rc.1
-* [CHANGE] Update to cass-operator v1.8.0

--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -25,9 +25,9 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 * [ENHANCEMENT] #1140 securityContext defaults for operators and security foundations 
 * [ENHANCEMENT] #1150 Bring reaper resources and CRDs up to date with main reaper-operator repo; operator-sdk 1.6.1/controller-runtime 0.9.2.
 * [ENHANCEMENT] #1150 Update CRD versions to v1 from v1beta1 allowing compatibility with k8s 1.22.
-* [ENHANCEMENT] #1083 Add support for full query logging (Cassandra 4.0.0 feature)
-* [ENHANCEMENT] #1083 Add support for audit logging (Cassandra 4.0.0 feature)
-* [ENHANCEMENT] #1083 Add support for client backpressure (Cassandra 4.0.0 feature)
+* [ENHANCEMENT] #1102 Add support for full query logging (Cassandra 4.0.0 feature)
+* [ENHANCEMENT] #1102 Add support for audit logging (Cassandra 4.0.0 feature)
+* [ENHANCEMENT] #1102 Add support for client backpressure (Cassandra 4.0.0 feature)
 * [ENHANCEMENT] #1083 Add support for deployment of Cassandra 4.0.1
 * [ENHANCEMENT] #874 expose cass-operator AdditionalServiceConfig in k8ssandra helm chart values.yaml
 * [ENHANCEMENT] #959 Root file system in Cassandra pod read only; security context for containers.

--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -21,7 +21,7 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 * [CHANGE] #1118 Update to Stargate 1.0.40
 * [CHANGE] #950 Update to cass-operator 1.8.0-rc.1
 * [CHANGE] Update to cass-operator v1.8.0
-* [ENHANCEMENT] #1179 Make `JAVA_OPTS` configurable for Stargate
+* [FEATURE] #1023, #1166, #1169, #1177 Allow custom cassandra.yaml ConfigMap for Cassandra and Stargate
 * [ENHANCEMENT] Apply customizable filters on table level metrics in MCAC
 * [ENHANCEMENT] #1140 securityContext defaults for operators and security foundations 
 * [ENHANCEMENT] #1150 Bring reaper resources and CRDs up to date with main reaper-operator repo; operator-sdk 1.6.1/controller-runtime 0.9.2.
@@ -30,12 +30,16 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 * [ENHANCEMENT] #1083 Add support for audit logging (Cassandra 4.0.0 feature)
 * [ENHANCEMENT] #1083 Add support for client backpressure (Cassandra 4.0.0 feature)
 * [ENHANCEMENT] #1083 Add support for deployment of Cassandra 4.0.1
-* [ENHANCEMENT] #959 Root file system in Cassandra pod read only; security context for containers.
 * [ENHANCEMENT] #874 expose cass-operator AdditionalServiceConfig in k8ssandra helm chart values.yaml
-* [BUGFIX] #1181 Update k8ssandra-operator chart
+* [ENHANCEMENT] #959 Root file system in Cassandra pod read only; security context for containers.
+* [BUGFIX] Ensure Cassandra 4x is compatible with Stargate deployments by including `allow_alter_rf_during_range_movement` in config.
 * [BUGFIX] #1129 CassOperator kills C* pods with due to incorrect memory
 * [BUGFIX] #1066 Azure backups are broken due to missing azure-cli deps
 * [BUGFIX] #1012 reaper-operator's role.yaml has more data than it should, causing role name conflicts
 * [BUGFIX] #1018 reaper image registry typo and jvm typo fixed
 * [BUGFIX] #1029 Do not change num_tokens when upgrading
-* [BUGFIX] Ensure Cassandra 4x is compatible with Stargate deployments by including `allow_alter_rf_during_range_movement` in config
+* [ENHANCEMENT] #874 expose cass-operator AdditionalServiceConfig in k8ssandra helm chart values.yaml
+* [CHANGE] Update to Reaper 3.0.0
+* [CHANGE] #1118 Update to Stargate 1.0.40
+* [CHANGE] #950 Update to cass-operator 1.8.0-rc.1
+* [CHANGE] Update to cass-operator v1.8.0

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -222,6 +222,21 @@ spec:
           {{- end }}
       - name: server-config-init
         securityContext: {{- toYaml .Values.cassandra.configBuilder.securityContext | nindent 10 }}
+    {{- if .Values.cassandra.cassandraYamlConfigMap }}
+      - name: apply-custom-config
+        image: {{ include "k8ssandra-common.flattenedImage" .Values.cassandra.applyCustomConfig.image }}
+        imagePullPolicy: {{ .Values.cassandra.applyCustomConfig.image.pullPolicy }}
+        command:
+          - /bin/sh
+          - -c
+        args:
+          - yq eval-all 'select(fileIndex == 0) * select(fileIndex == 1)' /config/cassandra.yaml /cassandra-custom-config/cassandra.yaml > /config/merged-cassandra.yaml && mv /config/merged-cassandra.yaml /config/cassandra.yaml
+        volumeMounts:
+          - name: cassandra-custom-config
+            mountPath: /cassandra-custom-config
+          - name: server-config
+            mountPath: /config
+    {{- end }}
      {{- if (or .Values.cassandra.auth.enabled .Values.reaper.enabled) }}
       - name: jmx-credentials
         image: {{ include "k8ssandra-common.flattenedImage" .Values.cassandra.jmxCredentialsConfig.image }}
@@ -355,6 +370,11 @@ spec:
         emptyDir: {}
       - name: cassandra-tmp
         emptyDir: {}
+      {{- if .Values.cassandra.cassandraYamlConfigMap }}
+      - name: cassandra-custom-config
+        configMap:
+          name: {{ .Values.cassandra.cassandraYamlConfigMap }}
+      {{- end }}
       {{- if .Values.reaper.enabled }}
       - name: reaper-config
         emptyDir: {}

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -322,13 +322,28 @@ spec:
             value: {{ printf "%s" (join " " .Values.cassandra.metric_filters) }}
           {{- end }}
         {{- end }}
-       {{- if .Values.medusa.enabled }}
+
         volumeMounts:
+          {{- if .Values.medusa.enabled }}
           - name: cassandra-config
             mountPath: /etc/cassandra
           - name: podinfo
             mountPath: /etc/podinfo
-        {{- end }}
+          {{- end }}
+          {{- if .Values.cassandra.encryption.keystoreSecret }}
+          {{- if not .Values.cassandra.encryption.keystoreMountPath }}
+            {{- (fail (print "keystoreMountPath must be set when keystoreSecret is set")) }}
+          {{- end }}
+          - name: keystore-secret
+            mountPath: {{ .Values.cassandra.encryption.keystoreMountPath }}
+          {{- end}}
+          {{- if .Values.cassandra.encryption.truststoreSecret }}
+          {{- if not .Values.cassandra.encryption.truststoreMountPath }}
+          {{- (fail (print "truststoreMountPath must be set when keystoreSecret is set")) }}
+          {{- end }}
+          - name: truststore-secret
+            mountPath: {{ .Values.cassandra.encryption.truststoreMountPath }}
+        {{- end}}
       {{- if .Values.medusa.enabled }}
       - name: medusa
         image: {{ include "k8ssandra-common.flattenedImage" .Values.medusa.image }}
@@ -378,6 +393,16 @@ spec:
       {{- if .Values.reaper.enabled }}
       - name: reaper-config
         emptyDir: {}
+      {{- end }}
+      {{- if .Values.cassandra.encryption.keystoreSecret }}
+      - name: keystore-secret
+        secret:
+          secretName: {{ .Values.cassandra.encryption.keystoreSecret }}
+      {{- end }}
+      {{- if .Values.cassandra.encryption.truststoreSecret }}
+      - name: truststore-secret
+        secret:
+          secretName: {{ .Values.cassandra.encryption.truststoreSecret }}
       {{- end }}
       {{- if .Values.medusa.enabled }}
       - name: podinfo

--- a/charts/k8ssandra/templates/stargate/stargate.yaml
+++ b/charts/k8ssandra/templates/stargate/stargate.yaml
@@ -127,9 +127,11 @@ spec:
             timeoutSeconds: 10
             initialDelaySeconds: {{ .Values.stargate.readinessInitialDelaySeconds }}
             failureThreshold: 5
+          {{- if .Values.stargate.cassandraYamlConfigMap }}
           volumeMounts:
             - mountPath: /config
               name: cassandra-config
+          {{- end }}
       {{- if .Values.stargate.affinity }}
       affinity: {{ toYaml .Values.stargate.affinity | nindent 8 }}
       {{- end }}

--- a/charts/k8ssandra/templates/stargate/stargate.yaml
+++ b/charts/k8ssandra/templates/stargate/stargate.yaml
@@ -93,6 +93,9 @@ spec:
                 -XX:+CrashOnOutOfMemoryError
                 -Xms{{ $heapMB }}M
                 -Xmx{{ $heapMB }}M
+                {{- if .Values.stargate.cassandraYamlConfigMap }}
+                -Dstargate.unsafe.cassandra_config_path=/config/cassandra.yaml
+                {{- end}}
                 {{- range .Values.stargate.javaOpts }}
                 {{ . }}
                 {{- end }}
@@ -124,10 +127,19 @@ spec:
             timeoutSeconds: 10
             initialDelaySeconds: {{ .Values.stargate.readinessInitialDelaySeconds }}
             failureThreshold: 5
+          volumeMounts:
+            - mountPath: /config
+              name: cassandra-config
       {{- if .Values.stargate.affinity }}
       affinity: {{ toYaml .Values.stargate.affinity | nindent 8 }}
       {{- end }}
       {{- if .Values.stargate.tolerations }}
       tolerations: {{ toYaml .Values.stargate.tolerations | nindent 6 }}
+      {{- end }}
+      {{- if .Values.stargate.cassandraYamlConfigMap }}
+      volumes:
+        - name: cassandra-config
+          configMap:
+            name: {{ .Values.stargate.cassandraYamlConfigMap }}
       {{- end }}
 {{- end }}

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -430,6 +430,9 @@ stargate:
   # Cassandra cluster nodes. Each instance handles API and coordination tasks
   # for inbound queries.
   replicas: 1
+    # -- Specifies the name of a ConfigMap that contains a custom cassandra.yaml. The
+  # ConfigMap should have a key named cassandra.yaml.  
+  cassandraYamlConfigMap:
   # -- The wait-for-cassandra init container in the Stargate Deployment
   waitForCassandra:
     image:

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -61,6 +61,18 @@ cassandra:
       tag: 1.0.4
       # -- Pull policy for the config builder image
       pullPolicy: IfNotPresent
+  # -- The apply-custom-config init container that is deployed when the cassandraYaml
+  # property is set.
+  applyCustomConfig:
+    image:
+      # -- Container registry for the apply-custom-config container
+      registry: docker.io
+      # -- Repository for the apply-custom-config image
+      repository: mikefarah/yq
+      # -- Tag of the apply-custom-config image to pull from
+      tag: 4.14.1
+      # -- Pull policy for the apply-custom-config image
+      pullPolicy: IfNotPresent
   # -- The jmx-credentials init container that configures JMX credentials.
   jmxCredentialsConfig:
     # -- Security context override for jmx init container
@@ -125,6 +137,22 @@ cassandra:
     # highly dependent on data model and compaction strategies in use. Consider
     # testing with your data model to find an optimal value for your usecase.
     size: 5Gi
+  # -- Specifies the name of a ConfigMap that contains a custom cassandra.yaml. The
+  # ConfigMap should have a key named cassandra.yaml. The values will be merged with the
+  # base configuration. The following properties should NOT be specified in the ConfigMap:
+  #
+  #    * cluster_name
+  #    * seed_provider
+  #    * authenticator
+  #    * authorizer
+  #    * commitlog_directory
+  #    * data_file_directories
+  #    * saved_caches_directory
+  #    * hints_directory
+  #    * endpoint_snitch
+  #    * server_encryption_options
+  #    * client_encryption_options
+  cassandraYamlConfigMap:
   # -- Permits running multiple Cassandra pods per Kubernetes worker. If enabled
   # resources.limits and resources.requests **must** be defined.
   allowMultipleNodesPerWorker: false

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -150,9 +150,21 @@ cassandra:
   #    * saved_caches_directory
   #    * hints_directory
   #    * endpoint_snitch
-  #    * server_encryption_options
-  #    * client_encryption_options
   cassandraYamlConfigMap:
+  # -- Specifies properties for configuring internode and client encryption. Specifically,
+  # secrets are specified for which volumes and volume mounts are created. Internode
+  # and client encryption should otherwise be configured through the cassandraYamlConfigMap
+  # property.
+  encryption:
+    # -- A secret that contains the keystore.
+    keystoreSecret:
+    # -- Path in the cassandra container at which the keystore secret should be mounted.
+    keystoreMountPath:
+    # -- A secret that contains the truststore.
+    truststoreSecret:
+    # truststoreKey:
+    # -- Path in the cassandra container at which the truststore secret should be mounted.
+    truststoreMountPath:
   # -- Permits running multiple Cassandra pods per Kubernetes worker. If enabled
   # resources.limits and resources.requests **must** be defined.
   allowMultipleNodesPerWorker: false

--- a/tests/integration/charts/cluster_with_custom_config.yaml
+++ b/tests/integration/charts/cluster_with_custom_config.yaml
@@ -1,0 +1,20 @@
+cassandra:
+  heap:
+    size: 500M
+    newGenSize: 200M
+  cassandraYamlConfigMap: cassandra-config
+  datacenters:
+    - name: dc1
+      size: 1
+
+stargate:
+  enabled: false
+
+reaper:
+  enabled: false
+
+kube-prometheus-stack:
+  # -- Controls whether the kube-prometheus-stack chart is used at all.
+  # Disabling this parameter prevents all monitoring components from being
+  # installed.
+  enabled: false

--- a/tests/integration/testdata/cassandra-config.yaml
+++ b/tests/integration/testdata/cassandra-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cassandra-config
+data:
+  cassandra.yaml: |-
+    read_request_timeout_in_ms: 90000
+    range_request_timeout_in_ms: 90000
+    write_request_timeout_in_ms: 90000


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds a `cassandraYamlConfigMap` property for Cassandra and Stargate. The property specifies a ConfigMap that contains a custom cassandra.yaml. The custom cassandra.yaml is merged with the base config.

As noted in the comments in values.yaml, there are a number of properties that should not be specified in the custom cassandra.yaml. Some properties, like those that require setting up volumes and mounts need to be handled separately. Others are generated elsehwere in the the cassdc.yaml template.

**Which issue(s) this PR fixes**:
Fixes #1023, #1166, #1169, #1177

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
