### PR TITLE
Upgrade cass-operator dependency 1.11.0 -> 1.12.0

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -18,9 +18,9 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 
 ## unreleased
 
+* [CHANGE] Upgrade cass-operator to v1.12.0
 * [CHANGE] Upgrade Reaper to v3.2.0
 * [ENHANCEMENT] Added s3_rgw support
-* [CHANGE] Upgrade cass-operator to v1.11.0
 * [CHANGE] cass-operator HELM-Chart: Upgrade requires manual action if registryOverride was used before. registryOverride is now repositoryOverride.
 * [ENHANCEMENT] Enable webhook functionality in cass-operator if cert-manager is installed.
 * [CHANGE] [#1409](https://github.com/k8ssandra/k8ssandra/pull/1409) Upgrade cass-operator to v1.11.0

--- a/charts/cass-operator/Chart.yaml
+++ b/charts/cass-operator/Chart.yaml
@@ -3,8 +3,8 @@ name: cass-operator
 description: |
   Kubernetes operator which handles the provisioning and management of Apache Cassandra clusters.
 type: application
-version: 0.37.0
-appVersion: 1.11.0
+version: 0.37.1
+appVersion: 1.12.0
 dependencies:
   - name: k8ssandra-common
     version: 0.28.6

--- a/charts/cass-operator/values.yaml
+++ b/charts/cass-operator/values.yaml
@@ -29,7 +29,7 @@ image:
   # -- Pull policy for the operator container
   pullPolicy: IfNotPresent
   # -- Tag of the cass-operator image to pull from image.repository
-  tag: v1.11.0
+  tag: v1.12.0
   # -- Docker registry containing all cass-operator related images. Setting this
   # allows for usage of an internal registry without specifying serverImage,
   # configBuilderImage, and busyboxImage on all CassandraDatacenter objects.
@@ -40,7 +40,6 @@ image:
   #     "6.8.999": "datastax/dse-server-prototype:latest"
   # Overrides the global Image repository for Cassandra container
   registryOverride:
-
 # -- References to secrets to use when pulling images. See:
 # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 # imagePullSecret: []

--- a/charts/k8ssandra-operator/Chart.yaml
+++ b/charts/k8ssandra-operator/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: 0.28.6
     repository: file://../k8ssandra-common
   - name: cass-operator
-    version: 0.37.0
+    version: 0.37.1
     repository: file://../cass-operator
 home: https://github.com/k8ssandra/k8ssandra-operator
 sources:

--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 version: 1.6.0-SNAPSHOT
 dependencies:
   - name: cass-operator
-    version: 0.37.0
+    version: 0.37.1
     repository: file://../cass-operator
     condition: cass-operator.enabled
   - name: reaper-operator


### PR DESCRIPTION
This is auto-generated update from the K8ssandra upgrade GHA workflow.
Check that CI passes correctly before merging this PR.