### PR TITLE
Add prometheus related permissions to k8ssandra-operator role.

### DIFF
--- a/charts/k8ssandra-operator/templates/role.yaml
+++ b/charts/k8ssandra-operator/templates/role.yaml
@@ -17,6 +17,19 @@ rules:
       - update
       - watch
   - apiGroups:
+    - monitoring.coreos.com
+    resources:
+    - servicemonitors
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
       - cassandra.datastax.com
     resources:
       - cassandradatacenters


### PR DESCRIPTION
**What this PR does**:

Adds RBAC permissions to the k8ssandra-operator role. This gives the controller permissions to reconcile Prometheus ServiceMonitors which is required by the telemetry functionality implemented under #234, #236.

**Which issue(s) this PR fixes**:
Fixes #1224 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
