### PR TITLE
several k8ssandra-operator chart updates [K8SSAND-1128][K8SSAND-1129]

### DIFF
--- a/charts/cass-operator/Chart.yaml
+++ b/charts/cass-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: cass-operator
 description: |
   Kubernetes operator which handles the provisioning and management of Apache Cassandra clusters.
 type: application
-version: 0.32.0
+version: 0.33.0
 appVersion: 1.9.0
 dependencies:
   - name: k8ssandra-common

--- a/charts/cass-operator/templates/deployment.yaml
+++ b/charts/cass-operator/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
             - name: ENABLE_VMWARE_PSP
               value: "true"
             {{- end }}
-            {{- if .Values.clusterScoped }}
+            {{- if .Values.global.clusterScoped }}
             - name: WATCH_NAMESPACE
               value: ""
             {{- else }}

--- a/charts/cass-operator/templates/role.yaml
+++ b/charts/cass-operator/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clusterScoped }}
+{{- if .Values.global.clusterScoped }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/cass-operator/templates/rolebinding.yaml
+++ b/charts/cass-operator/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clusterScoped }}
+{{- if .Values.global.clusterScoped }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/cass-operator/values.yaml
+++ b/charts/cass-operator/values.yaml
@@ -1,3 +1,9 @@
+global:
+  # -- Determines whether cass-operator only watch and manages
+  # CassandraDatacenters in the same namespace in which the operator is deployed
+  # or if watches and manages CassandraDatacenters across all namespaces.
+  clusterScoped: false
+
 # -- A name in place of the chart name which is used in the metadata.name of
 # objects created by this chart.
 nameOverride: ''
@@ -11,11 +17,6 @@ commonLabels: {}
 
 # -- Sets the number of cass-operator pods.
 replicaCount: 1
-
-# -- Determines whether cass-operator only watch and manages
-# CassandraDatacenters in the same namespace in which the operator is deployed
-# or if watches and manages CassandraDatacenters across all namespaces.
-clusterScoped: false
 
 # -- Configures admission webhooks deployed with cass-operator.
 admissionWebhooks:

--- a/charts/k8ssandra-operator/Chart.yaml
+++ b/charts/k8ssandra-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: k8ssandra-operator
 description: |
   Kubernetes operator which handles the provisioning and management of K8ssandra clusters.
 type: application
-version: 0.32.0
+version: 0.33.0
 appVersion: 1.0.0
 dependencies:
   - name: k8ssandra-common

--- a/charts/k8ssandra-operator/Chart.yaml
+++ b/charts/k8ssandra-operator/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: 0.28.4
     repository: file://../k8ssandra-common
   - name: cass-operator
-    version: 0.32.0
+    version: 0.33.0
     repository: file://../cass-operator
 home: https://github.com/k8ssandra/k8ssandra-operator
 sources:

--- a/charts/k8ssandra-operator/crds/k8ssandra.io_k8ssandraclusters.yaml
+++ b/charts/k8ssandra-operator/crds/k8ssandra.io_k8ssandraclusters.yaml
@@ -12,6 +12,9 @@ spec:
     kind: K8ssandraCluster
     listKind: K8ssandraClusterList
     plural: k8ssandraclusters
+    shortNames:
+      - k8c
+      - k8cs
     singular: k8ssandracluster
   scope: Namespaced
   versions:
@@ -41,6 +44,27 @@ spec:
                     cluster where each DC should be deployed, node affinity (via racks),
                     individual C* node settings, JVM settings, and more.
                   properties:
+                    cassandraTelemetry:
+                      description: CassandraTelemetry defines the desired state for
+                        telemetry resources in this K8ssandraCluster. If telemetry configurations
+                        are defined, telemetry resources will be deployed to integrate
+                        with a user-provided monitoring solution (at present, only support
+                        for Prometheus is available).
+                      properties:
+                        prometheus:
+                          properties:
+                            commonLabels:
+                              additionalProperties:
+                                type: string
+                              description: CommonLabels are applied to all serviceMonitors
+                                created.
+                              type: object
+                            enabled:
+                              description: Enable the creation of Prometheus serviceMonitors
+                                for this resource (Cassandra or Stargate).
+                              type: boolean
+                          type: object
+                      type: object
                     cluster:
                       description: Cluster is the name of the cluster. This corresponds
                         to cluster_name in cassandra.yaml.
@@ -116,6 +140,27 @@ spec:
                       description: Datacenters a list of the DCs in the cluster.
                       items:
                         properties:
+                          cassandraTelemetry:
+                            description: Telemetry defines the desired state for telemetry
+                              resources in this datacenter. If telemetry configurations
+                              are defined, telemetry resources will be deployed to integrate
+                              with a user-provided monitoring solution (at present,
+                              only support for Prometheus is available).
+                            properties:
+                              prometheus:
+                                properties:
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonLabels are applied to all serviceMonitors
+                                      created.
+                                    type: object
+                                  enabled:
+                                    description: Enable the creation of Prometheus serviceMonitors
+                                      for this resource (Cassandra or Stargate).
+                                    type: boolean
+                                type: object
+                            type: object
                           k8sContext:
                             type: string
                           metadata:
@@ -135,6 +180,14 @@ spec:
                             required:
                               - name
                             type: object
+                          mgmtAPIHeap:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            description: MgmtAPIHeap defines the amount of memory devoted
+                              to the management api heap.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           networking:
                             description: Networking enables host networking and configures
                               a NodePort ports.
@@ -175,6 +228,2021 @@ spec:
                                 - name
                               type: object
                             type: array
+                          reaper:
+                            description: Reaper defines the desired deployment characteristics
+                              for Reaper in this datacenter. Leave nil to skip deploying
+                              Reaper in this datacenter.
+                            properties:
+                              ServiceAccountName:
+                                default: default
+                                type: string
+                              affinity:
+                                description: Affinity applied to the Reaper pods.
+                                properties:
+                                  nodeAffinity:
+                                    description: Describes node affinity scheduling
+                                      rules for the pod.
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to schedule
+                                          pods to nodes that satisfy the affinity expressions
+                                          specified by this field, but it may choose
+                                          a node that violates one or more of the expressions.
+                                          The node that is most preferred is the one
+                                          with the greatest sum of weights, i.e. for
+                                          each node that meets all of the scheduling
+                                          requirements (resource request, requiredDuringScheduling
+                                          affinity expressions, etc.), compute a sum
+                                          by iterating through the elements of this
+                                          field and adding "weight" to the sum if the
+                                          node matches the corresponding matchExpressions;
+                                          the node(s) with the highest sum are the most
+                                          preferred.
+                                        items:
+                                          description: An empty preferred scheduling
+                                            term matches all objects with implicit weight
+                                            0 (i.e. it's a no-op). A null preferred
+                                            scheduling term matches no objects (i.e.
+                                            is also a no-op).
+                                          properties:
+                                            preference:
+                                              description: A node selector term, associated
+                                                with the corresponding weight.
+                                              properties:
+                                                matchExpressions:
+                                                  description: A list of node selector
+                                                    requirements by node's labels.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains values,
+                                                      a key, and an operator that relates
+                                                      the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key that
+                                                          the selector applies to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a key's
+                                                          relationship to a set of values.
+                                                          Valid operators are In, NotIn,
+                                                          Exists, DoesNotExist. Gt,
+                                                          and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator is
+                                                          In or NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be empty.
+                                                          If the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which will
+                                                          be interpreted as an integer.
+                                                          This array is replaced during
+                                                          a strategic merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                      - key
+                                                      - operator
+                                                    type: object
+                                                  type: array
+                                                matchFields:
+                                                  description: A list of node selector
+                                                    requirements by node's fields.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains values,
+                                                      a key, and an operator that relates
+                                                      the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key that
+                                                          the selector applies to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a key's
+                                                          relationship to a set of values.
+                                                          Valid operators are In, NotIn,
+                                                          Exists, DoesNotExist. Gt,
+                                                          and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator is
+                                                          In or NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be empty.
+                                                          If the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which will
+                                                          be interpreted as an integer.
+                                                          This array is replaced during
+                                                          a strategic merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                      - key
+                                                      - operator
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            weight:
+                                              description: Weight associated with matching
+                                                the corresponding nodeSelectorTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                            - preference
+                                            - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the affinity requirements specified
+                                          by this field are not met at scheduling time,
+                                          the pod will not be scheduled onto the node.
+                                          If the affinity requirements specified by
+                                          this field cease to be met at some point during
+                                          pod execution (e.g. due to an update), the
+                                          system may or may not try to eventually evict
+                                          the pod from its node.
+                                        properties:
+                                          nodeSelectorTerms:
+                                            description: Required. A list of node selector
+                                              terms. The terms are ORed.
+                                            items:
+                                              description: A null or empty node selector
+                                                term matches no objects. The requirements
+                                                of them are ANDed. The TopologySelectorTerm
+                                                type implements a subset of the NodeSelectorTerm.
+                                              properties:
+                                                matchExpressions:
+                                                  description: A list of node selector
+                                                    requirements by node's labels.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains values,
+                                                      a key, and an operator that relates
+                                                      the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key that
+                                                          the selector applies to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a key's
+                                                          relationship to a set of values.
+                                                          Valid operators are In, NotIn,
+                                                          Exists, DoesNotExist. Gt,
+                                                          and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator is
+                                                          In or NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be empty.
+                                                          If the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which will
+                                                          be interpreted as an integer.
+                                                          This array is replaced during
+                                                          a strategic merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                      - key
+                                                      - operator
+                                                    type: object
+                                                  type: array
+                                                matchFields:
+                                                  description: A list of node selector
+                                                    requirements by node's fields.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains values,
+                                                      a key, and an operator that relates
+                                                      the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key that
+                                                          the selector applies to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a key's
+                                                          relationship to a set of values.
+                                                          Valid operators are In, NotIn,
+                                                          Exists, DoesNotExist. Gt,
+                                                          and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator is
+                                                          In or NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be empty.
+                                                          If the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which will
+                                                          be interpreted as an integer.
+                                                          This array is replaced during
+                                                          a strategic merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                      - key
+                                                      - operator
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            type: array
+                                        required:
+                                          - nodeSelectorTerms
+                                        type: object
+                                    type: object
+                                  podAffinity:
+                                    description: Describes pod affinity scheduling rules
+                                      (e.g. co-locate this pod in the same node, zone,
+                                      etc. as some other pod(s)).
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to schedule
+                                          pods to nodes that satisfy the affinity expressions
+                                          specified by this field, but it may choose
+                                          a node that violates one or more of the expressions.
+                                          The node that is most preferred is the one
+                                          with the greatest sum of weights, i.e. for
+                                          each node that meets all of the scheduling
+                                          requirements (resource request, requiredDuringScheduling
+                                          affinity expressions, etc.), compute a sum
+                                          by iterating through the elements of this
+                                          field and adding "weight" to the sum if the
+                                          node has pods which matches the corresponding
+                                          podAffinityTerm; the node(s) with the highest
+                                          sum are the most preferred.
+                                        items:
+                                          description: The weights of all of the matched
+                                            WeightedPodAffinityTerm fields are added
+                                            per-node to find the most preferred node(s)
+                                          properties:
+                                            podAffinityTerm:
+                                              description: Required. A pod affinity
+                                                term, associated with the corresponding
+                                                weight.
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over a
+                                                    set of resources, in this case pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a key,
+                                                          and an operator that relates
+                                                          the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator represents
+                                                              a key's relationship to
+                                                              a set of values. Valid
+                                                              operators are In, NotIn,
+                                                              Exists and DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is an
+                                                              array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the values
+                                                              array must be empty. This
+                                                              array is replaced during
+                                                              a strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                          - key
+                                                          - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is a
+                                                        map of {key,value} pairs. A
+                                                        single {key,value} in the matchLabels
+                                                        map is equivalent to an element
+                                                        of matchExpressions, whose key
+                                                        field is "key", the operator
+                                                        is "In", and the values array
+                                                        contains only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over the
+                                                    set of namespaces that the term
+                                                    applies to. The term is applied
+                                                    to the union of the namespaces selected
+                                                    by this field and the ones listed
+                                                    in the namespaces field. null selector
+                                                    and null or empty namespaces list
+                                                    means "this pod's namespace". An
+                                                    empty selector ({}) matches all
+                                                    namespaces. This field is beta-level
+                                                    and is only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a key,
+                                                          and an operator that relates
+                                                          the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator represents
+                                                              a key's relationship to
+                                                              a set of values. Valid
+                                                              operators are In, NotIn,
+                                                              Exists and DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is an
+                                                              array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the values
+                                                              array must be empty. This
+                                                              array is replaced during
+                                                              a strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                          - key
+                                                          - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is a
+                                                        map of {key,value} pairs. A
+                                                        single {key,value} in the matchLabels
+                                                        map is equivalent to an element
+                                                        of matchExpressions, whose key
+                                                        field is "key", the operator
+                                                        is "In", and the values array
+                                                        contains only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The term
+                                                    is applied to the union of the namespaces
+                                                    listed in this field and the ones
+                                                    selected by namespaceSelector. null
+                                                    or empty namespaces list and null
+                                                    namespaceSelector means "this pod's
+                                                    namespace"
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be co-located
+                                                    (affinity) or not co-located (anti-affinity)
+                                                    with the pods matching the labelSelector
+                                                    in the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                                - topologyKey
+                                              type: object
+                                            weight:
+                                              description: weight associated with matching
+                                                the corresponding podAffinityTerm, in
+                                                the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                            - podAffinityTerm
+                                            - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the affinity requirements specified
+                                          by this field are not met at scheduling time,
+                                          the pod will not be scheduled onto the node.
+                                          If the affinity requirements specified by
+                                          this field cease to be met at some point during
+                                          pod execution (e.g. due to a pod label update),
+                                          the system may or may not try to eventually
+                                          evict the pod from its node. When there are
+                                          multiple elements, the lists of nodes corresponding
+                                          to each podAffinityTerm are intersected, i.e.
+                                          all terms must be satisfied.
+                                        items:
+                                          description: Defines a set of pods (namely
+                                            those matching the labelSelector relative
+                                            to the given namespace(s)) that this pod
+                                            should be co-located (affinity) or not co-located
+                                            (anti-affinity) with, where co-located is
+                                            defined as running on a node whose value
+                                            of the label with key <topologyKey> matches
+                                            that of any node on which a pod of the set
+                                            of pods is running
+                                          properties:
+                                            labelSelector:
+                                              description: A label query over a set
+                                                of resources, in this case pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is a
+                                                    list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector requirement
+                                                      is a selector that contains values,
+                                                      a key, and an operator that relates
+                                                      the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an array
+                                                          of string values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty. If
+                                                          the operator is Exists or
+                                                          DoesNotExist, the values array
+                                                          must be empty. This array
+                                                          is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                      - key
+                                                      - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single {key,value}
+                                                    in the matchLabels map is equivalent
+                                                    to an element of matchExpressions,
+                                                    whose key field is "key", the operator
+                                                    is "In", and the values array contains
+                                                    only "value". The requirements are
+                                                    ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaceSelector:
+                                              description: A label query over the set
+                                                of namespaces that the term applies
+                                                to. The term is applied to the union
+                                                of the namespaces selected by this field
+                                                and the ones listed in the namespaces
+                                                field. null selector and null or empty
+                                                namespaces list means "this pod's namespace".
+                                                An empty selector ({}) matches all namespaces.
+                                                This field is beta-level and is only
+                                                honored when PodAffinityNamespaceSelector
+                                                feature is enabled.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is a
+                                                    list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector requirement
+                                                      is a selector that contains values,
+                                                      a key, and an operator that relates
+                                                      the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an array
+                                                          of string values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty. If
+                                                          the operator is Exists or
+                                                          DoesNotExist, the values array
+                                                          must be empty. This array
+                                                          is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                      - key
+                                                      - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single {key,value}
+                                                    in the matchLabels map is equivalent
+                                                    to an element of matchExpressions,
+                                                    whose key field is "key", the operator
+                                                    is "In", and the values array contains
+                                                    only "value". The requirements are
+                                                    ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              description: namespaces specifies a static
+                                                list of namespace names that the term
+                                                applies to. The term is applied to the
+                                                union of the namespaces listed in this
+                                                field and the ones selected by namespaceSelector.
+                                                null or empty namespaces list and null
+                                                namespaceSelector means "this pod's
+                                                namespace"
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              description: This pod should be co-located
+                                                (affinity) or not co-located (anti-affinity)
+                                                with the pods matching the labelSelector
+                                                in the specified namespaces, where co-located
+                                                is defined as running on a node whose
+                                                value of the label with key topologyKey
+                                                matches that of any node on which any
+                                                of the selected pods is running. Empty
+                                                topologyKey is not allowed.
+                                              type: string
+                                          required:
+                                            - topologyKey
+                                          type: object
+                                        type: array
+                                    type: object
+                                  podAntiAffinity:
+                                    description: Describes pod anti-affinity scheduling
+                                      rules (e.g. avoid putting this pod in the same
+                                      node, zone, etc. as some other pod(s)).
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to schedule
+                                          pods to nodes that satisfy the anti-affinity
+                                          expressions specified by this field, but it
+                                          may choose a node that violates one or more
+                                          of the expressions. The node that is most
+                                          preferred is the one with the greatest sum
+                                          of weights, i.e. for each node that meets
+                                          all of the scheduling requirements (resource
+                                          request, requiredDuringScheduling anti-affinity
+                                          expressions, etc.), compute a sum by iterating
+                                          through the elements of this field and adding
+                                          "weight" to the sum if the node has pods which
+                                          matches the corresponding podAffinityTerm;
+                                          the node(s) with the highest sum are the most
+                                          preferred.
+                                        items:
+                                          description: The weights of all of the matched
+                                            WeightedPodAffinityTerm fields are added
+                                            per-node to find the most preferred node(s)
+                                          properties:
+                                            podAffinityTerm:
+                                              description: Required. A pod affinity
+                                                term, associated with the corresponding
+                                                weight.
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over a
+                                                    set of resources, in this case pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a key,
+                                                          and an operator that relates
+                                                          the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator represents
+                                                              a key's relationship to
+                                                              a set of values. Valid
+                                                              operators are In, NotIn,
+                                                              Exists and DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is an
+                                                              array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the values
+                                                              array must be empty. This
+                                                              array is replaced during
+                                                              a strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                          - key
+                                                          - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is a
+                                                        map of {key,value} pairs. A
+                                                        single {key,value} in the matchLabels
+                                                        map is equivalent to an element
+                                                        of matchExpressions, whose key
+                                                        field is "key", the operator
+                                                        is "In", and the values array
+                                                        contains only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over the
+                                                    set of namespaces that the term
+                                                    applies to. The term is applied
+                                                    to the union of the namespaces selected
+                                                    by this field and the ones listed
+                                                    in the namespaces field. null selector
+                                                    and null or empty namespaces list
+                                                    means "this pod's namespace". An
+                                                    empty selector ({}) matches all
+                                                    namespaces. This field is beta-level
+                                                    and is only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a key,
+                                                          and an operator that relates
+                                                          the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator represents
+                                                              a key's relationship to
+                                                              a set of values. Valid
+                                                              operators are In, NotIn,
+                                                              Exists and DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is an
+                                                              array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the values
+                                                              array must be empty. This
+                                                              array is replaced during
+                                                              a strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                          - key
+                                                          - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is a
+                                                        map of {key,value} pairs. A
+                                                        single {key,value} in the matchLabels
+                                                        map is equivalent to an element
+                                                        of matchExpressions, whose key
+                                                        field is "key", the operator
+                                                        is "In", and the values array
+                                                        contains only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The term
+                                                    is applied to the union of the namespaces
+                                                    listed in this field and the ones
+                                                    selected by namespaceSelector. null
+                                                    or empty namespaces list and null
+                                                    namespaceSelector means "this pod's
+                                                    namespace"
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be co-located
+                                                    (affinity) or not co-located (anti-affinity)
+                                                    with the pods matching the labelSelector
+                                                    in the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                                - topologyKey
+                                              type: object
+                                            weight:
+                                              description: weight associated with matching
+                                                the corresponding podAffinityTerm, in
+                                                the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                            - podAffinityTerm
+                                            - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the anti-affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto the
+                                          node. If the anti-affinity requirements specified
+                                          by this field cease to be met at some point
+                                          during pod execution (e.g. due to a pod label
+                                          update), the system may or may not try to
+                                          eventually evict the pod from its node. When
+                                          there are multiple elements, the lists of
+                                          nodes corresponding to each podAffinityTerm
+                                          are intersected, i.e. all terms must be satisfied.
+                                        items:
+                                          description: Defines a set of pods (namely
+                                            those matching the labelSelector relative
+                                            to the given namespace(s)) that this pod
+                                            should be co-located (affinity) or not co-located
+                                            (anti-affinity) with, where co-located is
+                                            defined as running on a node whose value
+                                            of the label with key <topologyKey> matches
+                                            that of any node on which a pod of the set
+                                            of pods is running
+                                          properties:
+                                            labelSelector:
+                                              description: A label query over a set
+                                                of resources, in this case pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is a
+                                                    list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector requirement
+                                                      is a selector that contains values,
+                                                      a key, and an operator that relates
+                                                      the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an array
+                                                          of string values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty. If
+                                                          the operator is Exists or
+                                                          DoesNotExist, the values array
+                                                          must be empty. This array
+                                                          is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                      - key
+                                                      - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single {key,value}
+                                                    in the matchLabels map is equivalent
+                                                    to an element of matchExpressions,
+                                                    whose key field is "key", the operator
+                                                    is "In", and the values array contains
+                                                    only "value". The requirements are
+                                                    ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaceSelector:
+                                              description: A label query over the set
+                                                of namespaces that the term applies
+                                                to. The term is applied to the union
+                                                of the namespaces selected by this field
+                                                and the ones listed in the namespaces
+                                                field. null selector and null or empty
+                                                namespaces list means "this pod's namespace".
+                                                An empty selector ({}) matches all namespaces.
+                                                This field is beta-level and is only
+                                                honored when PodAffinityNamespaceSelector
+                                                feature is enabled.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is a
+                                                    list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector requirement
+                                                      is a selector that contains values,
+                                                      a key, and an operator that relates
+                                                      the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an array
+                                                          of string values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty. If
+                                                          the operator is Exists or
+                                                          DoesNotExist, the values array
+                                                          must be empty. This array
+                                                          is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                      - key
+                                                      - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single {key,value}
+                                                    in the matchLabels map is equivalent
+                                                    to an element of matchExpressions,
+                                                    whose key field is "key", the operator
+                                                    is "In", and the values array contains
+                                                    only "value". The requirements are
+                                                    ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              description: namespaces specifies a static
+                                                list of namespace names that the term
+                                                applies to. The term is applied to the
+                                                union of the namespaces listed in this
+                                                field and the ones selected by namespaceSelector.
+                                                null or empty namespaces list and null
+                                                namespaceSelector means "this pod's
+                                                namespace"
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              description: This pod should be co-located
+                                                (affinity) or not co-located (anti-affinity)
+                                                with the pods matching the labelSelector
+                                                in the specified namespaces, where co-located
+                                                is defined as running on a node whose
+                                                value of the label with key topologyKey
+                                                matches that of any node on which any
+                                                of the selected pods is running. Empty
+                                                topologyKey is not allowed.
+                                              type: string
+                                          required:
+                                            - topologyKey
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              autoScheduling:
+                                description: Auto scheduling properties. When you enable
+                                  the auto-schedule feature, Reaper dynamically schedules
+                                  repairs for all non-system keyspaces in a cluster.
+                                  A cluster's keyspaces are monitored and any modifications
+                                  (additions or removals) are detected. When a new keyspace
+                                  is created, a new repair schedule is created automatically
+                                  for that keyspace. Conversely, when a keyspace is
+                                  removed, the corresponding repair schedule is deleted.
+                                properties:
+                                  enabled:
+                                    default: false
+                                    type: boolean
+                                  excludedClusters:
+                                    description: ExcludedClusters are the clusters that
+                                      are to be excluded from the repair schedule.
+                                    items:
+                                      type: string
+                                    type: array
+                                  excludedKeyspaces:
+                                    description: ExcludedKeyspaces are the keyspaces
+                                      that are to be excluded from the repair schedule.
+                                    items:
+                                      type: string
+                                    type: array
+                                  initialDelayPeriod:
+                                    default: PT15S
+                                    description: InitialDelay is the amount of delay
+                                      time before the schedule period starts. Must be
+                                      a valid ISO-8601 duration string. The default
+                                      is "PT15S" (15 seconds).
+                                    pattern: ([-+]?)P(?:([-+]?[0-9]+)D)?(T(?:([-+]?[0-9]+)H)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)(?:[.,]([0-9]{0,9}))?S)?)?
+                                    type: string
+                                  percentUnrepairedThreshold:
+                                    default: 10
+                                    description: PercentUnrepairedThreshold is the percentage
+                                      of unrepaired data over which an incremental repair
+                                      should be started. Only relevant when using repair
+                                      type INCREMENTAL.
+                                    maximum: 100
+                                    minimum: 0
+                                    type: integer
+                                  periodBetweenPolls:
+                                    default: PT10M
+                                    description: PeriodBetweenPolls is the interval
+                                      time to wait before checking whether to start
+                                      a repair task. Must be a valid ISO-8601 duration
+                                      string. The default is "PT10M" (10 minutes).
+                                    pattern: ([-+]?)P(?:([-+]?[0-9]+)D)?(T(?:([-+]?[0-9]+)H)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)(?:[.,]([0-9]{0,9}))?S)?)?
+                                    type: string
+                                  repairType:
+                                    default: AUTO
+                                    description: 'RepairType is the type of repair to
+                                    create: - REGULAR creates a regular repair (non-adaptive
+                                    and non-incremental); - ADAPTIVE creates an adaptive
+                                    repair; adaptive repairs are most suited for Cassandra
+                                    3. - INCREMENTAL creates an incremental repair;
+                                    incremental repairs should only be used with Cassandra
+                                    4+. - AUTO chooses between ADAPTIVE and INCREMENTAL
+                                    depending on the Cassandra server version; ADAPTIVE
+                                    for Cassandra 3 and INCREMENTAL for Cassandra
+                                    4+.'
+                                    enum:
+                                      - REGULAR
+                                      - ADAPTIVE
+                                      - INCREMENTAL
+                                      - AUTO
+                                    type: string
+                                  scheduleSpreadPeriod:
+                                    default: PT6H
+                                    description: ScheduleSpreadPeriod is the time spacing
+                                      between each of the repair schedules that is to
+                                      be carried out. Must be a valid ISO-8601 duration
+                                      string. The default is "PT6H" (6 hours).
+                                    pattern: ([-+]?)P(?:([-+]?[0-9]+)D)?(T(?:([-+]?[0-9]+)H)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)(?:[.,]([0-9]{0,9}))?S)?)?
+                                    type: string
+                                  timeBeforeFirstSchedule:
+                                    default: PT5M
+                                    description: TimeBeforeFirstSchedule is the grace
+                                      period before the first repair in the schedule
+                                      is started. Must be a valid ISO-8601 duration
+                                      string. The default is "PT5M" (5 minutes).
+                                    pattern: ([-+]?)P(?:([-+]?[0-9]+)D)?(T(?:([-+]?[0-9]+)H)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)(?:[.,]([0-9]{0,9}))?S)?)?
+                                    type: string
+                                type: object
+                              containerImage:
+                                default:
+                                  name: cassandra-reaper
+                                  repository: thelastpickle
+                                  tag: 3.1.0
+                                description: The image to use for the Reaper pod main
+                                  container. The default is "thelastpickle/cassandra-reaper:3.1.0".
+                                properties:
+                                  name:
+                                    description: The image name to use.
+                                    type: string
+                                  pullPolicy:
+                                    description: The image pull policy to use. Defaults
+                                      to "Always" if the tag is "latest", otherwise
+                                      to "IfNotPresent".
+                                    enum:
+                                      - Always
+                                      - IfNotPresent
+                                      - Never
+                                    type: string
+                                  pullSecretRef:
+                                    description: 'The secret to use when pulling the
+                                    image from private repositories. If specified,
+                                    this secret will be passed to individual puller
+                                    implementations for them to use. For example,
+                                    in the case of Docker, only DockerConfig type
+                                    secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                        type: string
+                                    type: object
+                                  registry:
+                                    default: docker.io
+                                    description: The Docker registry to use. Defaults
+                                      to "docker.io", the official Docker Hub.
+                                    type: string
+                                  repository:
+                                    description: The Docker repository to use.
+                                    type: string
+                                  tag:
+                                    default: latest
+                                    description: The image tag to use. Defaults to "latest".
+                                    type: string
+                                type: object
+                              initContainerImage:
+                                default:
+                                  name: cassandra-reaper
+                                  repository: thelastpickle
+                                  tag: 3.1.0
+                                description: The image to use for tje Reaper pod init
+                                  container (that performs schema migrations). The default
+                                  is "thelastpickle/cassandra-reaper:3.1.0".
+                                properties:
+                                  name:
+                                    description: The image name to use.
+                                    type: string
+                                  pullPolicy:
+                                    description: The image pull policy to use. Defaults
+                                      to "Always" if the tag is "latest", otherwise
+                                      to "IfNotPresent".
+                                    enum:
+                                      - Always
+                                      - IfNotPresent
+                                      - Never
+                                    type: string
+                                  pullSecretRef:
+                                    description: 'The secret to use when pulling the
+                                    image from private repositories. If specified,
+                                    this secret will be passed to individual puller
+                                    implementations for them to use. For example,
+                                    in the case of Docker, only DockerConfig type
+                                    secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                        type: string
+                                    type: object
+                                  registry:
+                                    default: docker.io
+                                    description: The Docker registry to use. Defaults
+                                      to "docker.io", the official Docker Hub.
+                                    type: string
+                                  repository:
+                                    description: The Docker repository to use.
+                                    type: string
+                                  tag:
+                                    default: latest
+                                    description: The image tag to use. Defaults to "latest".
+                                    type: string
+                                type: object
+                              initContainerSecurityContext:
+                                description: InitContainerSecurityContext is the SecurityContext
+                                  applied to the Reaper init container, used to perform
+                                  schema migrations.
+                                properties:
+                                  allowPrivilegeEscalation:
+                                    description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN'
+                                    type: boolean
+                                  capabilities:
+                                    description: The capabilities to add/drop when running
+                                      containers. Defaults to the default set of capabilities
+                                      granted by the container runtime.
+                                    properties:
+                                      add:
+                                        description: Added capabilities
+                                        items:
+                                          description: Capability represent POSIX capabilities
+                                            type
+                                          type: string
+                                        type: array
+                                      drop:
+                                        description: Removed capabilities
+                                        items:
+                                          description: Capability represent POSIX capabilities
+                                            type
+                                          type: string
+                                        type: array
+                                    type: object
+                                  privileged:
+                                    description: Run container in privileged mode. Processes
+                                      in privileged containers are essentially equivalent
+                                      to root on the host. Defaults to false.
+                                    type: boolean
+                                  procMount:
+                                    description: procMount denotes the type of proc
+                                      mount to use for the containers. The default is
+                                      DefaultProcMount which uses the container runtime
+                                      defaults for readonly paths and masked paths.
+                                      This requires the ProcMountType feature flag to
+                                      be enabled.
+                                    type: string
+                                  readOnlyRootFilesystem:
+                                    description: Whether this container has a read-only
+                                      root filesystem. Default is false.
+                                    type: boolean
+                                  runAsGroup:
+                                    description: The GID to run the entrypoint of the
+                                      container process. Uses runtime default if unset.
+                                      May also be set in PodSecurityContext.  If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes precedence.
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    description: Indicates that the container must run
+                                      as a non-root user. If true, the Kubelet will
+                                      validate the image at runtime to ensure that it
+                                      does not run as UID 0 (root) and fail to start
+                                      the container if it does. If unset or false, no
+                                      such validation will be performed. May also be
+                                      set in PodSecurityContext.  If set in both SecurityContext
+                                      and PodSecurityContext, the value specified in
+                                      SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: The UID to run the entrypoint of the
+                                      container process. Defaults to user specified
+                                      in image metadata if unspecified. May also be
+                                      set in PodSecurityContext.  If set in both SecurityContext
+                                      and PodSecurityContext, the value specified in
+                                      SecurityContext takes precedence.
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    description: The SELinux context to be applied to
+                                      the container. If unspecified, the container runtime
+                                      will allocate a random SELinux context for each
+                                      container.  May also be set in PodSecurityContext.  If
+                                      set in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes precedence.
+                                    properties:
+                                      level:
+                                        description: Level is SELinux level label that
+                                          applies to the container.
+                                        type: string
+                                      role:
+                                        description: Role is a SELinux role label that
+                                          applies to the container.
+                                        type: string
+                                      type:
+                                        description: Type is a SELinux type label that
+                                          applies to the container.
+                                        type: string
+                                      user:
+                                        description: User is a SELinux user label that
+                                          applies to the container.
+                                        type: string
+                                    type: object
+                                  seccompProfile:
+                                    description: The seccomp options to use by this
+                                      container. If seccomp options are provided at
+                                      both the pod & container level, the container
+                                      options override the pod options.
+                                    properties:
+                                      localhostProfile:
+                                        description: localhostProfile indicates a profile
+                                          defined in a file on the node should be used.
+                                          The profile must be preconfigured on the node
+                                          to work. Must be a descending path, relative
+                                          to the kubelet's configured seccomp profile
+                                          location. Must only be set if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: "type indicates which kind of seccomp
+                                        profile will be applied. Valid options are:
+                                        \n Localhost - a profile defined in a file
+                                        on the node should be used. RuntimeDefault
+                                        - the container runtime default profile should
+                                        be used. Unconfined - no profile should be
+                                        applied."
+                                        type: string
+                                    required:
+                                      - type
+                                    type: object
+                                  windowsOptions:
+                                    description: The Windows specific settings applied
+                                      to all containers. If unspecified, the options
+                                      from the PodSecurityContext will be used. If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes precedence.
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        description: GMSACredentialSpec is where the
+                                          GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                          inlines the contents of the GMSA credential
+                                          spec named by the GMSACredentialSpecName field.
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        description: GMSACredentialSpecName is the name
+                                          of the GMSA credential spec to use.
+                                        type: string
+                                      hostProcess:
+                                        description: HostProcess determines if a container
+                                          should be run as a 'Host Process' container.
+                                          This field is alpha-level and will only be
+                                          honored by components that enable the WindowsHostProcessContainers
+                                          feature flag. Setting this field without the
+                                          feature flag will result in errors when validating
+                                          the Pod. All of a Pod's containers must have
+                                          the same effective HostProcess value (it is
+                                          not allowed to have a mix of HostProcess containers
+                                          and non-HostProcess containers).  In addition,
+                                          if HostProcess is true then HostNetwork must
+                                          also be set to true.
+                                        type: boolean
+                                      runAsUserName:
+                                        description: The UserName in Windows to run
+                                          the entrypoint of the container process. Defaults
+                                          to the user specified in image metadata if
+                                          unspecified. May also be set in PodSecurityContext.
+                                          If set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        type: string
+                                    type: object
+                                type: object
+                              livenessProbe:
+                                description: LivenessProbe sets the Reaper liveness
+                                  probe. Leave nil to use defaults.
+                                properties:
+                                  exec:
+                                    description: One and only one of the following should
+                                      be specified. Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/') in
+                                          the container's filesystem. The command is
+                                          simply exec'd, it is not run inside a shell,
+                                          so traditional shell instructions ('|', etc)
+                                          won't work. To use a shell, you need to explicitly
+                                          call out to that shell. Exit status of 0 is
+                                          treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    description: Minimum consecutive failures for the
+                                      probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set "Host"
+                                          in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request.
+                                          HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: Name or number of the port to access
+                                          on the container. Number must be in the range
+                                          1 to 65535. Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: Scheme to use for connecting to
+                                          the host. Defaults to HTTP.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: How often (in seconds) to perform the
+                                      probe. Default to 10 seconds. Minimum value is
+                                      1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: Minimum consecutive successes for the
+                                      probe to be considered successful after having
+                                      failed. Defaults to 1. Must be 1 for liveness
+                                      and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: Number or name of the port to access
+                                          on the container. Number must be in the range
+                                          1 to 65535. Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: Optional duration in seconds the pod
+                                      needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after
+                                      the processes running in the pod are sent a termination
+                                      signal and the time when the processes are forcibly
+                                      halted with a kill signal. Set this value longer
+                                      than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds
+                                      will be used. Otherwise, this value overrides
+                                      the value provided by the pod spec. Value must
+                                      be non-negative integer. The value zero indicates
+                                      stop immediately via the kill signal (no opportunity
+                                      to shut down). This is a beta field and requires
+                                      enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds
+                                      is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    format: int32
+                                    type: integer
+                                type: object
+                              podSecurityContext:
+                                description: PodSecurityContext contains a pod-level
+                                  SecurityContext to apply to Reaper pods.
+                                properties:
+                                  fsGroup:
+                                    description: "A special supplemental group that
+                                    applies to all containers in a pod. Some volume
+                                    types allow the Kubelet to change the ownership
+                                    of that volume to be owned by the pod: \n 1. The
+                                    owning GID will be the FSGroup 2. The setgid bit
+                                    is set (new files created in the volume will be
+                                    owned by FSGroup) 3. The permission bits are OR'd
+                                    with rw-rw---- \n If unset, the Kubelet will not
+                                    modify the ownership and permissions of any volume."
+                                    format: int64
+                                    type: integer
+                                  fsGroupChangePolicy:
+                                    description: 'fsGroupChangePolicy defines behavior
+                                    of changing ownership and permission of the volume
+                                    before being exposed inside Pod. This field will
+                                    only apply to volume types which support fsGroup
+                                    based ownership(and permissions). It will have
+                                    no effect on ephemeral volume types such as: secret,
+                                    configmaps and emptydir. Valid values are "OnRootMismatch"
+                                    and "Always". If not specified, "Always" is used.'
+                                    type: string
+                                  runAsGroup:
+                                    description: The GID to run the entrypoint of the
+                                      container process. Uses runtime default if unset.
+                                      May also be set in SecurityContext.  If set in
+                                      both SecurityContext and PodSecurityContext, the
+                                      value specified in SecurityContext takes precedence
+                                      for that container.
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    description: Indicates that the container must run
+                                      as a non-root user. If true, the Kubelet will
+                                      validate the image at runtime to ensure that it
+                                      does not run as UID 0 (root) and fail to start
+                                      the container if it does. If unset or false, no
+                                      such validation will be performed. May also be
+                                      set in SecurityContext.  If set in both SecurityContext
+                                      and PodSecurityContext, the value specified in
+                                      SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: The UID to run the entrypoint of the
+                                      container process. Defaults to user specified
+                                      in image metadata if unspecified. May also be
+                                      set in SecurityContext.  If set in both SecurityContext
+                                      and PodSecurityContext, the value specified in
+                                      SecurityContext takes precedence for that container.
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    description: The SELinux context to be applied to
+                                      all containers. If unspecified, the container
+                                      runtime will allocate a random SELinux context
+                                      for each container.  May also be set in SecurityContext.  If
+                                      set in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes precedence
+                                      for that container.
+                                    properties:
+                                      level:
+                                        description: Level is SELinux level label that
+                                          applies to the container.
+                                        type: string
+                                      role:
+                                        description: Role is a SELinux role label that
+                                          applies to the container.
+                                        type: string
+                                      type:
+                                        description: Type is a SELinux type label that
+                                          applies to the container.
+                                        type: string
+                                      user:
+                                        description: User is a SELinux user label that
+                                          applies to the container.
+                                        type: string
+                                    type: object
+                                  seccompProfile:
+                                    description: The seccomp options to use by the containers
+                                      in this pod.
+                                    properties:
+                                      localhostProfile:
+                                        description: localhostProfile indicates a profile
+                                          defined in a file on the node should be used.
+                                          The profile must be preconfigured on the node
+                                          to work. Must be a descending path, relative
+                                          to the kubelet's configured seccomp profile
+                                          location. Must only be set if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: "type indicates which kind of seccomp
+                                        profile will be applied. Valid options are:
+                                        \n Localhost - a profile defined in a file
+                                        on the node should be used. RuntimeDefault
+                                        - the container runtime default profile should
+                                        be used. Unconfined - no profile should be
+                                        applied."
+                                        type: string
+                                    required:
+                                      - type
+                                    type: object
+                                  supplementalGroups:
+                                    description: A list of groups applied to the first
+                                      process run in each container, in addition to
+                                      the container's primary GID.  If unspecified,
+                                      no groups will be added to any container.
+                                    items:
+                                      format: int64
+                                      type: integer
+                                    type: array
+                                  sysctls:
+                                    description: Sysctls hold a list of namespaced sysctls
+                                      used for the pod. Pods with unsupported sysctls
+                                      (by the container runtime) might fail to launch.
+                                    items:
+                                      description: Sysctl defines a kernel parameter
+                                        to be set
+                                      properties:
+                                        name:
+                                          description: Name of a property to set
+                                          type: string
+                                        value:
+                                          description: Value of a property to set
+                                          type: string
+                                      required:
+                                        - name
+                                        - value
+                                      type: object
+                                    type: array
+                                  windowsOptions:
+                                    description: The Windows specific settings applied
+                                      to all containers. If unspecified, the options
+                                      within a container's SecurityContext will be used.
+                                      If set in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes precedence.
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        description: GMSACredentialSpec is where the
+                                          GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                          inlines the contents of the GMSA credential
+                                          spec named by the GMSACredentialSpecName field.
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        description: GMSACredentialSpecName is the name
+                                          of the GMSA credential spec to use.
+                                        type: string
+                                      hostProcess:
+                                        description: HostProcess determines if a container
+                                          should be run as a 'Host Process' container.
+                                          This field is alpha-level and will only be
+                                          honored by components that enable the WindowsHostProcessContainers
+                                          feature flag. Setting this field without the
+                                          feature flag will result in errors when validating
+                                          the Pod. All of a Pod's containers must have
+                                          the same effective HostProcess value (it is
+                                          not allowed to have a mix of HostProcess containers
+                                          and non-HostProcess containers).  In addition,
+                                          if HostProcess is true then HostNetwork must
+                                          also be set to true.
+                                        type: boolean
+                                      runAsUserName:
+                                        description: The UserName in Windows to run
+                                          the entrypoint of the container process. Defaults
+                                          to the user specified in image metadata if
+                                          unspecified. May also be set in PodSecurityContext.
+                                          If set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        type: string
+                                    type: object
+                                type: object
+                              readinessProbe:
+                                description: ReadinessProbe sets the Reaper readiness
+                                  probe. Leave nil to use defaults.
+                                properties:
+                                  exec:
+                                    description: One and only one of the following should
+                                      be specified. Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/') in
+                                          the container's filesystem. The command is
+                                          simply exec'd, it is not run inside a shell,
+                                          so traditional shell instructions ('|', etc)
+                                          won't work. To use a shell, you need to explicitly
+                                          call out to that shell. Exit status of 0 is
+                                          treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    description: Minimum consecutive failures for the
+                                      probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set "Host"
+                                          in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request.
+                                          HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: Name or number of the port to access
+                                          on the container. Number must be in the range
+                                          1 to 65535. Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: Scheme to use for connecting to
+                                          the host. Defaults to HTTP.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: How often (in seconds) to perform the
+                                      probe. Default to 10 seconds. Minimum value is
+                                      1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: Minimum consecutive successes for the
+                                      probe to be considered successful after having
+                                      failed. Defaults to 1. Must be 1 for liveness
+                                      and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: Number or name of the port to access
+                                          on the container. Number must be in the range
+                                          1 to 65535. Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: Optional duration in seconds the pod
+                                      needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after
+                                      the processes running in the pod are sent a termination
+                                      signal and the time when the processes are forcibly
+                                      halted with a kill signal. Set this value longer
+                                      than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds
+                                      will be used. Otherwise, this value overrides
+                                      the value provided by the pod spec. Value must
+                                      be non-negative integer. The value zero indicates
+                                      stop immediately via the kill signal (no opportunity
+                                      to shut down). This is a beta field and requires
+                                      enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds
+                                      is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    format: int32
+                                    type: integer
+                                type: object
+                              securityContext:
+                                description: SecurityContext applied to the Reaper main
+                                  container.
+                                properties:
+                                  allowPrivilegeEscalation:
+                                    description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN'
+                                    type: boolean
+                                  capabilities:
+                                    description: The capabilities to add/drop when running
+                                      containers. Defaults to the default set of capabilities
+                                      granted by the container runtime.
+                                    properties:
+                                      add:
+                                        description: Added capabilities
+                                        items:
+                                          description: Capability represent POSIX capabilities
+                                            type
+                                          type: string
+                                        type: array
+                                      drop:
+                                        description: Removed capabilities
+                                        items:
+                                          description: Capability represent POSIX capabilities
+                                            type
+                                          type: string
+                                        type: array
+                                    type: object
+                                  privileged:
+                                    description: Run container in privileged mode. Processes
+                                      in privileged containers are essentially equivalent
+                                      to root on the host. Defaults to false.
+                                    type: boolean
+                                  procMount:
+                                    description: procMount denotes the type of proc
+                                      mount to use for the containers. The default is
+                                      DefaultProcMount which uses the container runtime
+                                      defaults for readonly paths and masked paths.
+                                      This requires the ProcMountType feature flag to
+                                      be enabled.
+                                    type: string
+                                  readOnlyRootFilesystem:
+                                    description: Whether this container has a read-only
+                                      root filesystem. Default is false.
+                                    type: boolean
+                                  runAsGroup:
+                                    description: The GID to run the entrypoint of the
+                                      container process. Uses runtime default if unset.
+                                      May also be set in PodSecurityContext.  If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes precedence.
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    description: Indicates that the container must run
+                                      as a non-root user. If true, the Kubelet will
+                                      validate the image at runtime to ensure that it
+                                      does not run as UID 0 (root) and fail to start
+                                      the container if it does. If unset or false, no
+                                      such validation will be performed. May also be
+                                      set in PodSecurityContext.  If set in both SecurityContext
+                                      and PodSecurityContext, the value specified in
+                                      SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: The UID to run the entrypoint of the
+                                      container process. Defaults to user specified
+                                      in image metadata if unspecified. May also be
+                                      set in PodSecurityContext.  If set in both SecurityContext
+                                      and PodSecurityContext, the value specified in
+                                      SecurityContext takes precedence.
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    description: The SELinux context to be applied to
+                                      the container. If unspecified, the container runtime
+                                      will allocate a random SELinux context for each
+                                      container.  May also be set in PodSecurityContext.  If
+                                      set in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes precedence.
+                                    properties:
+                                      level:
+                                        description: Level is SELinux level label that
+                                          applies to the container.
+                                        type: string
+                                      role:
+                                        description: Role is a SELinux role label that
+                                          applies to the container.
+                                        type: string
+                                      type:
+                                        description: Type is a SELinux type label that
+                                          applies to the container.
+                                        type: string
+                                      user:
+                                        description: User is a SELinux user label that
+                                          applies to the container.
+                                        type: string
+                                    type: object
+                                  seccompProfile:
+                                    description: The seccomp options to use by this
+                                      container. If seccomp options are provided at
+                                      both the pod & container level, the container
+                                      options override the pod options.
+                                    properties:
+                                      localhostProfile:
+                                        description: localhostProfile indicates a profile
+                                          defined in a file on the node should be used.
+                                          The profile must be preconfigured on the node
+                                          to work. Must be a descending path, relative
+                                          to the kubelet's configured seccomp profile
+                                          location. Must only be set if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: "type indicates which kind of seccomp
+                                        profile will be applied. Valid options are:
+                                        \n Localhost - a profile defined in a file
+                                        on the node should be used. RuntimeDefault
+                                        - the container runtime default profile should
+                                        be used. Unconfined - no profile should be
+                                        applied."
+                                        type: string
+                                    required:
+                                      - type
+                                    type: object
+                                  windowsOptions:
+                                    description: The Windows specific settings applied
+                                      to all containers. If unspecified, the options
+                                      from the PodSecurityContext will be used. If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes precedence.
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        description: GMSACredentialSpec is where the
+                                          GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                          inlines the contents of the GMSA credential
+                                          spec named by the GMSACredentialSpecName field.
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        description: GMSACredentialSpecName is the name
+                                          of the GMSA credential spec to use.
+                                        type: string
+                                      hostProcess:
+                                        description: HostProcess determines if a container
+                                          should be run as a 'Host Process' container.
+                                          This field is alpha-level and will only be
+                                          honored by components that enable the WindowsHostProcessContainers
+                                          feature flag. Setting this field without the
+                                          feature flag will result in errors when validating
+                                          the Pod. All of a Pod's containers must have
+                                          the same effective HostProcess value (it is
+                                          not allowed to have a mix of HostProcess containers
+                                          and non-HostProcess containers).  In addition,
+                                          if HostProcess is true then HostNetwork must
+                                          also be set to true.
+                                        type: boolean
+                                      runAsUserName:
+                                        description: The UserName in Windows to run
+                                          the entrypoint of the container process. Defaults
+                                          to the user specified in image metadata if
+                                          unspecified. May also be set in PodSecurityContext.
+                                          If set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        type: string
+                                    type: object
+                                type: object
+                              tolerations:
+                                description: Tolerations applied to the Reaper pods.
+                                items:
+                                  description: The pod this Toleration is attached to
+                                    tolerates any taint that matches the triple <key,value,effect>
+                                    using the matching operator <operator>.
+                                  properties:
+                                    effect:
+                                      description: Effect indicates the taint effect
+                                        to match. Empty means match all taint effects.
+                                        When specified, allowed values are NoSchedule,
+                                        PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Key is the taint key that the toleration
+                                        applies to. Empty means match all taint keys.
+                                        If the key is empty, operator must be Exists;
+                                        this combination means to match all values and
+                                        all keys.
+                                      type: string
+                                    operator:
+                                      description: Operator represents a key's relationship
+                                        to the value. Valid operators are Exists and
+                                        Equal. Defaults to Equal. Exists is equivalent
+                                        to wildcard for value, so that a pod can tolerate
+                                        all taints of a particular category.
+                                      type: string
+                                    tolerationSeconds:
+                                      description: TolerationSeconds represents the
+                                        period of time the toleration (which must be
+                                        of effect NoExecute, otherwise this field is
+                                        ignored) tolerates the taint. By default, it
+                                        is not set, which means tolerate the taint forever
+                                        (do not evict). Zero and negative values will
+                                        be treated as 0 (evict immediately) by the system.
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      description: Value is the taint value the toleration
+                                        matches to. If the operator is Exists, the value
+                                        should be empty, otherwise just a regular string.
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
                           resources:
                             description: Resources is the cpu and memory resources for
                               the cassandra container.
