### PR TITLE
Upgrade Reaper dependency 3.0.0 -> 3.1.0

### DIFF
--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -595,7 +595,7 @@ reaper:
     # -- Image repository for reaper
     repository: thelastpickle/cassandra-reaper
     # -- Tag of the reaper image to pull from
-    tag: 3.0.0
+    tag: 3.1.0
     # -- Pull policy for the reaper container
     pullPolicy: IfNotPresent
   # -- Configures the Cassandra user used by Reaper when authentication is


### PR DESCRIPTION
This is auto-generated update from the K8ssandra upgrade GHA workflow.
Check that CI passes correctly before merging this PR.