### PR TITLE
Add operators in the dep upgrade workflow

### DIFF
--- a/.github/workflows/dependency-upgrade.yaml
+++ b/.github/workflows/dependency-upgrade.yaml
@@ -13,17 +13,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dependency: ["Stargate", "Medusa", "Reaper"]
+        dependency: ["Stargate", "Medusa", "Reaper", "cass-operator", "k8ssandra-operator"]
         include:
           - dependency: Stargate
             version_path: ".stargate.version"
-            docker_hub_url: "https://registry.hub.docker.com/v2/repositories/stargateio/stargate-3_11/tags?page_size=25"
+            operator: false
+            docker_hub_url: "https://registry.hub.docker.com/v2/repositories/stargateio/stargate-3_11/tags?page_size=100"
           - dependency: Medusa
             version_path: ".medusa.image.tag"
-            docker_hub_url: "https://registry.hub.docker.com/v2/repositories/k8ssandra/medusa/tags?page_size=25"
+            operator: false
+            docker_hub_url: "https://registry.hub.docker.com/v2/repositories/k8ssandra/medusa/tags?page_size=100"
           - dependency: Reaper
             version_path: ".reaper.image.tag"
-            docker_hub_url: "https://registry.hub.docker.com/v2/repositories/thelastpickle/cassandra-reaper/tags?page_size=25"
+            operator: false
+            docker_hub_url: "https://registry.hub.docker.com/v2/repositories/thelastpickle/cassandra-reaper/tags?page_size=100"
+          - dependency: cass-operator
+            app_version_path: ".appVersion"
+            version_path: ".version"
+            chart_file: "charts/cass-operator/Chart.yaml"
+            operator: true
+            docker_hub_url: "https://registry.hub.docker.com/v2/repositories/k8ssandra/cass-operator/tags?page_size=100"
+          - dependency: k8ssandra-operator
+            app_version_path: ".appVersion"
+            version_path: ".version"
+            chart_file: "charts/k8ssandra-operator/Chart.yaml"
+            operator: true
+            docker_hub_url: "https://registry.hub.docker.com/v2/repositories/k8ssandra/k8ssandra-operator/tags?page_size=100"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -41,8 +56,12 @@ jobs:
           jq --version
       - name: Get current dependencies versions
         run: |
-          CURRENT=$(yq e '${{ matrix.version_path }}' charts/k8ssandra/values.yaml)
           
+          if [ "${{ matrix.operator }}" == "true" ]; then
+            CURRENT=$(yq e '${{ matrix.app_version_path }}' ${{ matrix.chart_file }})
+          else
+            CURRENT=$(yq e '${{ matrix.version_path }}' charts/k8ssandra/values.yaml)
+          fi
           echo "CURRENT_VERSION=${CURRENT}" >> $GITHUB_ENV
           
       - name: Get latest released versions
@@ -56,9 +75,23 @@ jobs:
           CLOSED_UPGRADE_PR=$(curl -L -s "https://api.github.com/repos/k8ssandra/k8ssandra/pulls?state=closed"|jq -c '.[] | select( .title == "Upgrade ${{ matrix.dependency }} dependency ${{ env.CURRENT_VERSION }} -> ${{ env.LATEST_VERSION }}" )'|jq -r '.title')
           
           if [ -z "$CLOSED_UPGRADE_PR" ] && [ "${{ env.CURRENT_VERSION }}" != "${{ env.LATEST_VERSION }}" ]; then