@@ -1232,6 +3300,54 @@ spec:
                                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
+                                    type: string
+                                type: object
+                              containerImage:
+                                default:
+                                  repository: stargateio
+                                  tag: v1.0.45
+                                description: ContainerImage is the image characteristics
+                                  to use for Stargate containers. Leave nil to use a
+                                  default image.
+                                properties:
+                                  name:
+                                    description: The image name to use.
+                                    type: string
+                                  pullPolicy:
+                                    description: The image pull policy to use. Defaults
+                                      to "Always" if the tag is "latest", otherwise
+                                      to "IfNotPresent".
+                                    enum:
+                                      - Always
+                                      - IfNotPresent
+                                      - Never
+                                    type: string
+                                  pullSecretRef:
+                                    description: 'The secret to use when pulling the
+                                    image from private repositories. If specified,
+                                    this secret will be passed to individual puller
+                                    implementations for them to use. For example,
+                                    in the case of Docker, only DockerConfig type
+                                    secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                        type: string
+                                    type: object
+                                  registry:
+                                    default: docker.io
+                                    description: The Docker registry to use. Defaults
+                                      to "docker.io", the official Docker Hub.
+                                    type: string
+                                  repository:
+                                    description: The Docker repository to use.
+                                    type: string
+                                  tag:
+                                    default: latest
+                                    description: The image tag to use. Defaults to "latest".
                                     type: string
                                 type: object
                               heapSize:
