### PR TITLE
don't create empty (i.e., null) containers in Reaper object

### DIFF
--- a/charts/k8ssandra/templates/reaper/reaper.yaml
+++ b/charts/k8ssandra/templates/reaper/reaper.yaml
@@ -32,14 +32,14 @@ spec:
   {{- if .Values.reaper.tolerations }}
   tolerations: {{ toYaml .Values.reaper.tolerations | nindent 4 }}
   {{- end }}
+  {{- if (and .Values.reaper.schemaInitContainerConfig .Values.reaper.schemaInitContainerConfig.securityContext) }}
   schemaInitContainerConfig:
-    {{- if (and .Values.reaper.schemaInitContainerConfig .Values.reaper.schemaInitContainerConfig.securityContext) }}
     securityContext: {{ toYaml .Values.reaper.schemaInitContainerConfig.securityContext | nindent 6 }}
-    {{- end }}
+  {{- end }}
+  {{- if (and .Values.reaper.configInitContainerConfig .Values.reaper.configInitContainerConfig.securityContext) }}
   configInitContainerConfig:
-    {{- if (and .Values.reaper.configInitContainerConfig .Values.reaper.configInitContainerConfig.securityContext) }}
     securityContext: {{ toYaml .Values.reaper.configInitContainerConfig.securityContext | nindent 6 }}
-    {{- end }}
+  {{- end }}
   podSecurityContext: {{- toYaml .Values.reaper.podSecurityContext | nindent 4 }}
   securityContext: {{- toYaml .Values.reaper.securityContext | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
On k8s versions < 1.21 creation of the Reaper object can fail with this:

`Error: Reaper.reaper.cassandra-reaper.io "k8ssandra-reaper" is invalid: spec.schemaInitContainerConfig: Invalid value: "null": spec.schemaInitContainerConfig in body must be of type object: null`

This commit fixes it by not creating empty containers.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
