### PR TITLE
Upgrade Stargate dependency 1.0.44 -> 1.0.50

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -18,7 +18,7 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 
 ## unreleased
 
+* [CHANGE] Upgrade Stargate to v1.0.50
 * [CHANGE] Upgrade Medusa to v0.12.1
 * [CHANGE] Upgrade Reaper to v3.1.1
 * [CHANGE] Upgrade Management API to v0.1.37
-* [CHANGE] Upgrade Stargate to v1.0.44

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -429,7 +429,7 @@ stargate:
   enabled: true
   # -- version of Stargate to deploy. This is used in conjunction with cassandra.version to select the Stargate container image.
   # If stargate.image is set, this value has no effect.
-  version: "1.0.44"
+  version: "1.0.50"
   # -- Sets the Stargate container image. This value must be compatible
   # with the value provided for stargate.clusterVersion. If left blank (recommended),
   # k8ssandra will derive an appropriate image based on cassandra.clusterVersion.


### PR DESCRIPTION
This is auto-generated update from the K8ssandra upgrade GHA workflow.
Check that CI passes correctly before merging this PR.