@@ -2559,6 +4675,56 @@ spec:
                                           kind, uid?'
                                           type: string
                                       type: object
+                                    containerImage:
+                                      default:
+                                        repository: stargateio
+                                        tag: v1.0.45
+                                      description: ContainerImage is the image characteristics
+                                        to use for Stargate containers. Leave nil to
+                                        use a default image.
+                                      properties:
+                                        name:
+                                          description: The image name to use.
+                                          type: string
+                                        pullPolicy:
+                                          description: The image pull policy to use.
+                                            Defaults to "Always" if the tag is "latest",
+                                            otherwise to "IfNotPresent".
+                                          enum:
+                                            - Always
+                                            - IfNotPresent
+                                            - Never
+                                          type: string
+                                        pullSecretRef:
+                                          description: 'The secret to use when pulling
+                                          the image from private repositories. If
+                                          specified, this secret will be passed to
+                                          individual puller implementations for them
+                                          to use. For example, in the case of Docker,
+                                          only DockerConfig type secrets are honored.
+                                          More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                              type: string
+                                          type: object
+                                        registry:
+                                          default: docker.io
+                                          description: The Docker registry to use. Defaults
+                                            to "docker.io", the official Docker Hub.
+                                          type: string
+                                        repository:
+                                          description: The Docker repository to use.
+                                          type: string
+                                        tag:
+                                          default: latest
+                                          description: The image tag to use. Defaults
+                                            to "latest".
+                                          type: string
+                                      type: object
                                     heapSize:
                                       anyOf:
                                         - type: integer
