### PR TITLE
Remove pod level SecurityContext to fix permissions issue [K8SSAND-1071]

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -16,6 +16,9 @@ last).
 When cutting a new release of the parent `k8ssandra` chart update the `unreleased` heading to the tag being generated 
 and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
+## unreleased
+* [BUGFIX] Remove pod level SecurityContext to fix permissions issue on Cassandra data dir creation
+
 ## v1.4.0 - 2021-11-19
 * [CHANGE] Update to Managment API v0.1.33
 * [CHANGE] Update to Medusa 0.11.3

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -198,7 +198,6 @@ spec:
 {{- end }}
   podTemplateSpec:
     spec:
-      securityContext: {{- toYaml .Values.cassandra.podSecurityContext | nindent 8 }}
       initContainers:
       - name: base-config-init
         image: {{ include "k8ssandra.cassandraImage" . }}

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -42,8 +42,6 @@ cassandra:
   # -- Security context override for cassandra container
   securityContext: {}
 
-  # -- Security context override for pod where Cassandra container resides
-  podSecurityContext: {}
   # -- Cassandra base init container
   baseConfig:
     # -- Security context override for base init container


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Reverts the addition of pod level `securityContext` on the Cassandra pods.
These prevented Cassandra data dir creation due to improper rights on `/var/lib/cassandra`.

**Which issue(s) this PR fixes**:
Fixes #1206

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