+            if [ "${{ matrix.operator }}" == "true" ]; then
+              CHART_VERSION=$(yq eval '.version' ${{ matrix.chart_file }})
+              NEW_CHART_VERSION=$(echo "$CHART_VERSION"|awk -F. -v OFS=. '{$NF += 1 ; print}')
+              yq eval "${{ matrix.app_version_path }} |= \"${{ env.LATEST_VERSION }}\"" ${{ matrix.chart_file }} -i
+              yq eval "${{ matrix.version_path }} |= \"${NEW_CHART_VERSION}\"" ${{ matrix.chart_file }} -i
+              yq eval "(.dependencies.[]| select(.name == \"${{ matrix.dependency }}\")| .version) |= \"${NEW_CHART_VERSION}\"" charts/k8ssandra/Chart.yaml -i
+              if [ "${{ matrix.dependency }}" == "cass-operator" ]; then
+                # Update the cass-operator chart version in the k8ssandra-operator chart
+                yq eval "(.dependencies.[]| select(.name == \"${{ matrix.dependency }}\")| .version) |= \"${NEW_CHART_VERSION}\"" charts/k8ssandra-operator/Chart.yaml -i
+              fi
+              cat ${{ matrix.chart_file }}
+              cat charts/k8ssandra/Chart.yaml
+            else
+              yq eval "${{ matrix.version_path }} |= \"${{ env.LATEST_VERSION }}\"" charts/k8ssandra/values.yaml -i
+              cat charts/k8ssandra/values.yaml
+            fi
             echo "PR_EXISTS=no" >> $GITHUB_ENV
-            yq eval "${{ matrix.version_path }} |= \"${{ env.LATEST_VERSION }}\"" charts/k8ssandra/values.yaml -i
-            cat charts/k8ssandra/values.yaml
           else
             echo "PR_EXISTS=yes" >> $GITHUB_ENV
           fi

--- a/.github/workflows/dependency-upgrade.yaml
+++ b/.github/workflows/dependency-upgrade.yaml
@@ -21,42 +21,48 @@ jobs:
             chart_version_path: ""
             operator: false
             docker_hub_url: "https://registry.hub.docker.com/v2/repositories/stargateio/stargate-3_11/tags?page_size=100"
+            version_character: ""
           - dependency: Medusa
             version_path: ".medusa.image.tag"
             values_file: "charts/k8ssandra/values.yaml"
             chart_version_path: ""
             operator: false
             docker_hub_url: "https://registry.hub.docker.com/v2/repositories/k8ssandra/medusa/tags?page_size=100"
+            version_character: ""
           - dependency: Reaper
             version_path: ".reaper.image.tag"
             values_file: "charts/k8ssandra/values.yaml"
             chart_version_path: ""
             operator: false
             docker_hub_url: "https://registry.hub.docker.com/v2/repositories/thelastpickle/cassandra-reaper/tags?page_size=100"
+            version_character: ""
           - dependency: cass-operator
             app_version_path: ".appVersion"
-            version_path: ".version"
+            version_path: ".image.tag"
             values_file: "charts/cass-operator/values.yaml"
             chart_version_path: ".version"
             chart_file: "charts/cass-operator/Chart.yaml"
             operator: true
             docker_hub_url: "https://registry.hub.docker.com/v2/repositories/k8ssandra/cass-operator/tags?page_size=100"
+            version_character: "v"
           - dependency: k8ssandra-operator
             app_version_path: ".appVersion"
-            version_path: ".version"
+            version_path: ".image.tag"
             values_file: "charts/k8ssandra-operator/values.yaml"
             chart_version_path: ".version"
             chart_file: "charts/k8ssandra-operator/Chart.yaml"
             operator: true
             docker_hub_url: "https://registry.hub.docker.com/v2/repositories/k8ssandra/k8ssandra-operator/tags?page_size=100"
+            version_character: "v"
           - dependency: medusa-operator
             app_version_path: ".appVersion"
-            version_path: ".version"
+            version_path: ".image.tag"
             values_file: "charts/medusa-operator/values.yaml"
             chart_version_path: ".version"
             chart_file: "charts/medusa-operator/Chart.yaml"
             operator: true
             docker_hub_url: "https://registry.hub.docker.com/v2/repositories/k8ssandra/medusa-operator/tags?page_size=100"