@@ -2924,26 +5090,26 @@ spec:
                                       description: ServiceAccount is the service account
                                         name to use for Stargate pods.
                                       type: string
-                                    stargateContainerImage:
-                                      description: StargateContainerImage is the image
-                                        characteristics to use for Stargate containers.
-                                        Leave nil to use a default image.
+                                    telemetry:
+                                      description: Telemetry defines the desired telemetry
+                                        integrations to deploy targeting the Stargate
+                                        pods for all DCs in this cluster (unless overriden
+                                        by DC specific settings)
                                       properties:
-                                        pullPolicy:
-                                          default: IfNotPresent
-                                          description: PullPolicy describes a policy
-                                            for if/when to pull a container image
-                                          type: string
-                                        registry:
-                                          default: docker.io
-                                          type: string
-                                        repository:
-                                          type: string
-                                        tag:
-                                          default: latest
-                                          type: string
-                                      required:
-                                        - repository
+                                        prometheus:
+                                          properties:
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: CommonLabels are applied
+                                                to all serviceMonitors created.
+                                              type: object
+                                            enabled:
+                                              description: Enable the creation of Prometheus
+                                                serviceMonitors for this resource (Cassandra
+                                                or Stargate).
+                                              type: boolean
+                                          type: object
                                       type: object
                                     tolerations:
                                       description: Tolerations are tolerations to apply
@@ -3181,26 +5347,26 @@ spec:
                                 format: int32
                                 minimum: 1
                                 type: integer
-                              stargateContainerImage:
-                                description: StargateContainerImage is the image characteristics
-                                  to use for Stargate containers. Leave nil to use a
-                                  default image.
+                              telemetry:
+                                description: Telemetry defines the desired telemetry
+                                  integrations to deploy targeting the Stargate pods
+                                  for all DCs in this cluster (unless overriden by DC
+                                  specific settings)
                                 properties:
-                                  pullPolicy:
-                                    default: IfNotPresent
-                                    description: PullPolicy describes a policy for if/when
-                                      to pull a container image
-                                    type: string
-                                  registry:
-                                    default: docker.io
-                                    type: string
-                                  repository:
-                                    type: string
-                                  tag:
-                                    default: latest
-                                    type: string
-                                required:
-                                  - repository
+                                  prometheus:
+                                    properties:
+                                      commonLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: CommonLabels are applied to all
+                                          serviceMonitors created.
+                                        type: object
+                                      enabled:
+                                        description: Enable the creation of Prometheus
+                                          serviceMonitors for this resource (Cassandra
+                                          or Stargate).
+                                        type: boolean
+                                    type: object
                                 type: object
                               tolerations:
                                 description: Tolerations are tolerations to apply to
@@ -3678,6 +5844,14 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       type: array
+                    mgmtAPIHeap:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: MgmtAPIHeap defines the amount of memory devoted
+                        to the management api heap.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
                     networking:
                       description: Networking enables host networking and configures
                         a NodePort ports.
