### PR TITLE
Add a GHA workflow which pushes PRs for CRD reference documentation updates

### DIFF
--- a/.github/workflows/update-crd-reference.yaml
+++ b/.github/workflows/update-crd-reference.yaml
@@ -1,0 +1,113 @@
+name: Update CRD Reference
+
+on:
+  schedule:
+    - cron:  '0 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-crd-reference:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout K8ssandra-operator
+        uses: actions/checkout@v2
+        with:
+          repository: k8ssandra/k8ssandra-operator
+          ref: main
+          path: k8ssandra-operator
+      - name: Checkout cass-operator
+        uses: actions/checkout@v2
+        with:
+          repository: k8ssandra/cass-operator
+          ref: master
+          path: cass-operator
+      - name: Checkout K8ssandra
+        uses: actions/checkout@v2
+        with:
+          ref: docs-v2
+          path: k8ssandra
+      
+      - name: Install crdoc
+        run: |
+          go install fybrik.io/crdoc@latest
+      - name: Generate CRD reference for each K8ssandra-operator release
+        run: |
+          set -x
+          # Compute the md5 sum of the current CRD reference directory contents. Will be used to decide if a PR is needed.
+          crd_dir_current_hash=$(find k8ssandra/docs/content/en/reference/crd/ -type f -exec md5sum {} + | LC_ALL=C sort | md5sum | head -c 8)
+
+          # Cleanup the CRD reference directory.
+          rm -rf k8ssandra/docs/content/en/reference/crd/*/
+          mkdir -p k8ssandra/docs/content/en/reference/crd/releases
+          cp k8ssandra/docs/config/crdoc-templates/_index_releases.md k8ssandra/docs/content/en/reference/crd/releases/_index.md
+          
+          # Fetch and cycle through K8ssandra-operator release branches to generate CRD references.
+          cd k8ssandra-operator
+          git fetch
+          k8c_releases=$(git branch -r |grep -E "release/[0-9]{1,2}.[0-9]{1,2}")
+          for branch in $k8c_releases
+          do 
+            git checkout -f $branch
+            version=$(echo $branch | sed 's/origin\/release\///g')
+            mkdir -p ../k8ssandra/docs/content/en/reference/crd/releases/k8ssandra-operator-releases/k8ssandra-operator-crds-$version > /dev/null 2>&1
+            ~/go/bin/crdoc --resources config/crd/bases --output ../k8ssandra/docs/content/en/reference/crd/releases/k8ssandra-operator-releases/k8ssandra-operator-crds-$version/_index.md --template ../k8ssandra/docs/config/crdoc-templates/k8c.tmpl
+            sed -i "s/RELEASE_VERSION/$version/g" ../k8ssandra/docs/content/en/reference/crd/releases/k8ssandra-operator-releases/k8ssandra-operator-crds-$version/_index.md
+          done
+
+          # Generate CRD reference for K8ssandra-operator main branch (latest)
+          git checkout -f main
+          mkdir -p ../k8ssandra/docs/content/en/reference/crd/k8ssandra-operator-crds-latest/ > /dev/null 2>&1
+          ~/go/bin/crdoc --resources config/crd/bases --output ../k8ssandra/docs/content/en/reference/crd/k8ssandra-operator-crds-latest/_index.md --template ../k8ssandra/docs/config/crdoc-templates/k8c.tmpl
+          sed -i "s/vRELEASE_VERSION/latest build/g" ../k8ssandra/docs/content/en/reference/crd/k8ssandra-operator-crds-latest/_index.md
+
+          cp ../k8ssandra/docs/config/crdoc-templates/_index_k8ssandra_operator_crds.md ../k8ssandra/docs/content/en/reference/crd/releases/k8ssandra-operator-releases/_index.md
+
+          # Fetch and cycle through cass-operator release branches to generate CRD references.
+          cd ../cass-operator
+          git fetch
+          cass_releases=$(git branch -r |grep -E "[0-9]{1,2}.[0-9]{1,2}.x")
+          for branch in $cass_releases
+          do 
+            git checkout -f $branch
+            version=$(echo $branch | sed 's/origin\///g')
+            if [ -d "config/crd/bases" ]; then
+              mkdir -p ../k8ssandra/docs/content/en/reference/crd/releases/cass-operator-releases/cass-operator-crds-$version > /dev/null 2>&1
+              ~/go/bin/crdoc --resources config/crd/bases --output ../k8ssandra/docs/content/en/reference/crd/releases/cass-operator-releases/cass-operator-crds-$version/_index.md --template ../k8ssandra/docs/config/crdoc-templates/cassdc.tmpl
+              sed -i "s/RELEASE_VERSION/$version/g" ../k8ssandra/docs/content/en/reference/crd/releases/cass-operator-releases/cass-operator-crds-$version/_index.md
+            fi
+          done
+
+          # Generate CRD reference for cass-operator master branch (latest)
+          git checkout -f master
+          mkdir -p ../k8ssandra/docs/content/en/reference/crd/cass-operator-crds-latest/ > /dev/null 2>&1
+          ~/go/bin/crdoc --resources config/crd/bases --output ../k8ssandra/docs/content/en/reference/crd/cass-operator-crds-latest/_index.md --template ../k8ssandra/docs/config/crdoc-templates/cassdc.tmpl
+          sed -i "s/vRELEASE_VERSION/latest build/g" ../k8ssandra/docs/content/en/reference/crd/cass-operator-crds-latest/_index.md
+
+          cp ../k8ssandra/docs/config/crdoc-templates/_index_cass_operator_crds.md ../k8ssandra/docs/content/en/reference/crd/releases/cass-operator-releases/_index.md
+
+          crd_dir_new_hash=$(find ../k8ssandra/docs/content/en/reference/crd/ -type f -exec md5sum {} + | LC_ALL=C sort | md5sum | head -c 8)
+          echo "PR_BRANCH=$crd_dir_current_hash-$crd_dir_new_hash" >> $GITHUB_ENV
+      - name: Check if a closed PR exists for the same version
+        run: |
+          set -x
+          cd k8ssandra
+          CLOSED_UPGRADE_PR=$(curl -L -s "https://api.github.com/repos/k8ssandra/k8ssandra/pulls?state=closed"|jq -c '.[] | select( .title == "Upgrade CRD reference ${{ env.PR_BRANCH }}" )'|jq -r '.title')
+          
+          if ([ -z "$CLOSED_UPGRADE_PR" ] && [ $crd_dir_current_hash != $crd_dir_new_hash ]); then
+            echo "PR_EXISTS=no" >> $GITHUB_ENV
+          else
+            echo "PR_EXISTS=yes" >> $GITHUB_ENV
+          fi
+      - name: Send CRD reference update PR
+        if: ${{ env.PR_EXISTS == 'no' }}
+        uses: peter-evans/create-pull-request@v3
+        with:
+          path: k8ssandra
+          token: ${{ secrets.CREATE_PR_TOKEN }}
+          commit-message: Upgrade CRD reference
+          delete-branch: true
+          branch: upgrade-crd-reference-${{ env.PR_BRANCH }}
+          base: docs-v2
+          title: Upgrade CRD reference ${{ env.PR_BRANCH }}
+          body: |
+            This is an auto-generated PR from the K8ssandra CRD reference update GHA workflow.

--- a/docs/config/crdoc-templates/_index_cass_operator_crds.md
+++ b/docs/config/crdoc-templates/_index_cass_operator_crds.md
@@ -1,0 +1,7 @@
+---
+title: "cass-operator releases"
+linkTitle: "cass-operator releases"
+weight: 6
+description: >
+  cass-operator CRD reference by release.
+---

--- a/docs/config/crdoc-templates/_index_k8ssandra_operator_crds.md
+++ b/docs/config/crdoc-templates/_index_k8ssandra_operator_crds.md
@@ -1,0 +1,7 @@
+---
+title: "K8ssandra Operator releases"
+linkTitle: "K8ssandra-operator releases"
+weight: 2
+description: >
+   K8ssandra-operator CRD reference by release.
+---

--- a/docs/config/crdoc-templates/_index_releases.md
+++ b/docs/config/crdoc-templates/_index_releases.md
@@ -1,0 +1,7 @@
+---
+title: "All releases"
+linkTitle: "All releases"
+weight: 10
+description: >
+   K8ssandra-operator and cass-operator CRD reference by release.
+---

--- a/docs/config/crdoc-templates/cassdc.tmpl
+++ b/docs/config/crdoc-templates/cassdc.tmpl
@@ -1,0 +1,102 @@
+---
+title: "cass-operator CRDs vRELEASE_VERSION"
+linkTitle: "cass-operator CRDs vRELEASE_VERSION"
+weight: 5
+description: >
+  Configuration reference for the CRDs used with cass-operator vRELEASE_VERSION.  
+---
+
+Packages:
+{{range .Groups}}
+- [{{.Group}}/{{.Version}}](#{{ anchorize (printf "%s/%s" .Group .Version) }})
+{{- end -}}{{/* range .Groups */}}
+
+{{- range .Groups }}
+{{- $group := . }}
+
+## {{.Group}}/{{.Version}}
+
+Resource Types:
+{{range .Kinds}}
+- [{{.Name}}](#{{ anchorize .Name }})
+{{end}}{{/* range .Kinds */}}
+
+{{range .Kinds}}
+{{$kind := .}}
+### {{.Name}}
+<sup><sup>[↩ Parent](#{{ anchorize (printf "%s/%s" $group.Group $group.Version) }} )</sup></sup>
+
+{{range .Types}}
+
+{{if not .IsTopLevel}}
+#### {{.Name}}
+{{if .ParentKey}}<sup><sup>[↩ Parent](#{{.ParentKey}})</sup></sup>{{end}}
+{{end}}
+
+
+{{.Description}}
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody>
+      {{- if .IsTopLevel -}}
+      <tr>
+      <td><b>apiVersion</b></td>
+      <td>string</td>
+      <td>{{$group.Group}}/{{$group.Version}}</td>
+      <td>true</td>
+      </tr>
+      <tr>
+      <td><b>kind</b></td>
+      <td>string</td>
+      <td>{{$kind.Name}}</td>
+      <td>true</td>
+      </tr>
+      <tr>
+      <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">metadata</a></b></td>
+      <td>object</td>
+      <td>Refer to the Kubernetes API documentation for the fields of the `metadata` field.</td>
+      <td>true</td>
+      </tr>
+      {{- end -}}
+      {{- range .Fields -}}
+      <tr>
+        <td><b>{{if .TypeKey}}<a href="#{{.TypeKey}}">{{.Name}}</a>{{else}}{{.Name}}{{end}}</b></td>
+        <td>{{.Type}}</td>
+        <td>
+          {{.Description}}<br/>
+          {{- if or .Schema.Format .Schema.Enum .Schema.Default .Schema.Minimum .Schema.Maximum }}
+          <br/>
+          {{- end}}
+          {{- if .Schema.Format }}
+            <i>Format</i>: {{ .Schema.Format }}<br/>
+          {{- end }}
+          {{- if .Schema.Enum }}
+            <i>Enum</i>: {{ .Schema.Enum | toStrings | join ", " }}<br/>
+          {{- end }}
+          {{- if .Schema.Default }}
+            <i>Default</i>: {{ .Schema.Default }}<br/>
+          {{- end }}
+          {{- if .Schema.Minimum }}
+            <i>Minimum</i>: {{ .Schema.Minimum }}<br/>
+          {{- end }}
+          {{- if .Schema.Maximum }}
+            <i>Maximum</i>: {{ .Schema.Maximum }}<br/>
+          {{- end }}
+        </td>
+        <td>{{.Required}}</td>
+      </tr>
+      {{- end -}}
+    </tbody>
+</table>
+
+{{- end}}{{/* range .Types */}}
+{{- end}}{{/* range .Kinds */}}
+{{- end}}{{/* range .Groups */}}

--- a/docs/config/crdoc-templates/k8c.tmpl
+++ b/docs/config/crdoc-templates/k8c.tmpl
@@ -1,0 +1,102 @@
+---
+title: "K8ssandra-operator CRDs vRELEASE_VERSION"
+linkTitle: "K8ssandra-operator CRDs vRELEASE_VERSION"
+weight: 1
+description: >
+  Configuration reference for the CRDs used with K8ssandra-operator vRELEASE_VERSION.  
+---
+
+Packages:
+{{range .Groups}}
+- [{{.Group}}/{{.Version}}](#{{ anchorize (printf "%s/%s" .Group .Version) }})
+{{- end -}}{{/* range .Groups */}}
+
+{{- range .Groups }}
+{{- $group := . }}
+
+## {{.Group}}/{{.Version}}
+
+Resource Types:
+{{range .Kinds}}
+- [{{.Name}}](#{{ anchorize .Name }})
+{{end}}{{/* range .Kinds */}}
+
+{{range .Kinds}}
+{{$kind := .}}
+### {{.Name}}
+<sup><sup>[↩ Parent](#{{ anchorize (printf "%s/%s" $group.Group $group.Version) }} )</sup></sup>
+
+{{range .Types}}
+
+{{if not .IsTopLevel}}
+#### {{.Name}}
+{{if .ParentKey}}<sup><sup>[↩ Parent](#{{.ParentKey}})</sup></sup>{{end}}
+{{end}}
+
+
+{{.Description}}
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody>
+      {{- if .IsTopLevel -}}
+      <tr>
+      <td><b>apiVersion</b></td>
+      <td>string</td>
+      <td>{{$group.Group}}/{{$group.Version}}</td>
+      <td>true</td>
+      </tr>
+      <tr>
+      <td><b>kind</b></td>
+      <td>string</td>
+      <td>{{$kind.Name}}</td>
+      <td>true</td>
+      </tr>
+      <tr>
+      <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">metadata</a></b></td>
+      <td>object</td>
+      <td>Refer to the Kubernetes API documentation for the fields of the `metadata` field.</td>
+      <td>true</td>
+      </tr>
+      {{- end -}}
+      {{- range .Fields -}}
+      <tr>
+        <td><b>{{if .TypeKey}}<a href="#{{.TypeKey}}">{{.Name}}</a>{{else}}{{.Name}}{{end}}</b></td>
+        <td>{{.Type}}</td>
+        <td>
+          {{.Description}}<br/>
+          {{- if or .Schema.Format .Schema.Enum .Schema.Default .Schema.Minimum .Schema.Maximum }}
+          <br/>
+          {{- end}}
+          {{- if .Schema.Format }}
+            <i>Format</i>: {{ .Schema.Format }}<br/>
+          {{- end }}
+          {{- if .Schema.Enum }}
+            <i>Enum</i>: {{ .Schema.Enum | toStrings | join ", " }}<br/>
+          {{- end }}
+          {{- if .Schema.Default }}
+            <i>Default</i>: {{ .Schema.Default }}<br/>
+          {{- end }}
+          {{- if .Schema.Minimum }}
+            <i>Minimum</i>: {{ .Schema.Minimum }}<br/>
+          {{- end }}
+          {{- if .Schema.Maximum }}
+            <i>Maximum</i>: {{ .Schema.Maximum }}<br/>
+          {{- end }}
+        </td>
+        <td>{{.Required}}</td>
+      </tr>
+      {{- end -}}
+    </tbody>
+</table>
+
+{{- end}}{{/* range .Types */}}
+{{- end}}{{/* range .Kinds */}}
+{{- end}}{{/* range .Groups */}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds a GHA workflow which:
- triggers every day at 1am UTC
- checks out K8ssandra-operator
- checks out cass-operator
- checks out K8ssandra@docs-v2
- Generates the CRD documentation for all release branches and the main branch
- Sends a PR against K8ssandra@docs-v2 if the CRD ref content has changed with the updated content

The CRD reference was reorganized as can be seen [here](https://docs-staging-v2.k8ssandra.io/reference/crd/).

**Which issue(s) this PR fixes**:
Fixes #1459 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
