### PR TITLE
add support for applying custom labels to cass-operator chart

### DIFF
--- a/charts/cass-operator/Chart.yaml
+++ b/charts/cass-operator/Chart.yaml
@@ -7,7 +7,7 @@ version: 0.35.1
 appVersion: 1.10.1
 dependencies:
   - name: k8ssandra-common
-    version: 0.28.4
+    version: 0.29.0
     repository: file://../k8ssandra-common
 home: https://github.com/k8ssandra/cass-operator
 sources:

--- a/charts/k8ssandra-common/Chart.yaml
+++ b/charts/k8ssandra-common/Chart.yaml
@@ -3,7 +3,7 @@ name: k8ssandra-common
 description: |
   Helper library containing functions used by many of the K8ssandra stack Helm charts.
 type: library
-version: 0.28.4
+version: 0.29.0
 dependencies:
   - name: common
     version: 1.3.4

--- a/charts/k8ssandra-common/templates/_helpers.tpl
+++ b/charts/k8ssandra-common/templates/_helpers.tpl
@@ -23,7 +23,14 @@ Create chart name and version as used by the chart label.
 
 {{- define "k8ssandra-common.labels" }}
 {{ include "common.labels.standard" . }}
-app.kubernetes.io/part-of: k8ssandra-{{ .Release.Name }}-{{ .Release.Namespace }}
+{{- if .Values.standardLabels }}
+app.kubernetes.io/part-of: {{ default (printf "k8ssandra-%s-%s" .Release.Name .Release.Namespace) .Values.standardLabels.partOf | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+app.kubernetes.io/part-of: {{ printf "k8ssandra-%s-%s" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- if .Values.commonLabels }}
+{{ toYaml .Values.commonLabels}}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -32,7 +39,11 @@ Selector labels
 {{- define "k8ssandra-common.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "k8ssandra-common.name" . | replace "\n" "" }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/part-of: k8ssandra-{{ .Release.Name }}-{{ .Release.Namespace }}
+{{- if .Values.standardLabels }}
+app.kubernetes.io/part-of: {{ default (printf "k8ssandra-%s-%s" .Release.Name .Release.Namespace) .Values.standardLabels.partOf | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+app.kubernetes.io/part-of: {{ printf "k8ssandra-%s-%s" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/k8ssandra-common/values.yaml
+++ b/charts/k8ssandra-common/values.yaml
@@ -5,3 +5,7 @@ nameOverride: ""
 # -- Replaces the value used for metadata.name in objects created by this chart.
 # The default value has the form releaseName-chartName.
 fullnameOverride: ""
+
+commonLabels: {}
+
+standardLabels: {}


### PR DESCRIPTION
This commit also makes the app.kubernetes.io/part-of label configurable. I need
for a use case outside of k8ssandra where the default generated label value is
invalid because it exceeds 63 chars.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
If `commonLabels` is set then all of the labels are applied to resources generated by the cass-operator chart.

I also added a `standardLabels` property in k8ssandra-common. It's kind of a hack. For my use case I need to override the `app.kubernetes.io/part-of` label because the generated value exceed the 63 char limit. I could have just added the truncation, but I want to fully customize the value.

**Which issue(s) this PR fixes**:
Fixes #1360

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