@@ -4152,6 +6326,1854 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                       type: object
+                  type: object
+                reaper:
+                  description: Reaper defines the desired deployment characteristics
+                    for Reaper in this K8ssandraCluster. If this is non-nil, Reaper
+                    will be deployed on every Cassandra datacenter in this K8ssandraCluster.
+                  properties:
+                    ServiceAccountName:
+                      default: default
+                      type: string
+                    affinity:
+                      description: Affinity applied to the Reaper pods.
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for
+                            the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node matches the corresponding matchExpressions;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: An empty preferred scheduling term matches
+                                  all objects with implicit weight 0 (i.e. it's a no-op).
+                                  A null preferred scheduling term matches no objects
+                                  (i.e. is also a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated with
+                                      the corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by
+                                this field are not met at scheduling time, the pod will
+                                not be scheduled onto the node. If the affinity requirements
+                                specified by this field cease to be met at some point
+                                during pod execution (e.g. due to an update), the system
+                                may or may not try to eventually evict the pod from
+                                its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
+                                  items:
+                                    description: A null or empty node selector term
+                                      matches no objects. The requirements of them are
+                                      ANDed. The TopologySelectorTerm type implements
+                                      a subset of the NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the corresponding
+                                podAffinityTerm; the node(s) with the highest sum are
+                                the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        description: A label query over the set of namespaces
+                                          that the term applies to. The term is applied
+                                          to the union of the namespaces selected by
+                                          this field and the ones listed in the namespaces
+                                          field. null selector and null or empty namespaces
+                                          list means "this pod's namespace". An empty
+                                          selector ({}) matches all namespaces. This
+                                          field is beta-level and is only honored when
+                                          PodAffinityNamespaceSelector feature is enabled.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies a static list
+                                          of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces
+                                          listed in this field and the ones selected
+                                          by namespaceSelector. null or empty namespaces
+                                          list and null namespaceSelector means "this
+                                          pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the
+                                          pods matching the labelSelector in the specified
+                                          namespaces, where co-located is defined as
+                                          running on a node whose value of the label
+                                          with key topologyKey matches that of any node
+                                          on which any of the selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by
+                                this field are not met at scheduling time, the pod will
+                                not be scheduled onto the node. If the affinity requirements
+                                specified by this field cease to be met at some point
+                                during pod execution (e.g. due to a pod label update),
+                                the system may or may not try to eventually evict the
+                                pod from its node. When there are multiple elements,
+                                the lists of nodes corresponding to each podAffinityTerm
+                                are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or not
+                                  co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any node
+                                  on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list
+                                      means "this pod's namespace". An empty selector
+                                      ({}) matches all namespaces. This field is beta-level
+                                      and is only honored when PodAffinityNamespaceSelector
+                                      feature is enabled.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to. The
+                                      term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces list
+                                      and null namespaceSelector means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the anti-affinity expressions
+                                specified by this field, but it may choose a node that
+                                violates one or more of the expressions. The node that
+                                is most preferred is the one with the greatest sum of
+                                weights, i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                anti-affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the corresponding
+                                podAffinityTerm; the node(s) with the highest sum are
+                                the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        description: A label query over the set of namespaces
+                                          that the term applies to. The term is applied
+                                          to the union of the namespaces selected by
+                                          this field and the ones listed in the namespaces
+                                          field. null selector and null or empty namespaces
+                                          list means "this pod's namespace". An empty
+                                          selector ({}) matches all namespaces. This
+                                          field is beta-level and is only honored when
+                                          PodAffinityNamespaceSelector feature is enabled.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies a static list
+                                          of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces
+                                          listed in this field and the ones selected
+                                          by namespaceSelector. null or empty namespaces
+                                          list and null namespaceSelector means "this
+                                          pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the
+                                          pods matching the labelSelector in the specified
+                                          namespaces, where co-located is defined as
+                                          running on a node whose value of the label
+                                          with key topologyKey matches that of any node
+                                          on which any of the selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the anti-affinity requirements specified
+                                by this field are not met at scheduling time, the pod
+                                will not be scheduled onto the node. If the anti-affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod
+                                label update), the system may or may not try to eventually
+                                evict the pod from its node. When there are multiple
+                                elements, the lists of nodes corresponding to each podAffinityTerm
+                                are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or not
+                                  co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any node
+                                  on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list
+                                      means "this pod's namespace". An empty selector
+                                      ({}) matches all namespaces. This field is beta-level
+                                      and is only honored when PodAffinityNamespaceSelector
+                                      feature is enabled.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to. The
+                                      term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces list
+                                      and null namespaceSelector means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    autoScheduling:
+                      description: Auto scheduling properties. When you enable the auto-schedule
+                        feature, Reaper dynamically schedules repairs for all non-system
+                        keyspaces in a cluster. A cluster's keyspaces are monitored
+                        and any modifications (additions or removals) are detected.
+                        When a new keyspace is created, a new repair schedule is created
+                        automatically for that keyspace. Conversely, when a keyspace
+                        is removed, the corresponding repair schedule is deleted.
+                      properties:
+                        enabled:
+                          default: false
+                          type: boolean
+                        excludedClusters:
+                          description: ExcludedClusters are the clusters that are to
+                            be excluded from the repair schedule.
+                          items:
+                            type: string
+                          type: array
+                        excludedKeyspaces:
+                          description: ExcludedKeyspaces are the keyspaces that are
+                            to be excluded from the repair schedule.
+                          items:
+                            type: string
+                          type: array
+                        initialDelayPeriod:
+                          default: PT15S
+                          description: InitialDelay is the amount of delay time before
+                            the schedule period starts. Must be a valid ISO-8601 duration
+                            string. The default is "PT15S" (15 seconds).
+                          pattern: ([-+]?)P(?:([-+]?[0-9]+)D)?(T(?:([-+]?[0-9]+)H)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)(?:[.,]([0-9]{0,9}))?S)?)?
+                          type: string
+                        percentUnrepairedThreshold:
+                          default: 10
+                          description: PercentUnrepairedThreshold is the percentage
+                            of unrepaired data over which an incremental repair should
+                            be started. Only relevant when using repair type INCREMENTAL.
+                          maximum: 100
+                          minimum: 0
+                          type: integer
+                        periodBetweenPolls:
+                          default: PT10M
+                          description: PeriodBetweenPolls is the interval time to wait
+                            before checking whether to start a repair task. Must be
+                            a valid ISO-8601 duration string. The default is "PT10M"
+                            (10 minutes).
+                          pattern: ([-+]?)P(?:([-+]?[0-9]+)D)?(T(?:([-+]?[0-9]+)H)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)(?:[.,]([0-9]{0,9}))?S)?)?
+                          type: string
+                        repairType:
+                          default: AUTO
+                          description: 'RepairType is the type of repair to create:
+                          - REGULAR creates a regular repair (non-adaptive and non-incremental);
+                          - ADAPTIVE creates an adaptive repair; adaptive repairs
+                          are most suited for Cassandra 3. - INCREMENTAL creates an
+                          incremental repair; incremental repairs should only be used
+                          with Cassandra 4+. - AUTO chooses between ADAPTIVE and INCREMENTAL
+                          depending on the Cassandra server version; ADAPTIVE for
+                          Cassandra 3 and INCREMENTAL for Cassandra 4+.'
+                          enum:
+                            - REGULAR
+                            - ADAPTIVE
+                            - INCREMENTAL
+                            - AUTO
+                          type: string
+                        scheduleSpreadPeriod:
+                          default: PT6H
+                          description: ScheduleSpreadPeriod is the time spacing between
+                            each of the repair schedules that is to be carried out.
+                            Must be a valid ISO-8601 duration string. The default is
+                            "PT6H" (6 hours).
+                          pattern: ([-+]?)P(?:([-+]?[0-9]+)D)?(T(?:([-+]?[0-9]+)H)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)(?:[.,]([0-9]{0,9}))?S)?)?
+                          type: string
+                        timeBeforeFirstSchedule:
+                          default: PT5M
+                          description: TimeBeforeFirstSchedule is the grace period before
+                            the first repair in the schedule is started. Must be a valid
+                            ISO-8601 duration string. The default is "PT5M" (5 minutes).
+                          pattern: ([-+]?)P(?:([-+]?[0-9]+)D)?(T(?:([-+]?[0-9]+)H)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)(?:[.,]([0-9]{0,9}))?S)?)?
+                          type: string
+                      type: object
+                    cassandraUserSecretRef:
+                      description: 'Defines the username and password that Reaper will
+                      use to authenticate CQL connections to Cassandra clusters. These
+                      credentials will be automatically turned into CQL roles by cass-operator
+                      when bootstrapping the datacenter, then passed to the Reaper
+                      instance, so that it can authenticate against nodes in the datacenter
+                      using CQL. If CQL authentication is not required, leave this
+                      field empty. The secret must be in the same namespace as Reaper
+                      itself and must contain two keys: "username" and "password".'
+                      type: string
+                    containerImage:
+                      default:
+                        name: cassandra-reaper
+                        repository: thelastpickle
+                        tag: 3.1.0
+                      description: The image to use for the Reaper pod main container.
+                        The default is "thelastpickle/cassandra-reaper:3.1.0".
+                      properties:
+                        name:
+                          description: The image name to use.
+                          type: string
+                        pullPolicy:
+                          description: The image pull policy to use. Defaults to "Always"
+                            if the tag is "latest", otherwise to "IfNotPresent".
+                          enum:
+                            - Always
+                            - IfNotPresent
+                            - Never
+                          type: string
+                        pullSecretRef:
+                          description: 'The secret to use when pulling the image from
+                          private repositories. If specified, this secret will be
+                          passed to individual puller implementations for them to
+                          use. For example, in the case of Docker, only DockerConfig
+                          type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        registry:
+                          default: docker.io
+                          description: The Docker registry to use. Defaults to "docker.io",
+                            the official Docker Hub.
+                          type: string
+                        repository:
+                          description: The Docker repository to use.
+                          type: string
+                        tag:
+                          default: latest
+                          description: The image tag to use. Defaults to "latest".
+                          type: string
+                      type: object
+                    initContainerImage:
+                      default:
+                        name: cassandra-reaper
+                        repository: thelastpickle
+                        tag: 3.1.0
+                      description: The image to use for tje Reaper pod init container
+                        (that performs schema migrations). The default is "thelastpickle/cassandra-reaper:3.1.0".
+                      properties:
+                        name:
+                          description: The image name to use.
+                          type: string
+                        pullPolicy:
+                          description: The image pull policy to use. Defaults to "Always"
+                            if the tag is "latest", otherwise to "IfNotPresent".
+                          enum:
+                            - Always
+                            - IfNotPresent
+                            - Never
+                          type: string
+                        pullSecretRef:
+                          description: 'The secret to use when pulling the image from
+                          private repositories. If specified, this secret will be
+                          passed to individual puller implementations for them to
+                          use. For example, in the case of Docker, only DockerConfig
+                          type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        registry:
+                          default: docker.io
+                          description: The Docker registry to use. Defaults to "docker.io",
+                            the official Docker Hub.
+                          type: string
+                        repository:
+                          description: The Docker repository to use.
+                          type: string
+                        tag:
+                          default: latest
+                          description: The image tag to use. Defaults to "latest".
+                          type: string
+                      type: object
+                    initContainerSecurityContext:
+                      description: InitContainerSecurityContext is the SecurityContext
+                        applied to the Reaper init container, used to perform schema
+                        migrations.
+                      properties:
+                        allowPrivilegeEscalation:
+                          description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                          type: boolean
+                        capabilities:
+                          description: The capabilities to add/drop when running containers.
+                            Defaults to the default set of capabilities granted by the
+                            container runtime.
+                          properties:
+                            add:
+                              description: Added capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                            drop:
+                              description: Removed capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                          type: object
+                        privileged:
+                          description: Run container in privileged mode. Processes in
+                            privileged containers are essentially equivalent to root
+                            on the host. Defaults to false.
+                          type: boolean
+                        procMount:
+                          description: procMount denotes the type of proc mount to use
+                            for the containers. The default is DefaultProcMount which
+                            uses the container runtime defaults for readonly paths and
+                            masked paths. This requires the ProcMountType feature flag
+                            to be enabled.
+                          type: string
+                        readOnlyRootFilesystem:
+                          description: Whether this container has a read-only root filesystem.
+                            Default is false.
+                          type: boolean
+                        runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: Indicates that the container must run as a non-root
+                            user. If true, the Kubelet will validate the image at runtime
+                            to ensure that it does not run as UID 0 (root) and fail
+                            to start the container if it does. If unset or false, no
+                            such validation will be performed. May also be set in PodSecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata if
+                            unspecified. May also be set in PodSecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          description: The SELinux context to be applied to the container.
+                            If unspecified, the container runtime will allocate a random
+                            SELinux context for each container.  May also be set in
+                            PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: The seccomp options to use by this container.
+                            If seccomp options are provided at both the pod & container
+                            level, the container options override the pod options.
+                          properties:
+                            localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile must
+                                be preconfigured on the node to work. Must be a descending
+                                path, relative to the kubelet's configured seccomp profile
+                                location. Must only be set if type is "Localhost".
+                              type: string
+                            type:
+                              description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options from the PodSecurityContext
+                            will be used. If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: HostProcess determines if a container should
+                                be run as a 'Host Process' container. This field is
+                                alpha-level and will only be honored by components that
+                                enable the WindowsHostProcessContainers feature flag.
+                                Setting this field without the feature flag will result
+                                in errors when validating the Pod. All of a Pod's containers
+                                must have the same effective HostProcess value (it is
+                                not allowed to have a mix of HostProcess containers
+                                and non-HostProcess containers).  In addition, if HostProcess
+                                is true then HostNetwork must also be set to true.
+                              type: boolean
+                            runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set in
+                                PodSecurityContext. If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    jmxUserSecretRef:
+                      description: 'Defines the username and password that Reaper will
+                      use to authenticate JMX connections to Cassandra clusters. These
+                      credentials will be automatically passed to each Cassandra node
+                      in the datacenter, as well as to the Reaper instance, so that
+                      the latter can authenticate against the former. If JMX authentication
+                      is not required, leave this field empty. The secret must be
+                      in the same namespace as Reaper itself and must contain two
+                      keys: "username" and "password".'
+                      type: string
+                    keyspace:
+                      default: reaper_db
+                      description: The keyspace to use to store Reaper's state. Will
+                        default to "reaper_db" if unspecified. Will be created if it
+                        does not exist, and if this Reaper resource is managed by K8ssandra.
+                      type: string
+                    livenessProbe:
+                      description: LivenessProbe sets the Reaper liveness probe. Leave
+                        nil to use defaults.
+                      properties:
+                        exec:
+                          description: One and only one of the following should be specified.
+                            Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute inside
+                                the container, the working directory for the command  is
+                                root ('/') in the container's filesystem. The command
+                                is simply exec'd, it is not run inside a shell, so traditional
+                                shell instructions ('|', etc) won't work. To use a shell,
+                                you need to explicitly call out to that shell. Exit
+                                status of 0 is treated as live/healthy and non-zero
+                                is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        failureThreshold:
+                          description: Minimum consecutive failures for the probe to
+                            be considered failed after having succeeded. Defaults to
+                            3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header to
+                                  be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: Name or number of the port to access on the
+                                container. Number must be in the range 1 to 65535. Name
+                                must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                            - port
+                          type: object
+                        initialDelaySeconds:
+                          description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: Minimum consecutive successes for the probe to
+                            be considered successful after having failed. Defaults to
+                            1. Must be 1 for liveness and startup. Minimum value is
+                            1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a TCP
+                          port. TCP hooks not yet supported TODO: implement a realistic
+                          TCP lifecycle hook'
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: Number or name of the port to access on the
+                                container. Number must be in the range 1 to 65535. Name
+                                must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                            - port
+                          type: object
+                        terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs to
+                            terminate gracefully upon probe failure. The grace period
+                            is the duration in seconds after the processes running in
+                            the pod are sent a termination signal and the time when
+                            the processes are forcibly halted with a kill signal. Set
+                            this value longer than the expected cleanup time for your
+                            process. If this value is nil, the pod's terminationGracePeriodSeconds
+                            will be used. Otherwise, this value overrides the value
+                            provided by the pod spec. Value must be non-negative integer.
+                            The value zero indicates stop immediately via the kill signal
+                            (no opportunity to shut down). This is a beta field and
+                            requires enabling ProbeTerminationGracePeriod feature gate.
+                            Minimum value is 1. spec.terminationGracePeriodSeconds is
+                            used if unset.
+                          format: int64
+                          type: integer
+                        timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                      type: object
+                    podSecurityContext:
+                      description: PodSecurityContext contains a pod-level SecurityContext
+                        to apply to Reaper pods.
+                      properties:
+                        fsGroup:
+                          description: "A special supplemental group that applies to
+                          all containers in a pod. Some volume types allow the Kubelet
+                          to change the ownership of that volume to be owned by the
+                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
+                          bit is set (new files created in the volume will be owned
+                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                          \n If unset, the Kubelet will not modify the ownership and
+                          permissions of any volume."
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          description: 'fsGroupChangePolicy defines behavior of changing
+                          ownership and permission of the volume before being exposed
+                          inside Pod. This field will only apply to volume types which
+                          support fsGroup based ownership(and permissions). It will
+                          have no effect on ephemeral volume types such as: secret,
+                          configmaps and emptydir. Valid values are "OnRootMismatch"
+                          and "Always". If not specified, "Always" is used.'
+                          type: string
+                        runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: Indicates that the container must run as a non-root
+                            user. If true, the Kubelet will validate the image at runtime
+                            to ensure that it does not run as UID 0 (root) and fail
+                            to start the container if it does. If unset or false, no
+                            such validation will be performed. May also be set in SecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata if
+                            unspecified. May also be set in SecurityContext.  If set
+                            in both SecurityContext and PodSecurityContext, the value
+                            specified in SecurityContext takes precedence for that container.
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          description: The SELinux context to be applied to all containers.
+                            If unspecified, the container runtime will allocate a random
+                            SELinux context for each container.  May also be set in
+                            SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence
+                            for that container.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: The seccomp options to use by the containers
+                            in this pod.
+                          properties:
+                            localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile must
+                                be preconfigured on the node to work. Must be a descending
+                                path, relative to the kubelet's configured seccomp profile
+                                location. Must only be set if type is "Localhost".
+                              type: string
+                            type:
+                              description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        supplementalGroups:
+                          description: A list of groups applied to the first process
+                            run in each container, in addition to the container's primary
+                            GID.  If unspecified, no groups will be added to any container.
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        sysctls:
+                          description: Sysctls hold a list of namespaced sysctls used
+                            for the pod. Pods with unsupported sysctls (by the container
+                            runtime) might fail to launch.
+                          items:
+                            description: Sysctl defines a kernel parameter to be set
+                            properties:
+                              name:
+                                description: Name of a property to set
+                                type: string
+                              value:
+                                description: Value of a property to set
+                                type: string
+                            required:
+                              - name
+                              - value
+                            type: object
+                          type: array
+                        windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options within a container's
+                            SecurityContext will be used. If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: HostProcess determines if a container should
+                                be run as a 'Host Process' container. This field is
+                                alpha-level and will only be honored by components that
+                                enable the WindowsHostProcessContainers feature flag.
+                                Setting this field without the feature flag will result
+                                in errors when validating the Pod. All of a Pod's containers
+                                must have the same effective HostProcess value (it is
+                                not allowed to have a mix of HostProcess containers
+                                and non-HostProcess containers).  In addition, if HostProcess
+                                is true then HostNetwork must also be set to true.
+                              type: boolean
+                            runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set in
+                                PodSecurityContext. If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    readinessProbe:
+                      description: ReadinessProbe sets the Reaper readiness probe. Leave
+                        nil to use defaults.
+                      properties:
+                        exec:
+                          description: One and only one of the following should be specified.
+                            Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute inside
+                                the container, the working directory for the command  is
+                                root ('/') in the container's filesystem. The command
+                                is simply exec'd, it is not run inside a shell, so traditional
+                                shell instructions ('|', etc) won't work. To use a shell,
+                                you need to explicitly call out to that shell. Exit
+                                status of 0 is treated as live/healthy and non-zero
+                                is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        failureThreshold:
+                          description: Minimum consecutive failures for the probe to
+                            be considered failed after having succeeded. Defaults to
+                            3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header to
+                                  be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: Name or number of the port to access on the
+                                container. Number must be in the range 1 to 65535. Name
+                                must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                            - port
+                          type: object
+                        initialDelaySeconds:
+                          description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: Minimum consecutive successes for the probe to
+                            be considered successful after having failed. Defaults to
+                            1. Must be 1 for liveness and startup. Minimum value is
+                            1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a TCP
+                          port. TCP hooks not yet supported TODO: implement a realistic
+                          TCP lifecycle hook'
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: Number or name of the port to access on the
+                                container. Number must be in the range 1 to 65535. Name
+                                must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                            - port
+                          type: object
+                        terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs to
+                            terminate gracefully upon probe failure. The grace period
+                            is the duration in seconds after the processes running in
+                            the pod are sent a termination signal and the time when
+                            the processes are forcibly halted with a kill signal. Set
+                            this value longer than the expected cleanup time for your
+                            process. If this value is nil, the pod's terminationGracePeriodSeconds
+                            will be used. Otherwise, this value overrides the value
+                            provided by the pod spec. Value must be non-negative integer.
+                            The value zero indicates stop immediately via the kill signal
+                            (no opportunity to shut down). This is a beta field and
+                            requires enabling ProbeTerminationGracePeriod feature gate.
+                            Minimum value is 1. spec.terminationGracePeriodSeconds is
+                            used if unset.
+                          format: int64
+                          type: integer
+                        timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                      type: object
+                    securityContext:
+                      description: SecurityContext applied to the Reaper main container.
+                      properties:
+                        allowPrivilegeEscalation:
+                          description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                          type: boolean
+                        capabilities:
+                          description: The capabilities to add/drop when running containers.
+                            Defaults to the default set of capabilities granted by the
+                            container runtime.
+                          properties:
+                            add:
+                              description: Added capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                            drop:
+                              description: Removed capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                          type: object
+                        privileged:
+                          description: Run container in privileged mode. Processes in
+                            privileged containers are essentially equivalent to root
+                            on the host. Defaults to false.
+                          type: boolean
+                        procMount:
+                          description: procMount denotes the type of proc mount to use
+                            for the containers. The default is DefaultProcMount which
+                            uses the container runtime defaults for readonly paths and
+                            masked paths. This requires the ProcMountType feature flag
+                            to be enabled.
+                          type: string
+                        readOnlyRootFilesystem:
+                          description: Whether this container has a read-only root filesystem.
+                            Default is false.
+                          type: boolean
+                        runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: Indicates that the container must run as a non-root
+                            user. If true, the Kubelet will validate the image at runtime
+                            to ensure that it does not run as UID 0 (root) and fail
+                            to start the container if it does. If unset or false, no
+                            such validation will be performed. May also be set in PodSecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata if
+                            unspecified. May also be set in PodSecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          description: The SELinux context to be applied to the container.
+                            If unspecified, the container runtime will allocate a random
+                            SELinux context for each container.  May also be set in
+                            PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: The seccomp options to use by this container.
+                            If seccomp options are provided at both the pod & container
+                            level, the container options override the pod options.
+                          properties:
+                            localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile must
+                                be preconfigured on the node to work. Must be a descending
+                                path, relative to the kubelet's configured seccomp profile
+                                location. Must only be set if type is "Localhost".
+                              type: string
+                            type:
+                              description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options from the PodSecurityContext
+                            will be used. If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: HostProcess determines if a container should
+                                be run as a 'Host Process' container. This field is
+                                alpha-level and will only be honored by components that
+                                enable the WindowsHostProcessContainers feature flag.
+                                Setting this field without the feature flag will result
+                                in errors when validating the Pod. All of a Pod's containers
+                                must have the same effective HostProcess value (it is
+                                not allowed to have a mix of HostProcess containers
+                                and non-HostProcess containers).  In addition, if HostProcess
+                                is true then HostNetwork must also be set to true.
+                              type: boolean
+                            runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set in
+                                PodSecurityContext. If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    tolerations:
+                      description: Tolerations applied to the Reaper pods.
+                      items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified, allowed
+                              values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration applies
+                              to. Empty means match all taint keys. If the key is empty,
+                              operator must be Exists; this combination means to match
+                              all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship to
+                              the value. Valid operators are Exists and Equal. Defaults
+                              to Equal. Exists is equivalent to wildcard for value,
+                              so that a pod can tolerate all taints of a particular
+                              category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the taint
+                              forever (do not evict). Zero and negative values will
+                              be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
                   type: object
                 stargate:
                   description: Stargate defines the desired deployment characteristics
@@ -5046,6 +9068,49 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                       type: object
+                    containerImage:
+                      default:
+                        repository: stargateio
+                        tag: v1.0.45
+                      description: ContainerImage is the image characteristics to use
+                        for Stargate containers. Leave nil to use a default image.
+                      properties:
+                        name:
+                          description: The image name to use.
+                          type: string
+                        pullPolicy:
+                          description: The image pull policy to use. Defaults to "Always"
+                            if the tag is "latest", otherwise to "IfNotPresent".
+                          enum:
+                            - Always
+                            - IfNotPresent
+                            - Never
+                          type: string
+                        pullSecretRef:
+                          description: 'The secret to use when pulling the image from
+                          private repositories. If specified, this secret will be
+                          passed to individual puller implementations for them to
+                          use. For example, in the case of Docker, only DockerConfig
+                          type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        registry:
+                          default: docker.io
+                          description: The Docker registry to use. Defaults to "docker.io",
+                            the official Docker Hub.
+                          type: string
+                        repository:
+                          description: The Docker repository to use.
+                          type: string
+                        tag:
+                          default: latest
+                          description: The image tag to use. Defaults to "latest".
+                          type: string
+                      type: object
                     heapSize:
                       anyOf:
                         - type: integer
@@ -5369,25 +9434,24 @@ spec:
                       format: int32
                       minimum: 1
                       type: integer
-                    stargateContainerImage:
-                      description: StargateContainerImage is the image characteristics
-                        to use for Stargate containers. Leave nil to use a default image.
+                    telemetry:
+                      description: Telemetry defines the desired telemetry integrations
+                        to deploy targeting the Stargate pods for all DCs in this cluster
+                        (unless overriden by DC specific settings)
                       properties:
-                        pullPolicy:
-                          default: IfNotPresent
-                          description: PullPolicy describes a policy for if/when to
-                            pull a container image
-                          type: string
-                        registry:
-                          default: docker.io
-                          type: string
-                        repository:
-                          type: string
-                        tag:
-                          default: latest
-                          type: string
-                      required:
-                        - repository
+                        prometheus:
+                          properties:
+                            commonLabels:
+                              additionalProperties:
+                                type: string
+                              description: CommonLabels are applied to all serviceMonitors
+                                created.
+                              type: object
+                            enabled:
+                              description: Enable the creation of Prometheus serviceMonitors
+                                for this resource (Cassandra or Stargate).
+                              type: boolean
+                          type: object
                       type: object
                     tolerations:
                       description: Tolerations are tolerations to apply to the Stargate
@@ -5439,6 +9503,23 @@ spec:
             status:
               description: K8ssandraClusterStatus defines the observed state of K8ssandraCluster
               properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition
+                          transited from one status to another.
+                        format: date-time
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
                 datacenters:
                   additionalProperties:
                     description: K8ssandraStatus defines the observed of a k8ssandra
@@ -5504,11 +9585,113 @@ spec:
                               upserted to the management API
                             format: date-time
                             type: string
+                          trackedTasks:
+                            description: TrackedTasks tracks the tasks for completion
+                              that were created by the cass-operator
+                            items:
+                              description: 'ObjectReference contains enough information
+                              to let you inspect or modify the referred object. ---
+                              New uses of this type are discouraged because of difficulty
+                              describing its usage when embedded in APIs.  1. Ignored
+                              fields.  It includes many fields which are not generally
+                              honored.  For instance, ResourceVersion and FieldPath
+                              are both very rarely valid in actual usage.  2. Invalid
+                              usage help.  It is impossible to add specific help for
+                              individual usage.  In most embedded usages, there are
+                              particular     restrictions like, "must refer only to
+                              types A and B" or "UID not honored" or "name must be
+                              restricted".     Those cannot be well described when
+                              embedded.  3. Inconsistent validation.  Because the
+                              usages are different, the validation rules are different
+                              by usage, which makes it hard for users to predict what
+                              will happen.  4. The fields are both imprecise and overly
+                              precise.  Kind is not a precise mapping to a URL. This
+                              can produce ambiguity     during interpretation and
+                              require a REST mapping.  In most cases, the dependency
+                              is on the group,resource tuple     and the version of
+                              the actual struct is irrelevant.  5. We cannot easily
+                              change it.  Because this type is embedded in many locations,
+                              updates to this type     will affect numerous schemas.  Don''t
+                              make new APIs embed an underspecified API type they
+                              do not control. Instead of using this type, create a
+                              locally provided and used type that is well-focused
+                              on your reference. For example, ServiceReferences for
+                              admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                              .'
+                              properties:
+                                apiVersion:
+                                  description: API version of the referent.
+                                  type: string
+                                fieldPath:
+                                  description: 'If referring to a piece of an object
+                                  instead of an entire object, this string should
+                                  contain a valid JSON/Go field access statement,
+                                  such as desiredState.manifest.containers[2]. For
+                                  example, if the object reference is to a container
+                                  within a pod, this would take on a value like: "spec.containers{name}"
+                                  (where "name" refers to the name of the container
+                                  that triggered the event) or if no container name
+                                  is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only
+                                  to have some well-defined way of referencing a part
+                                  of an object. TODO: this design is not final and
+                                  this field is subject to change in the future.'
+                                  type: string
+                                kind:
+                                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                namespace:
+                                  description: 'Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                  type: string
+                                resourceVersion:
+                                  description: 'Specific resourceVersion to which this
+                                  reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                  type: string
+                                uid:
+                                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                  type: string
+                              type: object
+                            type: array
                           usersUpserted:
                             description: The timestamp at which managed cassandra users'
                               credentials were last upserted to the management API
                             format: date-time
                             type: string
+                        type: object
+                      reaper:
+                        description: ReaperStatus defines the observed state of Reaper
+                        properties:
+                          conditions:
+                            items:
+                              properties:
+                                lastTransitionTime:
+                                  description: LastTransitionTime is the last time the
+                                    condition transited from one status to another.
+                                  format: date-time
+                                  type: string
+                                status:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                                - status
+                                - type
+                              type: object
+                            type: array
+                          progress:
+                            description: Progress is the progress of this Reaper object.
+                            enum:
+                              - Pending
+                              - Deploying
+                              - Configuring
+                              - Running
+                            type: string
+                        required:
+                          - progress
                         type: object
                       stargate:
                         description: StargateStatus defines the observed state of a

--- a/charts/k8ssandra-operator/crds/reaper.k8sandra.io_reapers.yaml
+++ b/charts/k8ssandra-operator/crds/reaper.k8sandra.io_reapers.yaml
@@ -1,0 +1,1890 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: reapers.reaper.k8ssandra.io
+spec:
+  group: reaper.k8ssandra.io
+  names:
+    kind: Reaper
+    listKind: ReaperList
+    plural: reapers
+    singular: reaper
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.datacenterRef.name
+          name: DC
+          type: string
+        - jsonPath: .status.progress
+          name: Status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Reaper is the Schema for the reapers API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ReaperSpec defines the desired state of Reaper
+              properties:
+                ServiceAccountName:
+                  default: default
+                  type: string
+                affinity:
+                  description: Affinity applied to the Reaper pods.
+                  properties:
+                    nodeAffinity:
+                      description: Describes node affinity scheduling rules for the
+                        pod.
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods to
+                            nodes that satisfy the affinity expressions specified by
+                            this field, but it may choose a node that violates one or
+                            more of the expressions. The node that is most preferred
+                            is the one with the greatest sum of weights, i.e. for each
+                            node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling affinity expressions,
+                            etc.), compute a sum by iterating through the elements of
+                            this field and adding "weight" to the sum if the node matches
+                            the corresponding matchExpressions; the node(s) with the
+                            highest sum are the most preferred.
+                          items:
+                            description: An empty preferred scheduling term matches
+                              all objects with implicit weight 0 (i.e. it's a no-op).
+                              A null preferred scheduling term matches no objects (i.e.
+                              is also a no-op).
+                            properties:
+                              preference:
+                                description: A node selector term, associated with the
+                                  corresponding weight.
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements
+                                      by node's labels.
+                                    items:
+                                      description: A node selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values. If
+                                            the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values array
+                                            must be empty. If the operator is Gt or
+                                            Lt, the values array must have a single
+                                            element, which will be interpreted as an
+                                            integer. This array is replaced during a
+                                            strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    description: A list of node selector requirements
+                                      by node's fields.
+                                    items:
+                                      description: A node selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values. If
+                                            the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values array
+                                            must be empty. If the operator is Gt or
+                                            Lt, the values array must have a single
+                                            element, which will be interpreted as an
+                                            integer. This array is replaced during a
+                                            strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              weight:
+                                description: Weight associated with matching the corresponding
+                                  nodeSelectorTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                              - preference
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the affinity requirements specified by this
+                            field are not met at scheduling time, the pod will not be
+                            scheduled onto the node. If the affinity requirements specified
+                            by this field cease to be met at some point during pod execution
+                            (e.g. due to an update), the system may or may not try to
+                            eventually evict the pod from its node.
+                          properties:
+                            nodeSelectorTerms:
+                              description: Required. A list of node selector terms.
+                                The terms are ORed.
+                              items:
+                                description: A null or empty node selector term matches
+                                  no objects. The requirements of them are ANDed. The
+                                  TopologySelectorTerm type implements a subset of the
+                                  NodeSelectorTerm.
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements
+                                      by node's labels.
+                                    items:
+                                      description: A node selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values. If
+                                            the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values array
+                                            must be empty. If the operator is Gt or
+                                            Lt, the values array must have a single
+                                            element, which will be interpreted as an
+                                            integer. This array is replaced during a
+                                            strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    description: A list of node selector requirements
+                                      by node's fields.
+                                    items:
+                                      description: A node selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values. If
+                                            the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values array
+                                            must be empty. If the operator is Gt or
+                                            Lt, the values array must have a single
+                                            element, which will be interpreted as an
+                                            integer. This array is replaced during a
+                                            strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          required:
+                            - nodeSelectorTerms
+                          type: object
+                      type: object
+                    podAffinity:
+                      description: Describes pod affinity scheduling rules (e.g. co-locate
+                        this pod in the same node, zone, etc. as some other pod(s)).
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods to
+                            nodes that satisfy the affinity expressions specified by
+                            this field, but it may choose a node that violates one or
+                            more of the expressions. The node that is most preferred
+                            is the one with the greatest sum of weights, i.e. for each
+                            node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling affinity expressions,
+                            etc.), compute a sum by iterating through the elements of
+                            this field and adding "weight" to the sum if the node has
+                            pods which matches the corresponding podAffinityTerm; the
+                            node(s) with the highest sum are the most preferred.
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm
+                              fields are added per-node to find the most preferred node(s)
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated
+                                  with the corresponding weight.
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list
+                                      means "this pod's namespace". An empty selector
+                                      ({}) matches all namespaces. This field is beta-level
+                                      and is only honored when PodAffinityNamespaceSelector
+                                      feature is enabled.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to. The
+                                      term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces list
+                                      and null namespaceSelector means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                description: weight associated with matching the corresponding
+                                  podAffinityTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the affinity requirements specified by this
+                            field are not met at scheduling time, the pod will not be
+                            scheduled onto the node. If the affinity requirements specified
+                            by this field cease to be met at some point during pod execution
+                            (e.g. due to a pod label update), the system may or may
+                            not try to eventually evict the pod from its node. When
+                            there are multiple elements, the lists of nodes corresponding
+                            to each podAffinityTerm are intersected, i.e. all terms
+                            must be satisfied.
+                          items:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not co-located
+                              (anti-affinity) with, where co-located is defined as running
+                              on a node whose value of the label with key <topologyKey>
+                              matches that of any node on which a pod of the set of
+                              pods is running
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the
+                                            operator is Exists or DoesNotExist, the
+                                            values array must be empty. This array is
+                                            replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value". The
+                                      requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaceSelector:
+                                description: A label query over the set of namespaces
+                                  that the term applies to. The term is applied to the
+                                  union of the namespaces selected by this field and
+                                  the ones listed in the namespaces field. null selector
+                                  and null or empty namespaces list means "this pod's
+                                  namespace". An empty selector ({}) matches all namespaces.
+                                  This field is beta-level and is only honored when
+                                  PodAffinityNamespaceSelector feature is enabled.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the
+                                            operator is Exists or DoesNotExist, the
+                                            values array must be empty. This array is
+                                            replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value". The
+                                      requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies a static list of namespace
+                                  names that the term applies to. The term is applied
+                                  to the union of the namespaces listed in this field
+                                  and the ones selected by namespaceSelector. null or
+                                  empty namespaces list and null namespaceSelector means
+                                  "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods matching
+                                  the labelSelector in the specified namespaces, where
+                                  co-located is defined as running on a node whose value
+                                  of the label with key topologyKey matches that of
+                                  any node on which any of the selected pods is running.
+                                  Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    podAntiAffinity:
+                      description: Describes pod anti-affinity scheduling rules (e.g.
+                        avoid putting this pod in the same node, zone, etc. as some
+                        other pod(s)).
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods to
+                            nodes that satisfy the anti-affinity expressions specified
+                            by this field, but it may choose a node that violates one
+                            or more of the expressions. The node that is most preferred
+                            is the one with the greatest sum of weights, i.e. for each
+                            node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling anti-affinity expressions,
+                            etc.), compute a sum by iterating through the elements of
+                            this field and adding "weight" to the sum if the node has
+                            pods which matches the corresponding podAffinityTerm; the
+                            node(s) with the highest sum are the most preferred.
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm
+                              fields are added per-node to find the most preferred node(s)
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated
+                                  with the corresponding weight.
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list
+                                      means "this pod's namespace". An empty selector
+                                      ({}) matches all namespaces. This field is beta-level
+                                      and is only honored when PodAffinityNamespaceSelector
+                                      feature is enabled.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to. The
+                                      term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces list
+                                      and null namespaceSelector means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                description: weight associated with matching the corresponding
+                                  podAffinityTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the anti-affinity requirements specified by
+                            this field are not met at scheduling time, the pod will
+                            not be scheduled onto the node. If the anti-affinity requirements
+                            specified by this field cease to be met at some point during
+                            pod execution (e.g. due to a pod label update), the system
+                            may or may not try to eventually evict the pod from its
+                            node. When there are multiple elements, the lists of nodes
+                            corresponding to each podAffinityTerm are intersected, i.e.
+                            all terms must be satisfied.
+                          items:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not co-located
+                              (anti-affinity) with, where co-located is defined as running
+                              on a node whose value of the label with key <topologyKey>
+                              matches that of any node on which a pod of the set of
+                              pods is running
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the
+                                            operator is Exists or DoesNotExist, the
+                                            values array must be empty. This array is
+                                            replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value". The
+                                      requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaceSelector:
+                                description: A label query over the set of namespaces
+                                  that the term applies to. The term is applied to the
+                                  union of the namespaces selected by this field and
+                                  the ones listed in the namespaces field. null selector
+                                  and null or empty namespaces list means "this pod's
+                                  namespace". An empty selector ({}) matches all namespaces.
+                                  This field is beta-level and is only honored when
+                                  PodAffinityNamespaceSelector feature is enabled.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the
+                                            operator is Exists or DoesNotExist, the
+                                            values array must be empty. This array is
+                                            replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value". The
+                                      requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies a static list of namespace
+                                  names that the term applies to. The term is applied
+                                  to the union of the namespaces listed in this field
+                                  and the ones selected by namespaceSelector. null or
+                                  empty namespaces list and null namespaceSelector means
+                                  "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods matching
+                                  the labelSelector in the specified namespaces, where
+                                  co-located is defined as running on a node whose value
+                                  of the label with key topologyKey matches that of
+                                  any node on which any of the selected pods is running.
+                                  Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                autoScheduling:
+                  description: Auto scheduling properties. When you enable the auto-schedule
+                    feature, Reaper dynamically schedules repairs for all non-system
+                    keyspaces in a cluster. A cluster's keyspaces are monitored and
+                    any modifications (additions or removals) are detected. When a new
+                    keyspace is created, a new repair schedule is created automatically
+                    for that keyspace. Conversely, when a keyspace is removed, the corresponding
+                    repair schedule is deleted.
+                  properties:
+                    enabled:
+                      default: false
+                      type: boolean
+                    excludedClusters:
+                      description: ExcludedClusters are the clusters that are to be
+                        excluded from the repair schedule.
+                      items:
+                        type: string
+                      type: array
+                    excludedKeyspaces:
+                      description: ExcludedKeyspaces are the keyspaces that are to be
+                        excluded from the repair schedule.
+                      items:
+                        type: string
+                      type: array
+                    initialDelayPeriod:
+                      default: PT15S
+                      description: InitialDelay is the amount of delay time before the
+                        schedule period starts. Must be a valid ISO-8601 duration string.
+                        The default is "PT15S" (15 seconds).
+                      pattern: ([-+]?)P(?:([-+]?[0-9]+)D)?(T(?:([-+]?[0-9]+)H)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)(?:[.,]([0-9]{0,9}))?S)?)?
+                      type: string
+                    percentUnrepairedThreshold:
+                      default: 10
+                      description: PercentUnrepairedThreshold is the percentage of unrepaired
+                        data over which an incremental repair should be started. Only
+                        relevant when using repair type INCREMENTAL.
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    periodBetweenPolls:
+                      default: PT10M
+                      description: PeriodBetweenPolls is the interval time to wait before
+                        checking whether to start a repair task. Must be a valid ISO-8601
+                        duration string. The default is "PT10M" (10 minutes).
+                      pattern: ([-+]?)P(?:([-+]?[0-9]+)D)?(T(?:([-+]?[0-9]+)H)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)(?:[.,]([0-9]{0,9}))?S)?)?
+                      type: string
+                    repairType:
+                      default: AUTO
+                      description: 'RepairType is the type of repair to create: - REGULAR
+                      creates a regular repair (non-adaptive and non-incremental);
+                      - ADAPTIVE creates an adaptive repair; adaptive repairs are
+                      most suited for Cassandra 3. - INCREMENTAL creates an incremental
+                      repair; incremental repairs should only be used with Cassandra
+                      4+. - AUTO chooses between ADAPTIVE and INCREMENTAL depending
+                      on the Cassandra server version; ADAPTIVE for Cassandra 3 and
+                      INCREMENTAL for Cassandra 4+.'
+                      enum:
+                        - REGULAR
+                        - ADAPTIVE
+                        - INCREMENTAL
+                        - AUTO
+                      type: string
+                    scheduleSpreadPeriod:
+                      default: PT6H
+                      description: ScheduleSpreadPeriod is the time spacing between
+                        each of the repair schedules that is to be carried out. Must
+                        be a valid ISO-8601 duration string. The default is "PT6H" (6
+                        hours).
+                      pattern: ([-+]?)P(?:([-+]?[0-9]+)D)?(T(?:([-+]?[0-9]+)H)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)(?:[.,]([0-9]{0,9}))?S)?)?
+                      type: string
+                    timeBeforeFirstSchedule:
+                      default: PT5M
+                      description: TimeBeforeFirstSchedule is the grace period before
+                        the first repair in the schedule is started. Must be a valid
+                        ISO-8601 duration string. The default is "PT5M" (5 minutes).
+                      pattern: ([-+]?)P(?:([-+]?[0-9]+)D)?(T(?:([-+]?[0-9]+)H)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)(?:[.,]([0-9]{0,9}))?S)?)?
+                      type: string
+                  type: object
+                cassandraUserSecretRef:
+                  description: 'Defines the username and password that Reaper will use
+                  to authenticate CQL connections to Cassandra clusters. These credentials
+                  will be automatically turned into CQL roles by cass-operator when
+                  bootstrapping the datacenter, then passed to the Reaper instance,
+                  so that it can authenticate against nodes in the datacenter using
+                  CQL. If CQL authentication is not required, leave this field empty.
+                  The secret must be in the same namespace as Reaper itself and must
+                  contain two keys: "username" and "password".'
+                  type: string
+                containerImage:
+                  default:
+                    name: cassandra-reaper
+                    repository: thelastpickle
+                    tag: 3.1.0
+                  description: The image to use for the Reaper pod main container. The
+                    default is "thelastpickle/cassandra-reaper:3.1.0".
+                  properties:
+                    name:
+                      description: The image name to use.
+                      type: string
+                    pullPolicy:
+                      description: The image pull policy to use. Defaults to "Always"
+                        if the tag is "latest", otherwise to "IfNotPresent".
+                      enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                      type: string
+                    pullSecretRef:
+                      description: 'The secret to use when pulling the image from private
+                      repositories. If specified, this secret will be passed to individual
+                      puller implementations for them to use. For example, in the
+                      case of Docker, only DockerConfig type secrets are honored.
+                      More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    registry:
+                      default: docker.io
+                      description: The Docker registry to use. Defaults to "docker.io",
+                        the official Docker Hub.
+                      type: string
+                    repository:
+                      description: The Docker repository to use.
+                      type: string
+                    tag:
+                      default: latest
+                      description: The image tag to use. Defaults to "latest".
+                      type: string
+                  type: object
+                datacenterAvailability:
+                  default: LOCAL
+                  description: DatacenterAvailability indicates to Reaper its deployment
+                    in relation to the target datacenter's network. For single-DC clusters,
+                    the default (LOCAL) is fine. For multi-DC clusters, it is recommended
+                    to use EACH, provided that there is one Reaper instance managing
+                    each DC in the cluster; otherwise, if one single Reaper instance
+                    is going to manage more than one DC in the cluster, use LOCAL and
+                    remote DCs will be handled internally by Cassandra itself. See https://cassandra-reaper.io/docs/usage/multi_dc/.
+                  enum:
+                    - LOCAL
+                    - ALL
+                    - EACH
+                  type: string
+                datacenterRef:
+                  description: DatacenterRef is the reference of a CassandraDatacenter
+                    resource that this Reaper instance should manage. It will also be
+                    used as the backend for persisting Reaper's state. Reaper must be
+                    able to access the JMX port (7199 by default) and the CQL port (9042
+                    by default) on this DC.
+                  properties:
+                    name:
+                      description: The datacenter name.
+                      type: string
+                    namespace:
+                      description: The datacenter namespace. If empty, the datacenter
+                        will be assumed to reside in the same namespace as the Reaper
+                        instance.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                initContainerImage:
+                  default:
+                    name: cassandra-reaper
+                    repository: thelastpickle
+                    tag: 3.1.0
+                  description: The image to use for tje Reaper pod init container (that
+                    performs schema migrations). The default is "thelastpickle/cassandra-reaper:3.1.0".
+                  properties:
+                    name:
+                      description: The image name to use.
+                      type: string
+                    pullPolicy:
+                      description: The image pull policy to use. Defaults to "Always"
+                        if the tag is "latest", otherwise to "IfNotPresent".
+                      enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                      type: string
+                    pullSecretRef:
+                      description: 'The secret to use when pulling the image from private
+                      repositories. If specified, this secret will be passed to individual
+                      puller implementations for them to use. For example, in the
+                      case of Docker, only DockerConfig type secrets are honored.
+                      More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    registry:
+                      default: docker.io
+                      description: The Docker registry to use. Defaults to "docker.io",
+                        the official Docker Hub.
+                      type: string
+                    repository:
+                      description: The Docker repository to use.
+                      type: string
+                    tag:
+                      default: latest
+                      description: The image tag to use. Defaults to "latest".
+                      type: string
+                  type: object
+                initContainerSecurityContext:
+                  description: InitContainerSecurityContext is the SecurityContext applied
+                    to the Reaper init container, used to perform schema migrations.
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                      can gain more privileges than its parent process. This bool
+                      directly controls if the no_new_privs flag will be set on the
+                      container process. AllowPrivilegeEscalation is true always when
+                      the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the container
+                        runtime.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            description: Capability represent POSIX capabilities type
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            description: Capability represent POSIX capabilities type
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      description: Run container in privileged mode. Processes in privileged
+                        containers are essentially equivalent to root on the host. Defaults
+                        to false.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use for
+                        the containers. The default is DefaultProcMount which uses the
+                        container runtime defaults for readonly paths and masked paths.
+                        This requires the ProcMountType feature flag to be enabled.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container process.
+                        Uses runtime default if unset. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to start
+                        the container if it does. If unset or false, no such validation
+                        will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container process.
+                        Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by this container. If
+                        seccomp options are provided at both the pod & container level,
+                        the container options override the pod options.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must be
+                            preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: "type indicates which kind of seccomp profile
+                          will be applied. Valid options are: \n Localhost - a profile
+                          defined in a file on the node should be used. RuntimeDefault
+                          - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied."
+                          type: string
+                      required:
+                        - type
+                      type: object
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will
+                        be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named by
+                            the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: HostProcess determines if a container should
+                            be run as a 'Host Process' container. This field is alpha-level
+                            and will only be honored by components that enable the WindowsHostProcessContainers
+                            feature flag. Setting this field without the feature flag
+                            will result in errors when validating the Pod. All of a
+                            Pod's containers must have the same effective HostProcess
+                            value (it is not allowed to have a mix of HostProcess containers
+                            and non-HostProcess containers).  In addition, if HostProcess
+                            is true then HostNetwork must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                jmxUserSecretRef:
+                  description: 'Defines the username and password that Reaper will use
+                  to authenticate JMX connections to Cassandra clusters. These credentials
+                  will be automatically passed to each Cassandra node in the datacenter,
+                  as well as to the Reaper instance, so that the latter can authenticate
+                  against the former. If JMX authentication is not required, leave
+                  this field empty. The secret must be in the same namespace as Reaper
+                  itself and must contain two keys: "username" and "password".'
+                  type: string
+                keyspace:
+                  default: reaper_db
+                  description: The keyspace to use to store Reaper's state. Will default
+                    to "reaper_db" if unspecified. Will be created if it does not exist,
+                    and if this Reaper resource is managed by K8ssandra.
+                  type: string
+                livenessProbe:
+                  description: LivenessProbe sets the Reaper liveness probe. Leave nil
+                    to use defaults.
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command is
+                            simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP allows
+                            repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                              - name
+                              - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: Name or number of the port to access on the container.
+                            Number must be in the range 1 to 65535. Name must be an
+                            IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                      required:
+                        - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                      before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to be
+                        considered successful after having failed. Defaults to 1. Must
+                        be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: 'TCPSocket specifies an action involving a TCP port.
+                      TCP hooks not yet supported TODO: implement a realistic TCP
+                      lifecycle hook'
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: Number or name of the port to access on the container.
+                            Number must be in the range 1 to 65535. Name must be an
+                            IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                        - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent a
+                        termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the expected
+                        cleanup time for your process. If this value is nil, the pod's
+                        terminationGracePeriodSeconds will be used. Otherwise, this
+                        value overrides the value provided by the pod spec. Value must
+                        be non-negative integer. The value zero indicates stop immediately
+                        via the kill signal (no opportunity to shut down). This is a
+                        beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                podSecurityContext:
+                  description: PodSecurityContext contains a pod-level SecurityContext
+                    to apply to Reaper pods.
+                  properties:
+                    fsGroup:
+                      description: "A special supplemental group that applies to all
+                      containers in a pod. Some volume types allow the Kubelet to
+                      change the ownership of that volume to be owned by the pod:
+                      \n 1. The owning GID will be the FSGroup 2. The setgid bit is
+                      set (new files created in the volume will be owned by FSGroup)
+                      3. The permission bits are OR'd with rw-rw---- \n If unset,
+                      the Kubelet will not modify the ownership and permissions of
+                      any volume."
+                      format: int64
+                      type: integer
+                    fsGroupChangePolicy:
+                      description: 'fsGroupChangePolicy defines behavior of changing
+                      ownership and permission of the volume before being exposed
+                      inside Pod. This field will only apply to volume types which
+                      support fsGroup based ownership(and permissions). It will have
+                      no effect on ephemeral volume types such as: secret, configmaps
+                      and emptydir. Valid values are "OnRootMismatch" and "Always".
+                      If not specified, "Always" is used.'
+                      type: string
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container process.
+                        Uses runtime default if unset. May also be set in SecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence for that container.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to start
+                        the container if it does. If unset or false, no such validation
+                        will be performed. May also be set in SecurityContext.  If set
+                        in both SecurityContext and PodSecurityContext, the value specified
+                        in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container process.
+                        Defaults to user specified in image metadata if unspecified.
+                        May also be set in SecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence for that container.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to all containers.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in SecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence for that container.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by the containers in this
+                        pod.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must be
+                            preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: "type indicates which kind of seccomp profile
+                          will be applied. Valid options are: \n Localhost - a profile
+                          defined in a file on the node should be used. RuntimeDefault
+                          - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied."
+                          type: string
+                      required:
+                        - type
+                      type: object
+                    supplementalGroups:
+                      description: A list of groups applied to the first process run
+                        in each container, in addition to the container's primary GID.  If
+                        unspecified, no groups will be added to any container.
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                    sysctls:
+                      description: Sysctls hold a list of namespaced sysctls used for
+                        the pod. Pods with unsupported sysctls (by the container runtime)
+                        might fail to launch.
+                      items:
+                        description: Sysctl defines a kernel parameter to be set
+                        properties:
+                          name:
+                            description: Name of a property to set
+                            type: string
+                          value:
+                            description: Value of a property to set
+                            type: string
+                        required:
+                          - name
+                          - value
+                        type: object
+                      type: array
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options within a container's SecurityContext
+                        will be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named by
+                            the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: HostProcess determines if a container should
+                            be run as a 'Host Process' container. This field is alpha-level
+                            and will only be honored by components that enable the WindowsHostProcessContainers
+                            feature flag. Setting this field without the feature flag
+                            will result in errors when validating the Pod. All of a
+                            Pod's containers must have the same effective HostProcess
+                            value (it is not allowed to have a mix of HostProcess containers
+                            and non-HostProcess containers).  In addition, if HostProcess
+                            is true then HostNetwork must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                readinessProbe:
+                  description: ReadinessProbe sets the Reaper readiness probe. Leave
+                    nil to use defaults.
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command is
+                            simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP allows
+                            repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                              - name
+                              - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: Name or number of the port to access on the container.
+                            Number must be in the range 1 to 65535. Name must be an
+                            IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                      required:
+                        - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                      before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to be
+                        considered successful after having failed. Defaults to 1. Must
+                        be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: 'TCPSocket specifies an action involving a TCP port.
+                      TCP hooks not yet supported TODO: implement a realistic TCP
+                      lifecycle hook'
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: Number or name of the port to access on the container.
+                            Number must be in the range 1 to 65535. Name must be an
+                            IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                        - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent a
+                        termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the expected
+                        cleanup time for your process. If this value is nil, the pod's
+                        terminationGracePeriodSeconds will be used. Otherwise, this
+                        value overrides the value provided by the pod spec. Value must
+                        be non-negative integer. The value zero indicates stop immediately
+                        via the kill signal (no opportunity to shut down). This is a
+                        beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                securityContext:
+                  description: SecurityContext applied to the Reaper main container.
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                      can gain more privileges than its parent process. This bool
+                      directly controls if the no_new_privs flag will be set on the
+                      container process. AllowPrivilegeEscalation is true always when
+                      the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the container
+                        runtime.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            description: Capability represent POSIX capabilities type
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            description: Capability represent POSIX capabilities type
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      description: Run container in privileged mode. Processes in privileged
+                        containers are essentially equivalent to root on the host. Defaults
+                        to false.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use for
+                        the containers. The default is DefaultProcMount which uses the
+                        container runtime defaults for readonly paths and masked paths.
+                        This requires the ProcMountType feature flag to be enabled.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container process.
+                        Uses runtime default if unset. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to start
+                        the container if it does. If unset or false, no such validation
+                        will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container process.
+                        Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by this container. If
+                        seccomp options are provided at both the pod & container level,
+                        the container options override the pod options.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must be
+                            preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: "type indicates which kind of seccomp profile
+                          will be applied. Valid options are: \n Localhost - a profile
+                          defined in a file on the node should be used. RuntimeDefault
+                          - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied."
+                          type: string
+                      required:
+                        - type
+                      type: object
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will
+                        be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named by
+                            the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: HostProcess determines if a container should
+                            be run as a 'Host Process' container. This field is alpha-level
+                            and will only be honored by components that enable the WindowsHostProcessContainers
+                            feature flag. Setting this field without the feature flag
+                            will result in errors when validating the Pod. All of a
+                            Pod's containers must have the same effective HostProcess
+                            value (it is not allowed to have a mix of HostProcess containers
+                            and non-HostProcess containers).  In addition, if HostProcess
+                            is true then HostNetwork must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                tolerations:
+                  description: Tolerations applied to the Reaper pods.
+                  items:
+                    description: The pod this Toleration is attached to tolerates any
+                      taint that matches the triple <key,value,effect> using the matching
+                      operator <operator>.
+                    properties:
+                      effect:
+                        description: Effect indicates the taint effect to match. Empty
+                          means match all taint effects. When specified, allowed values
+                          are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                      key:
+                        description: Key is the taint key that the toleration applies
+                          to. Empty means match all taint keys. If the key is empty,
+                          operator must be Exists; this combination means to match all
+                          values and all keys.
+                        type: string
+                      operator:
+                        description: Operator represents a key's relationship to the
+                          value. Valid operators are Exists and Equal. Defaults to Equal.
+                          Exists is equivalent to wildcard for value, so that a pod
+                          can tolerate all taints of a particular category.
+                        type: string
+                      tolerationSeconds:
+                        description: TolerationSeconds represents the period of time
+                          the toleration (which must be of effect NoExecute, otherwise
+                          this field is ignored) tolerates the taint. By default, it
+                          is not set, which means tolerate the taint forever (do not
+                          evict). Zero and negative values will be treated as 0 (evict
+                          immediately) by the system.
+                        format: int64
+                        type: integer
+                      value:
+                        description: Value is the taint value the toleration matches
+                          to. If the operator is Exists, the value should be empty,
+                          otherwise just a regular string.
+                        type: string
+                    type: object
+                  type: array
+              required:
+                - datacenterRef
+              type: object
+            status:
+              description: ReaperStatus defines the observed state of Reaper
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition
+                          transited from one status to another.
+                        format: date-time
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                progress:
+                  description: Progress is the progress of this Reaper object.
+                  enum:
+                    - Pending
+                    - Deploying
+                    - Configuring
+                    - Running
+                  type: string
+              required:
+                - progress
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/k8ssandra-operator/crds/replication.k8ssandra.io_replicatedsecrets.yaml
+++ b/charts/k8ssandra-operator/crds/replication.k8ssandra.io_replicatedsecrets.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -44,6 +43,11 @@ spec:
                         description: K8sContextName defines the target cluster name
                           as set in the ClientConfig. If left empty, current cluster
                           is assumed