+            version_character: "v"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -107,7 +113,7 @@ jobs:
               cat ${{ matrix.chart_file }}
               cat charts/k8ssandra/Chart.yaml
             fi
-            yq eval "${{ matrix.version_path }} |= \"${{ env.LATEST_VERSION }}\"" ${{ matrix.values_file }} -i
+            yq eval "${{ matrix.version_path }} |= \"${{ matrix.version_character }}${{ env.LATEST_VERSION }}\"" ${{ matrix.values_file }} -i
             cat ${{ matrix.values_file }}
             echo "PR_EXISTS=no" >> $GITHUB_ENV
           else

--- a/.github/workflows/dependency-upgrade.yaml
+++ b/.github/workflows/dependency-upgrade.yaml
@@ -115,7 +115,6 @@ jobs:
                 # Update the cass-operator chart version in the k8ssandra-operator chart
                 yq eval "(.dependencies.[]| select(.name == \"cass-operator\")| .version) |= \"${NEW_CHART_VERSION}\"" charts/k8ssandra-operator/Chart.yaml -i
               fi
-              yq eval "${{ matrix.version_path }} |= \"${{ env.LATEST_VERSION }}\"" charts/${{ matrix.dependency }}/values.yaml -i
             fi
             yq eval "${{ matrix.version_path }} |= \"${{ matrix.version_character }}${{ env.LATEST_VERSION }}\"" ${{ matrix.values_file }} -i
             echo "PR_EXISTS=no" >> $GITHUB_ENV

--- a/.github/workflows/dependency-upgrade.yaml
+++ b/.github/workflows/dependency-upgrade.yaml
@@ -17,28 +17,46 @@ jobs:
         include:
           - dependency: Stargate
             version_path: ".stargate.version"
+            values_file: "charts/k8ssandra/values.yaml"
+            chart_version_path: ""
             operator: false
             docker_hub_url: "https://registry.hub.docker.com/v2/repositories/stargateio/stargate-3_11/tags?page_size=100"
           - dependency: Medusa
             version_path: ".medusa.image.tag"
+            values_file: "charts/k8ssandra/values.yaml"
+            chart_version_path: ""
             operator: false
             docker_hub_url: "https://registry.hub.docker.com/v2/repositories/k8ssandra/medusa/tags?page_size=100"
           - dependency: Reaper
             version_path: ".reaper.image.tag"
+            values_file: "charts/k8ssandra/values.yaml"
+            chart_version_path: ""
             operator: false
             docker_hub_url: "https://registry.hub.docker.com/v2/repositories/thelastpickle/cassandra-reaper/tags?page_size=100"
           - dependency: cass-operator
             app_version_path: ".appVersion"
             version_path: ".version"
+            values_file: "charts/cass-operator/values.yaml"
+            chart_version_path: ".version"
             chart_file: "charts/cass-operator/Chart.yaml"
             operator: true
             docker_hub_url: "https://registry.hub.docker.com/v2/repositories/k8ssandra/cass-operator/tags?page_size=100"
           - dependency: k8ssandra-operator
             app_version_path: ".appVersion"
             version_path: ".version"
+            values_file: "charts/k8ssandra-operator/values.yaml"
+            chart_version_path: ".version"
             chart_file: "charts/k8ssandra-operator/Chart.yaml"
             operator: true
             docker_hub_url: "https://registry.hub.docker.com/v2/repositories/k8ssandra/k8ssandra-operator/tags?page_size=100"
+          - dependency: medusa-operator
+            app_version_path: ".appVersion"
+            version_path: ".version"
+            values_file: "charts/medusa-operator/values.yaml"
+            chart_version_path: ".version"
+            chart_file: "charts/medusa-operator/Chart.yaml"
+            operator: true
+            docker_hub_url: "https://registry.hub.docker.com/v2/repositories/k8ssandra/medusa-operator/tags?page_size=100"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -76,21 +94,21 @@ jobs:
           
           if [ -z "$CLOSED_UPGRADE_PR" ] && [ "${{ env.CURRENT_VERSION }}" != "${{ env.LATEST_VERSION }}" ]; then
             if [ "${{ matrix.operator }}" == "true" ]; then
