### PR TITLE
update setup-gclouds-action action

### DIFF
--- a/.github/workflows/integration-tests-release.yaml
+++ b/.github/workflows/integration-tests-release.yaml
@@ -328,7 +328,7 @@ jobs:
         working-directory: build/${{ steps.compute_next_version.outputs.RELEASE_VERSION }}
 
       # Helm Release
-      - uses: google-github-actions/setup-gcloud@master
+      - uses: google-github-actions/setup-gcloud@v0
         with:
           version: '290.0.1'
           project_id: ${{ secrets.GCP_PROJECT_ID }}


### PR DESCRIPTION
The build and release workflow failed on the last merged to main (see [here](https://github.com/k8ssandra/k8ssandra/runs/5661657938?check_suite_focus=true)) with this error:

```
Error: On 2022-04-05, the default branch will be renamed from "master" to "main". Your action is currently pinned to "@master". Even though GitHub creates redirects for renamed branches, testing found that this rename breaks existing GitHub Actions workflows that are pinned to the old branch name.

We strongly advise updating your GitHub Action YAML from:

    uses: 'google-github-actions/setup-gcloud@master'

to:

    uses: 'google-github-actions/setup-gcloud@v0'
```