### PR TITLE
Fix gc properties 4.0

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -18,7 +18,9 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 
 ## unreleased
 
+* [FEATURE] Enable the use of ZGC (Z Garbage Collector) for Cassandra 4.0
 * [CHANGE] Upgrade Stargate to v1.0.52
 * [CHANGE] Upgrade Medusa to v0.12.1
 * [CHANGE] Upgrade Reaper to v3.1.1
 * [CHANGE] Upgrade Management API to v0.1.37
+* [BUGFIX] Fix GC subsettings mappings for Cassandra 4.0

--- a/charts/k8ssandra/templates/cassandra/cassdc.yaml
+++ b/charts/k8ssandra/templates/cassandra/cassdc.yaml
@@ -181,11 +181,14 @@ spec:
   {{- end }}
   {{- if (hasPrefix "3" .Values.cassandra.version) }}
     jvm-options:
+    {{- include "k8ssandra.configureJvmHeap" . }}
+    {{- include "k8ssandra.configureGc" . -}}
   {{- else }}
     jvm-server-options:
-  {{- end }}
-    {{- include "k8ssandra.configureGc" . -}}
     {{- include "k8ssandra.configureJvmHeap" . }}
+    jvm11-server-options:
+    {{- include "k8ssandra.configureGc" . -}}
+  {{- end }}
       additional-jvm-opts:
 {{- if .Values.cassandra.auth.enabled }}
         - "-Dcassandra.system_distributed_replication_dc_names={{ $datacenter.name }}"

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -228,6 +228,9 @@ cassandra:
   gc:
     # -- GC configuration for the CMS collector.
     cms: {}
+    # CMS cannot be used with Cassandra 4.0 and later due to cass-operator dependencies.
+    # Even if marked as enabled here, G1 will be used.
+    #
     # -- Enables the CMS garbage collector
     # enabled: true
 
@@ -248,29 +251,38 @@ cassandra:
 
     # -- GC configuration for the G1 collector.
     g1: {}
+    # Default for Apache Cassandra 4.0 and later.
     # -- Enabled the G1 garbage collector.
     # enabled: true
-  # -- Determines the percentage of total garbage collection time that
-  # should be spent in the Update RS phase updating any remaining
-  # remembered sets. G1 controls the amount of concurrent remembered set
-  # updates using this setting.
-  # setUpdatingPauseTimePercent: 5
+    # -- Determines the percentage of total garbage collection time that
+    # should be spent in the Update RS phase updating any remaining
+    # remembered sets. G1 controls the amount of concurrent remembered set
+    # updates using this setting.
+    # setUpdatingPauseTimePercent: 5
 
-  # -- Sets a target value for desired maximum pause time.
-  # maxGcPauseMillis: 500
+    # -- Sets a target value for desired maximum pause time.
+    # maxGcPauseMillis: 500
 
-  # -- Sets the heap occupancy threshold that triggers a marking cycle.
-  # initiatingHeapOccupancyPercent: 70
+    # -- Sets the heap occupancy threshold that triggers a marking cycle.
+    # initiatingHeapOccupancyPercent: 70
 
-  # -- Set the number of stop the world (STW) worker threads.
-  # parallelGcThreads: 16
+    # -- Set the number of stop the world (STW) worker threads.
+    # parallelGcThreads: 16
 
-  # -- Set the number of stop the world (STW) worker threads.
-  # concurrentGcThreads: 16
+    # -- Set the number of stop the world (STW) worker threads.
+    # concurrentGcThreads: 16
 
-  # -- Resource requests for each Cassandra pod. See
-  # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-  # for background on managing resources.
+    # -- Resource requests for each Cassandra pod. See
+    # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+    # for background on managing resources.
+
+    # -- GC configuration for the ZGC collector.
+    zgc: {}
+    # Only for Apache Cassandra 4.0 and later.
+    # -- Enable the ZGC garbage collector.
+    # enabled: true
+
+
   resources: {}
   # Tolerations to apply to the Cassandra pods. See
   # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for background.

--- a/tests/integration/charts/cluster_full_stack.yaml
+++ b/tests/integration/charts/cluster_full_stack.yaml
@@ -2,6 +2,9 @@ cassandra:
   heap:
    size: 500M
    newGenSize: 200M
+  gc:
+    g1:
+      enabled: true
   datacenters:
   - name: dc1
     size: 3

--- a/tests/integration/charts/cluster_with_medusa_minio_upgraded.yaml
+++ b/tests/integration/charts/cluster_with_medusa_minio_upgraded.yaml
@@ -2,6 +2,9 @@ cassandra:
   heap:
     size: 505M
     newGenSize: 201M
