### PR TITLE
Upgrade Reaper dependency 3.1.1 -> 3.2.0

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -18,6 +18,7 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 
 ## unreleased
 
+* [CHANGE] Upgrade Reaper to v3.2.0
 * [ENHANCEMENT] Added s3_rgw support
 * [CHANGE] Upgrade cass-operator to v1.11.0
 * [CHANGE] cass-operator HELM-Chart: Upgrade requires manual action if registryOverride was used before. registryOverride is now repositoryOverride.

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -625,7 +625,7 @@ reaper:
     # -- Image repository for reaper
     repository: thelastpickle/cassandra-reaper
     # -- Tag of the reaper image to pull from
-    tag: 3.1.1
+    tag: 3.2.0
     # -- Pull policy for the reaper container
     pullPolicy: IfNotPresent
   # -- Configures the Cassandra user used by Reaper when authentication is


### PR DESCRIPTION
This is auto-generated update from the K8ssandra upgrade GHA workflow.
Check that CI passes correctly before merging this PR.