### PR TITLE
don't declare an empty volumeMounts

### DIFF
--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -323,6 +323,7 @@ spec:
           {{- end }}
         {{- end }}
 
+        {{- if or .Values.medusa.enabled .Values.cassandra.encryption.keystoreSecret }}
         volumeMounts:
           {{- if .Values.medusa.enabled }}
           - name: cassandra-config
@@ -344,6 +345,8 @@ spec:
           - name: truststore-secret
             mountPath: {{ .Values.cassandra.encryption.truststoreMountPath }}
         {{- end}}
+        {{- end }}
+
       {{- if .Values.medusa.enabled }}
       - name: medusa
         image: {{ include "k8ssandra-common.flattenedImage" .Values.medusa.image }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This is a follow up to #1180. An empty volumeMounts fails on k8s versions earlier than 1.21 with this error:

`Error: CassandraDatacenter.cassandra.datastax.com "dc1" is invalid: spec.podTemplateSpec.spec.containers.volumeMounts: Invalid value: "null": spec.podTemplateSpec.spec.containers.volumeMounts in body must be of type array: null`

This commit makes sure we avoid an empty volumeMounts property.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
