### PR TITLE
Upgrade Medusa dependency 0.12.1 -> 0.12.2

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -20,7 +20,7 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 
 * [FEATURE] Enable the use of ZGC (Z Garbage Collector) for Cassandra 4.0
 * [CHANGE] Upgrade Stargate to v1.0.52
-* [CHANGE] Upgrade Medusa to v0.12.1
+* [CHANGE] Upgrade Medusa to v0.12.2
 * [CHANGE] Upgrade Reaper to v3.1.1
 * [CHANGE] Upgrade Management API to v0.1.37
 * [BUGFIX] Fix GC subsettings mappings for Cassandra 4.0

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -281,8 +281,6 @@ cassandra:
     # Only for Apache Cassandra 4.0 and later.
     # -- Enable the ZGC garbage collector.
     # enabled: true
-
-
   resources: {}
   # Tolerations to apply to the Cassandra pods. See
   # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for background.
@@ -693,7 +691,7 @@ medusa:
     # -- Image repository for medusa
     repository: k8ssandra/medusa
     # -- Tag of the medusa image to pull from
-    tag: 0.12.1
+    tag: 0.12.2
     # -- Pull policy for the medusa container
     pullPolicy: IfNotPresent
   # -- Configures the Cassandra user used by Medusa when authentication is


### PR DESCRIPTION
This is auto-generated update from the K8ssandra upgrade GHA workflow.
Check that CI passes correctly before merging this PR.