+                        type: string
+                      namespace:
+                        description: TODO Implement at some point Namespace to replicate
+                          the data to in the target cluster. If left empty, current
+                          namespace is used.
                         type: string
                     type: object
                   type: array

--- a/charts/k8ssandra-operator/crds/stargate.k8ssandra.io_stargates.yaml
+++ b/charts/k8ssandra-operator/crds/stargate.k8ssandra.io_stargates.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -899,6 +898,49 @@ spec:
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                containerImage:
+                  default:
+                    repository: stargateio
+                    tag: v1.0.45
+                  description: ContainerImage is the image characteristics to use for
+                    Stargate containers. Leave nil to use a default image.
+                  properties:
+                    name:
+                      description: The image name to use.
+                      type: string
+                    pullPolicy:
+                      description: The image pull policy to use. Defaults to "Always"
+                        if the tag is "latest", otherwise to "IfNotPresent".
+                      enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                      type: string
+                    pullSecretRef:
+                      description: 'The secret to use when pulling the image from private
+                      repositories. If specified, this secret will be passed to individual
+                      puller implementations for them to use. For example, in the
+                      case of Docker, only DockerConfig type secrets are honored.
+                      More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    registry:
+                      default: docker.io
+                      description: The Docker registry to use. Defaults to "docker.io",
+                        the official Docker Hub.
+                      type: string
+                    repository:
+                      description: The Docker repository to use.
+                      type: string
+                    tag:
+                      default: latest
+                      description: The image tag to use. Defaults to "latest".
                       type: string
                   type: object
                 datacenterRef:
