### PR TITLE
Upgrade cass-operator dependency 1.10.0 -> 1.10.1

### DIFF
--- a/charts/cass-operator/Chart.yaml
+++ b/charts/cass-operator/Chart.yaml
@@ -3,8 +3,8 @@ name: cass-operator
 description: |
   Kubernetes operator which handles the provisioning and management of Apache Cassandra clusters.
 type: application
-version: 0.35.0
-appVersion: 1.10.0
+version: 0.35.1
+appVersion: 1.10.1
 dependencies:
   - name: k8ssandra-common
     version: 0.28.4

--- a/charts/cass-operator/values.yaml
+++ b/charts/cass-operator/values.yaml
@@ -3,59 +3,45 @@ global:
   # CassandraDatacenters in the same namespace in which the operator is deployed
   # or if watches and manages CassandraDatacenters across all namespaces.
   clusterScoped: false
-
 # -- A name in place of the chart name which is used in the metadata.name of
 # objects created by this chart.
 nameOverride: ''
-
 # -- A name in place of the value used for metadata.name in objects created by
 # this chart. The default value has the form releaseName-chartName.
 fullnameOverride: ''
-
 # -- Labels to be added to all deployed resources.
 commonLabels: {}
-
 # -- Sets the number of cass-operator pods.
 replicaCount: 1
-
 # -- Configures admission webhooks deployed with cass-operator.
 admissionWebhooks:
   # -- Turns the admission webhooks on or off
   enabled: false
-
 # Sets properties for the cass-operator container
 image:
   # -- Container registry containing the repository where the image resides
   registry: docker.io
   # -- Docker repository for cass-operator
   repository: k8ssandra/cass-operator
-
   # -- Pull policy for the operator container
   pullPolicy: IfNotPresent
-
   # -- Tag of the cass-operator image to pull from image.repository
-  tag: v1.10.0
-
+  tag: v1.10.1
   # -- Docker registry containing all cass-operator related images. Setting this
   # allows for usage of an internal registry without specifying serverImage,
   # configBuilderImage, and busyboxImage on all CassandraDatacenter objects.
   registryOverride:
-
 # -- References to secrets to use when pulling images. See:
 # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
-
 serviceAccount:
   # -- Annotations to add to the service account.
   annotations: {}
-
 # -- Annotations for the cass-operator pod.
 podAnnotations: {}
-
 # -- PodSecurityContext for the cass-operator pod. See:
 # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 podSecurityContext: {}
-
 securityContext:
   # -- Run cass-operator container as non-root user
   runAsNonRoot: true
@@ -65,7 +51,6 @@ securityContext:
   runAsUser: 65534
   # -- Run cass-operator container having read-only root file system permissions.
   readOnlyRootFilesystem: true
-
 # -- Resources requests and limits for the cass-operator pod. We usually
 # recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments
@@ -73,7 +58,6 @@ securityContext:
 # `requests` and `limits` for `cpu` and `memory` while removing the existing
 # `{}`
 resources: {}
-
 # -- Enables specific VMware functionality. If you need this functionality it
 # will automatically be enabled for you.
 vmwarePSPEnabled: false

--- a/charts/k8ssandra-operator/Chart.yaml
+++ b/charts/k8ssandra-operator/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: 0.28.4
     repository: file://../k8ssandra-common
   - name: cass-operator
-    version: 0.35.0
+    version: 0.35.1
     repository: file://../cass-operator
 home: https://github.com/k8ssandra/k8ssandra-operator
 sources:

--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 version: 1.5.0-SNAPSHOT
 dependencies:
   - name: cass-operator
-    version: 0.35.0
+    version: 0.35.1
     repository: file://../cass-operator
     condition: cass-operator.enabled
   - name: reaper-operator


### PR DESCRIPTION
This is auto-generated update from the K8ssandra upgrade GHA workflow.
Check that CI passes correctly before merging this PR.