### PR TITLE
Upgrade cass operator 1.10.4 1.5

### DIFF
--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -17,6 +17,7 @@ When cutting a new release of the parent `k8ssandra` chart update the `unrelease
 and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
+* [CHANGE] Upgrade cass-operator to v1.10.4
 
 ## v1.5.0 - 2022-04-09
 

--- a/charts/cass-operator/Chart.yaml
+++ b/charts/cass-operator/Chart.yaml
@@ -7,7 +7,7 @@ version: 0.35.3
 appVersion: 1.10.4
 dependencies:
   - name: k8ssandra-common
-    version: 0.28.4
+    version: 0.28.5
     repository: file://../k8ssandra-common
 home: https://github.com/k8ssandra/cass-operator
 sources:

--- a/charts/cass-operator/Chart.yaml
+++ b/charts/cass-operator/Chart.yaml
@@ -3,8 +3,8 @@ name: cass-operator
 description: |
   Kubernetes operator which handles the provisioning and management of Apache Cassandra clusters.
 type: application
-version: 0.35.2
-appVersion: 1.10.3
+version: 0.35.3
+appVersion: 1.10.4
 dependencies:
   - name: k8ssandra-common
     version: 0.28.4

--- a/charts/cass-operator/values.yaml
+++ b/charts/cass-operator/values.yaml
@@ -26,7 +26,7 @@ image:
   # -- Pull policy for the operator container
   pullPolicy: IfNotPresent
   # -- Tag of the cass-operator image to pull from image.repository
-  tag: v1.10.3
+  tag: v1.10.4
   # -- Docker registry containing all cass-operator related images. Setting this
   # allows for usage of an internal registry without specifying serverImage,
   # configBuilderImage, and busyboxImage on all CassandraDatacenter objects.

--- a/charts/k8ssandra-common/Chart.yaml
+++ b/charts/k8ssandra-common/Chart.yaml
@@ -3,10 +3,10 @@ name: k8ssandra-common
 description: |
   Helper library containing functions used by many of the K8ssandra stack Helm charts.
 type: library
-version: 0.28.4
+version: 0.28.5
 dependencies:
   - name: common
-    version: 1.3.4
+    version: 1.16.0
     repository: https://charts.bitnami.com/bitnami
 home: https://k8ssandra.io/
 sources:

--- a/charts/k8ssandra-common/README.md
+++ b/charts/k8ssandra-common/README.md
@@ -21,7 +21,7 @@ Helper library containing functions used by many of the K8ssandra stack Helm cha
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.3.4 |
+| https://charts.bitnami.com/bitnami | common | 1.16.0 |
 
 ## Values
 

--- a/charts/k8ssandra-operator/Chart.yaml
+++ b/charts/k8ssandra-operator/Chart.yaml
@@ -7,7 +7,7 @@ version: 0.37.1
 appVersion: 1.0.1
 dependencies:
   - name: k8ssandra-common
-    version: 0.28.4
+    version: 0.28.5
     repository: file://../k8ssandra-common
   - name: cass-operator
     version: 0.35.3

--- a/charts/k8ssandra-operator/Chart.yaml
+++ b/charts/k8ssandra-operator/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: 0.28.4
     repository: file://../k8ssandra-common
   - name: cass-operator
-    version: 0.35.2
+    version: 0.35.3
     repository: file://../cass-operator
 home: https://github.com/k8ssandra/k8ssandra-operator
 sources:

--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 version: 1.5.1-SNAPSHOT
 dependencies:
   - name: cass-operator
-    version: 0.35.2
+    version: 0.35.3
     repository: file://../cass-operator
     condition: cass-operator.enabled
   - name: reaper-operator

--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
     repository: file://../medusa-operator
     condition: medusa.enabled
   - name: k8ssandra-common
-    version: 0.28.4
+    version: 0.28.5
     repository: file://../k8ssandra-common
   - name: kube-prometheus-stack
     version: 20.0.1

--- a/charts/medusa-operator/Chart.yaml
+++ b/charts/medusa-operator/Chart.yaml
@@ -7,7 +7,7 @@ version: 0.32.0
 appVersion: 0.1.0
 dependencies:
   - name: k8ssandra-common
-    version: 0.28.4
+    version: 0.28.5
     repository: file://../k8ssandra-common
 home: https://k8ssandra.io/
 sources:

--- a/charts/reaper-operator/Chart.yaml
+++ b/charts/reaper-operator/Chart.yaml
@@ -8,7 +8,7 @@ version: 0.32.3
 appVersion: 0.1.0
 dependencies:
   - name: k8ssandra-common
-    version: 0.28.4
+    version: 0.28.5
     repository: file://../k8ssandra-common
 home: https://k8ssandra.io/
 sources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Upgrades cass-operator to 1.10.4 on the 1.5 release branch.
This will allow releasing 1.10.4 to our Helm repo.

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