-              CHART_VERSION=$(yq eval '.version' ${{ matrix.chart_file }})
+              CHART_VERSION=$(yq eval '${{ matrix.chart_version_path }}' ${{ matrix.chart_file }})
               NEW_CHART_VERSION=$(echo "$CHART_VERSION"|awk -F. -v OFS=. '{$NF += 1 ; print}')
               yq eval "${{ matrix.app_version_path }} |= \"${{ env.LATEST_VERSION }}\"" ${{ matrix.chart_file }} -i
-              yq eval "${{ matrix.version_path }} |= \"${NEW_CHART_VERSION}\"" ${{ matrix.chart_file }} -i
-              yq eval "(.dependencies.[]| select(.name == \"${{ matrix.dependency }}\")| .version) |= \"${NEW_CHART_VERSION}\"" charts/k8ssandra/Chart.yaml -i
+              yq eval "${{ matrix.chart_version_path }} |= \"${NEW_CHART_VERSION}\"" ${{ matrix.chart_file }} -i
+              yq eval "(.dependencies.[]| select(.name == \"${{ matrix.dependency }}\")| ${{ matrix.chart_version_path }}) |= \"${NEW_CHART_VERSION}\"" charts/k8ssandra/Chart.yaml -i
               if [ "${{ matrix.dependency }}" == "cass-operator" ]; then
                 # Update the cass-operator chart version in the k8ssandra-operator chart
-                yq eval "(.dependencies.[]| select(.name == \"${{ matrix.dependency }}\")| .version) |= \"${NEW_CHART_VERSION}\"" charts/k8ssandra-operator/Chart.yaml -i
+                yq eval "(.dependencies.[]| select(.name == \"${{ matrix.dependency }}\")| ${{ matrix.chart_version_path }}) |= \"${NEW_CHART_VERSION}\"" charts/k8ssandra-operator/Chart.yaml -i
               fi
+              yq eval "${{ matrix.version_path }} |= \"${{ env.LATEST_VERSION }}\"" charts/${{ matrix.dependency }}/values.yaml -i
               cat ${{ matrix.chart_file }}
               cat charts/k8ssandra/Chart.yaml
-            else
-              yq eval "${{ matrix.version_path }} |= \"${{ env.LATEST_VERSION }}\"" charts/k8ssandra/values.yaml -i
-              cat charts/k8ssandra/values.yaml
             fi
+            yq eval "${{ matrix.version_path }} |= \"${{ env.LATEST_VERSION }}\"" ${{ matrix.values_file }} -i
+            cat ${{ matrix.values_file }}
             echo "PR_EXISTS=no" >> $GITHUB_ENV
           else
             echo "PR_EXISTS=yes" >> $GITHUB_ENV

--- a/.github/workflows/dependency-upgrade.yaml
+++ b/.github/workflows/dependency-upgrade.yaml
@@ -18,21 +18,18 @@ jobs:
           - dependency: Stargate
             version_path: ".stargate.version"
             values_file: "charts/k8ssandra/values.yaml"
-            chart_version_path: ""
             operator: false
             docker_hub_url: "https://registry.hub.docker.com/v2/repositories/stargateio/stargate-3_11/tags?page_size=100"
             version_character: ""
           - dependency: Medusa
             version_path: ".medusa.image.tag"
             values_file: "charts/k8ssandra/values.yaml"
-            chart_version_path: ""
             operator: false
             docker_hub_url: "https://registry.hub.docker.com/v2/repositories/k8ssandra/medusa/tags?page_size=100"
             version_character: ""
           - dependency: Reaper
             version_path: ".reaper.image.tag"
             values_file: "charts/k8ssandra/values.yaml"