@@ -1967,6 +2009,49 @@ spec:
                             TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
+                      containerImage:
+                        default:
+                          repository: stargateio
+                          tag: v1.0.45
+                        description: ContainerImage is the image characteristics to
+                          use for Stargate containers. Leave nil to use a default image.
+                        properties:
+                          name:
+                            description: The image name to use.
+                            type: string
+                          pullPolicy:
+                            description: The image pull policy to use. Defaults to "Always"
+                              if the tag is "latest", otherwise to "IfNotPresent".
+                            enum:
+                              - Always
+                              - IfNotPresent
+                              - Never
+                            type: string
+                          pullSecretRef:
+                            description: 'The secret to use when pulling the image from
+                            private repositories. If specified, this secret will be
+                            passed to individual puller implementations for them to
+                            use. For example, in the case of Docker, only DockerConfig
+                            type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                            type: object
+                          registry:
+                            default: docker.io
+                            description: The Docker registry to use. Defaults to "docker.io",
+                              the official Docker Hub.
+                            type: string
+                          repository:
+                            description: The Docker repository to use.
+                            type: string
+                          tag:
+                            default: latest
+                            description: The image tag to use. Defaults to "latest".
+                            type: string
+                        type: object
                       heapSize:
                         anyOf:
                           - type: integer