+  gc:
+    g1:
+      enabled: true
   datacenters:
     - name: dc1
       size: 1

--- a/tests/integration/charts/cluster_with_reaper.yaml
+++ b/tests/integration/charts/cluster_with_reaper.yaml
@@ -2,6 +2,9 @@ cassandra:
   heap:
    size: 500M
    newGenSize: 200M
+  gc:
+    g1:
+      enabled: true
   datacenters:
   - name: dc1
     size: 3

--- a/tests/integration/charts/cluster_with_reaper_upgraded.yaml
+++ b/tests/integration/charts/cluster_with_reaper_upgraded.yaml
@@ -2,6 +2,9 @@ cassandra:
   heap:
     size: 505M
     newGenSize: 201M
+  gc:
+    g1:
+      enabled: true
   datacenters:
     - name: dc1
       size: 3

--- a/tests/integration/steps/integration_steps.go
+++ b/tests/integration/steps/integration_steps.go
@@ -141,8 +141,11 @@ func deployCluster(t *testing.T, namespace, customValues string, helmValues map[
 	// Wait for CassandraDatacenter to be ready..
 	WaitForCassDcToBeReady(t, namespace)
 
-	// check that jvm options are set on the right files
-	checkJvmOptions(t, namespace)
+	if useLocalCharts {
+		// Previous versions may not support this check
+		// check that jvm options are set on the right files
+		checkJvmOptions(t, namespace)
+	}
 }
 
 func DeployClusterWithValues(t *testing.T, namespace, medusaBackend, customValues string, nodes int, upgrade bool, useLocalCharts bool, version string) {

--- a/tests/unit/template_4x_features_test.go
+++ b/tests/unit/template_4x_features_test.go
@@ -175,9 +175,9 @@ var _ = Describe("Verify 4x features are created in template", func() {
 			var dcCfg map[string]interface{}
 			json.Unmarshal(cassDC.Spec.Config, &dcCfg)
 
-			jvmOpts, ok := dcCfg["jvm-server-options"]
+			jvmOpts, ok := dcCfg["jvm11-server-options"]
 			if !ok {
-				Fail("couldn't index jvm-server-options in dc config")
+				Fail("couldn't index jvm11-server-options in dc config")
 			}
 
 			additionalOpts, ok := jvmOpts.(map[string]interface{})["additional-jvm-opts"]

--- a/tests/unit/template_cassdc_test.go
+++ b/tests/unit/template_cassdc_test.go
@@ -140,9 +140,9 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 			// JVM heap options -- default to settings as defined in cassdc.yaml
 			var config Config
 			Expect(json.Unmarshal(cassdc.Spec.Config, &config)).To(Succeed())
-			Expect(config.JvmServerOptions.InitialHeapSize).To(BeEmpty())
-			Expect(config.JvmServerOptions.MaxHeapSize).To(BeEmpty())
-			Expect(config.JvmServerOptions.YoungGenSize).To(BeEmpty())
+			Expect(config.Jvm11ServerOptions.InitialHeapSize).To(BeEmpty())
+			Expect(config.Jvm11ServerOptions.MaxHeapSize).To(BeEmpty())
+			Expect(config.Jvm11ServerOptions.YoungGenSize).To(BeEmpty())
 
 			// Default set of volume and volume mounts
 			Expect(kubeapi.GetVolumeMountNames(&initContainers[0])).To(ConsistOf(CassandraConfigVolumeName,
@@ -1088,7 +1088,9 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 			Expect(config.CassandraConfig.PermissionsUpdateMillis).To(Equal(cacheUpdateInterval))
 			Expect(config.CassandraConfig.CredentialsValidityMillis).To(Equal(cacheValidityPeriod))
 			Expect(config.CassandraConfig.CredentialsUpdateMillis).To(Equal(cacheUpdateInterval))
-			Expect(config.JvmServerOptions.AdditionalJvmOptions).To(ContainElements(
+			Expect(config.Jvm11ServerOptions).NotTo(BeNil(), "Jvm11ServerOptions should not be nil")
+			Expect(config.Jvm11ServerOptions.AdditionalJvmOptions).NotTo(BeNil(), "Jvm11ServerOptions.AdditionalJvmOptions should not be nil")
+			Expect(config.Jvm11ServerOptions.AdditionalJvmOptions).To(ContainElements(
 				"-Dcassandra.system_distributed_replication_dc_names="+dcName,
 				"-Dcassandra.system_distributed_replication_per_dc="+strconv.Itoa(clusterSize),
 			))

--- a/tests/unit/template_cassdc_test.go
+++ b/tests/unit/template_cassdc_test.go
@@ -51,9 +51,10 @@ type JvmOptions struct {
 }
 
 type Config struct {
-	CassandraConfig  CassandraConfig `json:"cassandra-yaml"`
-	JvmOptions       *JvmOptions     `json:"jvm-options"`
-	JvmServerOptions *JvmOptions     `json:"jvm-server-options"`
+	CassandraConfig    CassandraConfig `json:"cassandra-yaml"`
+	JvmOptions         *JvmOptions     `json:"jvm-options"`
+	JvmServerOptions   *JvmOptions     `json:"jvm-server-options"`
+	Jvm11ServerOptions *JvmOptions     `json:"jvm11-server-options"`
 }
 
 var (
@@ -139,7 +140,6 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 			// JVM heap options -- default to settings as defined in cassdc.yaml
 			var config Config
 			Expect(json.Unmarshal(cassdc.Spec.Config, &config)).To(Succeed())
-			Expect(config.JvmServerOptions).ToNot(BeNil())
 			Expect(config.JvmServerOptions.InitialHeapSize).To(BeEmpty())
 			Expect(config.JvmServerOptions.MaxHeapSize).To(BeEmpty())
 			Expect(config.JvmServerOptions.YoungGenSize).To(BeEmpty())
@@ -1684,6 +1684,70 @@ var _ = Describe("Verify CassandraDatacenter template", func() {
 		Entry("3.11.12 default", "3.11.12", "", 256),
 		Entry("3.11.12 custom", "3.11.12", "16", 16),
 	)
+
+	It("using ZGC with Cassandra 3.11", func() {
+		options := &helm.Options{
+			KubectlOptions: defaultKubeCtlOptions,
+			SetValues: map[string]string{
+				"cassandra.version":        "3.11.12",
+				"cassandra.gc.zgc.enabled": "true",
+			},
+		}
+
+		err := renderTemplate(options)
+
+		Expect(err).ToNot(BeNil(), "Rendering should fail when using ZGC with Cassandra 3.11")
+	})
+
+	It("using both G1 and CMS with Cassandra 3.11", func() {
+		options := &helm.Options{
+			KubectlOptions: defaultKubeCtlOptions,
+			SetValues: map[string]string{
+				"cassandra.version":        "3.11.12",
+				"cassandra.gc.g1.enabled":  "true",
+				"cassandra.gc.cms.enabled": "true",
+			},
+		}
+
+		err := renderTemplate(options)
+
+		Expect(err).ToNot(BeNil(), "Rendering should fail when using both CMS and G1 with Cassandra 3.11")
+	})
+
+	It("using both G1 and ZGC with Cassandra 4.0", func() {
+		options := &helm.Options{
+			KubectlOptions: defaultKubeCtlOptions,
+			SetValues: map[string]string{
+				"cassandra.version":        "4.0.0",
+				"cassandra.gc.g1.enabled":  "true",
+				"cassandra.gc.zgc.enabled": "true",
+			},
+		}
+
+		err := renderTemplate(options)
+
+		Expect(err).ToNot(BeNil(), "Rendering should fail when using both ZGC and G1 with Cassandra 4.0")
+	})
+
+	It("using ZGC with Cassandra 4.0", func() {
+		options := &helm.Options{
+			KubectlOptions: defaultKubeCtlOptions,
+			SetValues: map[string]string{
+				"cassandra.version":        "4.0.0",
+				"cassandra.gc.zgc.enabled": "true",
+			},
+		}
+
+		err := renderTemplate(options)
+		var config Config
+		Expect(json.Unmarshal(cassdc.Spec.Config, &config)).To(Succeed())
+
+		Expect(config.JvmOptions).To(BeNil())
+		//Expect(config.JvmServerOptions).ToNot(BeNil())
+		Expect(config.Jvm11ServerOptions).ToNot(BeNil())
+		Expect(config.Jvm11ServerOptions.GarbageCollector).To(Equal("ZGC"))
+		Expect(err).To(BeNil(), "Rendering should succeed when using ZGC with Cassandra 4.0")
+	})
 })
 
 func verifyMedusaVolumeMounts(container *corev1.Container) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Fixes GC settings for Cassandra 4.0 which were not applied correctly as they are supposed to go in jvm11-server.options and jvm-server.options, but were only going in the latter.
I also introduced the possibility to use ZGC with Cassandra 4.0 as it's available with JDK11 and cass-config-definitions support it.

**Which issue(s) this PR fixes**:
Fixes #1269

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