-            chart_version_path: ""
             operator: false
             docker_hub_url: "https://registry.hub.docker.com/v2/repositories/thelastpickle/cassandra-reaper/tags?page_size=100"
             version_character: ""
@@ -116,14 +113,11 @@ jobs:
               yq eval "(.dependencies.[]| select(.name == \"${{ matrix.dependency }}\")| ${{ matrix.chart_version_path }}) |= \"${NEW_CHART_VERSION}\"" charts/k8ssandra/Chart.yaml -i
               if [ "${{ matrix.dependency }}" == "cass-operator" ]; then
                 # Update the cass-operator chart version in the k8ssandra-operator chart
-                yq eval "(.dependencies.[]| select(.name == \"${{ matrix.dependency }}\")| ${{ matrix.chart_version_path }}) |= \"${NEW_CHART_VERSION}\"" charts/k8ssandra-operator/Chart.yaml -i
+                yq eval "(.dependencies.[]| select(.name == \"cass-operator\")| .version) |= \"${NEW_CHART_VERSION}\"" charts/k8ssandra-operator/Chart.yaml -i
               fi
               yq eval "${{ matrix.version_path }} |= \"${{ env.LATEST_VERSION }}\"" charts/${{ matrix.dependency }}/values.yaml -i
-              cat ${{ matrix.chart_file }}
-              cat charts/k8ssandra/Chart.yaml
             fi
             yq eval "${{ matrix.version_path }} |= \"${{ matrix.version_character }}${{ env.LATEST_VERSION }}\"" ${{ matrix.values_file }} -i
-            cat ${{ matrix.values_file }}
             echo "PR_EXISTS=no" >> $GITHUB_ENV
           else
             echo "PR_EXISTS=yes" >> $GITHUB_ENV

--- a/.github/workflows/dependency-upgrade.yaml
+++ b/.github/workflows/dependency-upgrade.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dependency: ["Stargate", "Medusa", "Reaper", "cass-operator", "k8ssandra-operator"]
+        dependency: ["Stargate", "Medusa", "Reaper", "cass-operator", "k8ssandra-operator", "medusa-operator", "reaper-operator"]
         include:
           - dependency: Stargate
             version_path: ".stargate.version"
@@ -62,6 +62,15 @@ jobs:
             chart_file: "charts/medusa-operator/Chart.yaml"
             operator: true
             docker_hub_url: "https://registry.hub.docker.com/v2/repositories/k8ssandra/medusa-operator/tags?page_size=100"
+            version_character: "v"
+          - dependency: reaper-operator
+            app_version_path: ".appVersion"
+            version_path: ".image.tag"
+            values_file: "charts/reaper-operator/values.yaml"
+            chart_version_path: ".version"
+            chart_file: "charts/reaper-operator/Chart.yaml"
+            operator: true
+            docker_hub_url: "https://registry.hub.docker.com/v2/repositories/k8ssandra/reaper-operator/tags?page_size=100"
             version_character: "v"
     steps:
       - name: Checkout

--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -7,7 +7,7 @@ version: 1.5.0-SNAPSHOT
 
 dependencies:
   - name: cass-operator
-    version: 0.33.0
+    version: 0.35.0
     repository: file://../cass-operator
     condition: cass-operator.enabled
 

--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -8,7 +8,7 @@ version: 1.5.0-SNAPSHOT
 dependencies:
   - name: cass-operator
     version: 0.33.0
-    repository: https://helm.k8ssandra.io/stable
+    repository: file://../cass-operator
     condition: cass-operator.enabled
 
   - name: reaper-operator


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Updates the dependency upgrade GHA workflow to upgrade the following operators:

- k8ssandra-operator
- cass-operator
- reaper-operator
- medusa-operator

Sample generated PRs can be seen [here](https://github.com/adejanovski/k8ssandra/pulls).

**Which issue(s) this PR fixes**:
Fixes #1304
Fixes #1305

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