@@ -2292,26 +2377,24 @@ spec:
                         description: ServiceAccount is the service account name to use
                           for Stargate pods.
                         type: string
-                      stargateContainerImage:
-                        description: StargateContainerImage is the image characteristics
-                          to use for Stargate containers. Leave nil to use a default
-                          image.
+                      telemetry:
+                        description: Telemetry defines the desired telemetry integrations
+                          to deploy targeting the Stargate pods for all DCs in this
+                          cluster (unless overriden by DC specific settings)
                         properties:
-                          pullPolicy:
-                            default: IfNotPresent
-                            description: PullPolicy describes a policy for if/when to
-                              pull a container image
-                            type: string
-                          registry:
-                            default: docker.io
-                            type: string
-                          repository:
-                            type: string
-                          tag:
-                            default: latest
-                            type: string
-                        required:
-                          - repository
+                          prometheus:
+                            properties:
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                description: CommonLabels are applied to all serviceMonitors
+                                  created.
+                                type: object
+                              enabled:
+                                description: Enable the creation of Prometheus serviceMonitors
+                                  for this resource (Cassandra or Stargate).
+                                type: boolean
+                            type: object
                         type: object
                       tolerations:
                         description: Tolerations are tolerations to apply to the Stargate
@@ -2527,25 +2610,24 @@ spec:
                   format: int32
                   minimum: 1
                   type: integer
-                stargateContainerImage:
-                  description: StargateContainerImage is the image characteristics to
-                    use for Stargate containers. Leave nil to use a default image.
+                telemetry:
+                  description: Telemetry defines the desired telemetry integrations
+                    to deploy targeting the Stargate pods for all DCs in this cluster
+                    (unless overriden by DC specific settings)
                   properties:
-                    pullPolicy:
-                      default: IfNotPresent
-                      description: PullPolicy describes a policy for if/when to pull
-                        a container image
-                      type: string
-                    registry:
-                      default: docker.io
-                      type: string
-                    repository:
-                      type: string
-                    tag:
-                      default: latest
-                      type: string
-                  required:
-                    - repository
+                    prometheus:
+                      properties:
+                        commonLabels:
+                          additionalProperties:
+                            type: string
+                          description: CommonLabels are applied to all serviceMonitors
+                            created.
+                          type: object
+                        enabled:
+                          description: Enable the creation of Prometheus serviceMonitors
+                            for this resource (Cassandra or Stargate).
+                          type: boolean
+                      type: object
                   type: object
                 tolerations:
                   description: Tolerations are tolerations to apply to the Stargate

--- a/charts/k8ssandra-operator/templates/clusterrole.yaml
+++ b/charts/k8ssandra-operator/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clusterScoped }}
+{{- if .Values.global.clusterScoped }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/k8ssandra-operator/templates/clusterrole.yaml
+++ b/charts/k8ssandra-operator/templates/clusterrole.yaml
@@ -1,6 +1,6 @@
-{{- if not .Values.clusterScoped }}
+{{- if .Values.clusterScoped }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: {{ include "k8ssandra-common.fullname" . }}
   labels: {{ include "k8ssandra-common.labels" . | indent 4 }}

--- a/charts/k8ssandra-operator/templates/clusterrolebinding.yaml
+++ b/charts/k8ssandra-operator/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clusterScoped }}
+{{- if .Values.global.clusterScoped }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/k8ssandra-operator/templates/clusterrolebinding.yaml
+++ b/charts/k8ssandra-operator/templates/clusterrolebinding.yaml
@@ -1,14 +1,15 @@
-{{- if not .Values.clusterScoped }}
+{{- if .Values.clusterScoped }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: {{ include "k8ssandra-common.fullname" . }}
   labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: {{ include "k8ssandra-common.fullname" . }}
 subjects:
-- kind: ServiceAccount
-  name: {{ template "k8ssandra-common.serviceAccountName" . }}
-  {{- end }}
+  - kind: ServiceAccount
+    name: {{ template "k8ssandra-common.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/k8ssandra-operator/templates/deployment.yaml
+++ b/charts/k8ssandra-operator/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "k8ssandra-common.fullname" . }}-k8ssandra-operator
+  name: {{ include "k8ssandra-common.fullname" . }}
   labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
     control-plane: k8ssandra-operator
 spec:
@@ -32,10 +32,15 @@ spec:
         # args:
         # - --config=controller_manager_config.yaml
         env:
+        {{- if .Values.clusterScoped}}
+        - name: WATCH_NAMESPACE
+          value: ""
+        {{- else }}
         - name: WATCH_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- end }}
         - name: K8SSANDRA_CONTROL_PLANE
           value: {{ .Values.controlPlane | quote }}
         image: {{ include "k8ssandra-common.flattenedImage" .Values.image }}

--- a/charts/k8ssandra-operator/templates/deployment.yaml
+++ b/charts/k8ssandra-operator/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         # args:
         # - --config=controller_manager_config.yaml
         env:
-        {{- if .Values.clusterScoped}}
+        {{- if .Values.global.clusterScoped}}
         - name: WATCH_NAMESPACE
           value: ""
         {{- else }}

--- a/charts/k8ssandra-operator/templates/role.yaml
+++ b/charts/k8ssandra-operator/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.clusterScoped }}
+{{- if not .Values.global.clusterScoped }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/k8ssandra-operator/templates/rolebinding.yaml
+++ b/charts/k8ssandra-operator/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.clusterScoped }}
+{{- if not .Values.global.clusterScoped }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/k8ssandra-operator/values.yaml
+++ b/charts/k8ssandra-operator/values.yaml
@@ -16,7 +16,7 @@ replicaCount: 1
 # K8ssandraCluster in the same namespace in which the operator is deployed
 # or if watches and manages K8ssandraClusters across all namespaces.
 # Not supported yet in k8ssandra-operator
-#clusterScoped: false
+clusterScoped: false
 
 # -- Determines if the k8ssandra-operator should be installed as the control plane
 # or if it's simply in a secondary cluster waiting to be promoted
@@ -33,7 +33,7 @@ image:
   pullPolicy: IfNotPresent
 
   # -- Tag of the k8ssandra-operator image to pull from image.repository
-  tag: 99c58003
+  tag: 5b95fc98
 
   # -- Docker registry containing all cass-operator related images. Setting this
   # allows for usage of an internal registry without specifying serverImage,

--- a/charts/k8ssandra-operator/values.yaml
+++ b/charts/k8ssandra-operator/values.yaml
@@ -1,3 +1,9 @@
+global:
+  # -- Determines whether k8ssandra-operator only watch and manages
+  # K8ssandraCluster in the same namespace in which the operator is deployed
+  # or if watches and manages K8ssandraClusters across all namespaces.
+  clusterScoped: false
+
 # -- A name in place of the chart name which is used in the metadata.name of
 # objects created by this chart.
 nameOverride: ''
@@ -11,12 +17,6 @@ commonLabels: {}
 
 # -- Sets the number of k8ssandra-operator pods.
 replicaCount: 1
-
-# -- Determines whether k8ssandra-operator only watch and manages
-# K8ssandraCluster in the same namespace in which the operator is deployed
-# or if watches and manages K8ssandraClusters across all namespaces.
-# Not supported yet in k8ssandra-operator
-clusterScoped: false
 
 # -- Determines if the k8ssandra-operator should be installed as the control plane
 # or if it's simply in a secondary cluster waiting to be promoted

--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -7,7 +7,7 @@ version: 1.5.0-SNAPSHOT
 
 dependencies:
   - name: cass-operator
-    version: 0.32.0
+    version: 0.33.0
     repository: file://../cass-operator
     condition: cass-operator.enabled
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
* Add/update CRDs
* Add support for cluster-scoped deployment
* Fix naming
* Update RBAC
* `clusterScoped` chart property is now global in both k8ssandra-operator and in cass-operator charts

By making `clusterScoped` global it only needs to be set once vs setting it separately for both charts, e.g.,

`helm install test ./charts/k8ssandra-operator --set "global.clusterScoped=true"`

whereas without the global variable you would instead have to do,

`helm install ./charts/k8ssandra-operator --set "clusterScoped=true,cass-operator.clusterScoped=true"`

Making `clusterScoped` global makes it easier for users without introducing a lot additional complexity in the chart templates.

**Which issue(s) this PR fixes**:
Fixes #1235

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
