### PR TITLE
Fix versions dropdown on mobile resolutions

### DIFF
--- a/docs/assets/scss/_colab_styles.scss
+++ b/docs/assets/scss/_colab_styles.scss
@@ -138,8 +138,13 @@ ul.footer-nav {
       display: flex;
       flex-flow: column nowrap;
       align-items: center;
+      li div.dropdown-menu {
+        @media (max-width: 992px) {
+          background-color: $blue;
+        }
+      }
       li a span {
-        display: block;
+        display: inline-block;
         padding: 10px 0;
         text-decoration: none;
         font-size: 20px;
@@ -150,6 +155,7 @@ ul.footer-nav {
           font-size: 16px;
           line-height: 1;
           color: unset;
+          background-color: unset;
         }
       }
       @media (min-width: 992px) {

--- a/docs/layouts/partials/navbar-version-selector.html
+++ b/docs/layouts/partials/navbar-version-selector.html
@@ -1,0 +1,8 @@
+<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+	<span>{{ .Site.Params.version_menu }}</span>
+</a>
+<div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+	{{ range .Site.Params.versions }}
+	<a class="dropdown-item" href="{{ .url }}"><span>{{ .version }}</span></a>
+	{{ end }}
+</div>

--- a/docs/layouts/partials/navbar.html
+++ b/docs/layouts/partials/navbar.html
@@ -22,7 +22,7 @@
 			</li>
 			{{ end }}
 			{{ if  .Site.Params.versions }}
-			<li class="nav-item dropdown d-none d-lg-block">
+			<li class="nav-item dropdown mr-2 mr-xl-3 mb-2 mb-lg-0">
 				{{ partial "navbar-version-selector.html" . }}
 			</li>
 			{{ end }}


### PR DESCRIPTION
**What this PR does**:
Makes the new `Versions` dropdown available on the mobile resolution version of the menu.

This will need to be cherry picked to `docs` and `docs-v1` as well.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
