### PR TITLE
Add clusterName cleanup similar to cass-operator to k8ssandra [K8SSAND-873]

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -18,6 +18,7 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 
 ## unreleased
 * [BUGFIX] Remove pod level SecurityContext to fix permissions issue on Cassandra data dir creation
+* [BUGFIX] #1208 Helm charts did not follow cass-operator's cleanup rules for clusterName to allow "broken" clusterNames which do not conform to DNS rules.
 
 ## v1.4.0 - 2021-11-19
 * [CHANGE] Update to Managment API v0.1.33

--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -17,5 +17,3 @@ When cutting a new release of the parent `k8ssandra` chart update the `unrelease
 and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
-
-* [BUGFIX] #1208 Helm charts did not follow cass-operator's cleanup rules for clusterName to allow "broken" clusterNames which do not conform to DNS rules.

--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -17,3 +17,5 @@ When cutting a new release of the parent `k8ssandra` chart update the `unrelease
 and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
+
+* [BUGFIX] #1208 Helm charts did not follow cass-operator's cleanup rules for clusterName to allow "broken" clusterNames which do not conform to DNS rules.

--- a/charts/k8ssandra/templates/_helpers.tpl
+++ b/charts/k8ssandra/templates/_helpers.tpl
@@ -10,7 +10,10 @@ Expand the name of the chart.
 Cluster name definition.
 */}}
 {{- define "k8ssandra.clusterName" -}}
-{{- default .Release.Name .Values.cassandra.clusterName }}
+{{- $clusterName := lower .Values.cassandra.clusterName | replace " " "-" | replace "_" "-" }}
+{{- $matchAll := mustRegexFindAll "[a-z]([-a-z0-9]*[a-z0-9])?" $clusterName -1 }}
+{{- $final := join "" $matchAll }}
+{{- default .Release.Name $final }}
 {{- end }}
 
 {{/*

--- a/tests/unit/template_cassdc_test.go
+++ b/tests/unit/template_cassdc_test.go
@@ -175,6 +175,19 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 			Expect(cassdc.Spec.ClusterName).To(Equal(clusterName))
 		})
 
+		It("override clusterName with invalid form", func() {
+			clusterName := "MrDvrCassandraTv3t"
+			options := &helm.Options{
+				KubectlOptions: defaultKubeCtlOptions,
+				SetValues: map[string]string{
+					"cassandra.clusterName": clusterName,
+				},
+			}
+
+			Expect(renderTemplate(options)).To(Succeed())
+			Expect(cassdc.Spec.ClusterName).To(Equal("mrdvrcassandratv3t"))
+		})
+
 		It("default clusterName as release name", func() {
 			clusterName := ""
 			options := &helm.Options{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds similar clusterName cleanup to our Helm templates as we have in cass-operator. This is because some of the resources created by k8ssandra helm charts are not using cass-operator's logic.

Allows "broken" clusterNames which do not conform to DNS rules.

**Which issue(s) this PR fixes**:
Fixes #1090

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
