### PR TITLE
Fix CRD upgrader breakage for the k8ssandra chart

### DIFF
--- a/pkg/crds/upgrade.go
+++ b/pkg/crds/upgrade.go
@@ -58,6 +58,10 @@ func New(namespace string) (*Upgrader, error) {
 
 // Upgrade installs the missing CRDs or updates them if they exists already
 func (u *Upgrader) Upgrade(chartName string, targetVersion string) ([]unstructured.Unstructured, error) {
+	chartNameToUpgrade := chartName
+	if chartName == "" {
+		chartNameToUpgrade = helmutil.DefaultChartName
+	}
 	extractDir, err := helmutil.GetChartTargetDir(targetVersion)
 	if err != nil {
 		return nil, err
@@ -66,7 +70,7 @@ func (u *Upgrader) Upgrade(chartName string, targetVersion string) ([]unstructur
 	// If the targetCacheDirectory does not exist, download the chart
 	if _, err := os.Stat(extractDir); os.IsNotExist(err) {
 		log.Printf("Downloading release %s from Helm repository", targetVersion)
-		extractDir, err = helmutil.DownloadChartRelease(chartName, targetVersion)
+		extractDir, err = helmutil.DownloadChartRelease(chartNameToUpgrade, targetVersion)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/crds/upgrade_test.go
+++ b/pkg/crds/upgrade_test.go
@@ -33,102 +33,107 @@ func TestUpgradingCRDs(t *testing.T) {
 	RegisterTestingT(t)
 	g := NewWithT(t)
 
-	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{}
+	chartNames := []string{"k8ssandra", ""}
+	for _, chartName := range chartNames {
+		t.Run(fmt.Sprintf("CRD upgrade for chart name: %s", chartName), func(t *testing.T) {
+			By("bootstrapping test environment")
+			testEnv = &envtest.Environment{}
 
-	var err error
-	cfg, err = testEnv.Start()
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(cfg).ToNot(BeNil())
+			var err error
+			cfg, err = testEnv.Start()
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(cfg).ToNot(BeNil())
 
-	// err = cassdcapi.AddToScheme(scheme.Scheme)
-	g.Expect(err).NotTo(HaveOccurred())
+			// err = cassdcapi.AddToScheme(scheme.Scheme)
+			g.Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:scheme
+			// +kubebuilder:scaffold:scheme
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(k8sClient).ToNot(BeNil())
+			k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(k8sClient).ToNot(BeNil())
 
-	testNamespace := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: UpgradeTestNamespace,
-		},
+			testNamespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: UpgradeTestNamespace,
+				},
+			}
+			g.Expect(k8sClient.Create(context.Background(), testNamespace)).Should(Succeed())
+
+			By("creating new upgrader")
+			u, err := NewWithClient(k8sClient)
+			g.Expect(err).Should(Succeed())
+
+			By("Upgrading / installing 1.0.0")
+			var crds []unstructured.Unstructured
+			g.Eventually(func() bool {
+				crds, err = u.Upgrade(chartName, "1.0.0")
+				return err == nil
+			}).WithTimeout(time.Minute * 10).WithPolling(time.Second * 5).Should(BeTrue())
+
+			g.Expect(err).Should(Succeed())
+
+			testOptions := envtest.CRDInstallOptions{
+				PollInterval: 100 * time.Millisecond,
+				MaxTime:      10 * time.Second,
+			}
+
+			unstructuredCRD := &unstructured.Unstructured{}
+			cassDCCRD := &apiextensions.CustomResourceDefinition{}
+			objs := []apiextensions.CustomResourceDefinition{}
+			for _, crd := range crds {
+				if crd.GetName() == "cassandradatacenters.cassandra.datastax.com" {
+					unstructuredCRD = crd.DeepCopy()
+					err = runtime.DefaultUnstructuredConverter.FromUnstructured(crd.UnstructuredContent(), cassDCCRD)
+					g.Expect(err).ShouldNot(HaveOccurred())
+				}
+				objs = append(objs, *cassDCCRD)
+			}
+
+			envtest.WaitForCRDs(cfg, objs, testOptions)
+			err = k8sClient.Get(context.TODO(), client.ObjectKey{Name: cassDCCRD.GetName()}, cassDCCRD)
+			ver := cassDCCRD.GetResourceVersion()
+			g.Expect(err).Should(Succeed())
+
+			_, found, err := unstructured.NestedFieldNoCopy(unstructuredCRD.Object, "spec", "validation", "openAPIV3Schema", "properties", "spec", "properties", "configSecret")
+			g.Expect(err).Should(Succeed())
+			g.Expect(found).To(BeFalse())
+
+			By("Upgrading to 1.5.1")
+			crds, err = u.Upgrade(chartName, "1.5.1")
+			g.Expect(err).Should(Succeed())
+
+			objs = []apiextensions.CustomResourceDefinition{}
+			for _, crd := range crds {
+				if crd.GetName() == "cassandradatacenters.cassandra.datastax.com" {
+					unstructuredCRD = crd.DeepCopy()
+					err = runtime.DefaultUnstructuredConverter.FromUnstructured(crd.UnstructuredContent(), cassDCCRD)
+					g.Expect(err).ShouldNot(HaveOccurred())
+					objs = append(objs, *cassDCCRD)
+				}
+			}
+
+			envtest.WaitForCRDs(cfg, objs, testOptions)
+			err = k8sClient.Get(context.TODO(), client.ObjectKey{Name: cassDCCRD.GetName()}, cassDCCRD)
+			g.Expect(err).Should(Succeed())
+			g.Eventually(func() bool {
+				newver := cassDCCRD.GetResourceVersion()
+				eq := newver == ver
+				println(fmt.Sprintf("equality: %t, current resourceVersion: %s, old resourceVersion: %s", eq, newver, ver))
+				return eq
+			}).WithTimeout(time.Minute * 10).WithPolling(time.Second * 5).Should(BeFalse())
+
+			versionsSlice, found, err := unstructured.NestedSlice(unstructuredCRD.Object, "spec", "versions")
+			g.Expect(found).To(BeTrue())
+			_, found, err = unstructured.NestedFieldNoCopy(versionsSlice[0].(map[string]interface{}), "schema", "openAPIV3Schema", "properties", "spec", "properties", "configSecret")
+
+			g.Expect(err).Should(Succeed())
+			g.Expect(found).To(BeTrue())
+
+			By("tearing down the test environment")
+			gexec.KillAndWait(5 * time.Second)
+			err = testEnv.Stop()
+			g.Expect(err).ToNot(HaveOccurred())
+		})
 	}
-	g.Expect(k8sClient.Create(context.Background(), testNamespace)).Should(Succeed())
-
-	By("creating new upgrader")
-	u, err := NewWithClient(k8sClient)
-	g.Expect(err).Should(Succeed())
-
-	By("Upgrading / installing 1.0.0")
-	var crds []unstructured.Unstructured
-	g.Eventually(func() bool {
-		crds, err = u.Upgrade("k8ssandra", "1.0.0")
-		return err == nil
-	}).WithTimeout(time.Minute * 10).WithPolling(time.Second * 5).Should(BeTrue())
-
-	g.Expect(err).Should(Succeed())
-
-	testOptions := envtest.CRDInstallOptions{
-		PollInterval: 100 * time.Millisecond,
-		MaxTime:      10 * time.Second,
-	}
-
-	unstructuredCRD := &unstructured.Unstructured{}
-	cassDCCRD := &apiextensions.CustomResourceDefinition{}
-	objs := []apiextensions.CustomResourceDefinition{}
-	for _, crd := range crds {
-		if crd.GetName() == "cassandradatacenters.cassandra.datastax.com" {
-			unstructuredCRD = crd.DeepCopy()
-			err = runtime.DefaultUnstructuredConverter.FromUnstructured(crd.UnstructuredContent(), cassDCCRD)
-			g.Expect(err).ShouldNot(HaveOccurred())
-		}
-		objs = append(objs, *cassDCCRD)
-	}
-
-	envtest.WaitForCRDs(cfg, objs, testOptions)
-	err = k8sClient.Get(context.TODO(), client.ObjectKey{Name: cassDCCRD.GetName()}, cassDCCRD)
-	ver := cassDCCRD.GetResourceVersion()
-	g.Expect(err).Should(Succeed())
-
-	_, found, err := unstructured.NestedFieldNoCopy(unstructuredCRD.Object, "spec", "validation", "openAPIV3Schema", "properties", "spec", "properties", "configSecret")
-	g.Expect(err).Should(Succeed())
-	g.Expect(found).To(BeFalse())
-
-	By("Upgrading to 1.5.1")
-	crds, err = u.Upgrade("k8ssandra", "1.5.1")
-	g.Expect(err).Should(Succeed())
-
-	objs = []apiextensions.CustomResourceDefinition{}
-	for _, crd := range crds {
-		if crd.GetName() == "cassandradatacenters.cassandra.datastax.com" {
-			unstructuredCRD = crd.DeepCopy()
-			err = runtime.DefaultUnstructuredConverter.FromUnstructured(crd.UnstructuredContent(), cassDCCRD)
-			g.Expect(err).ShouldNot(HaveOccurred())
-			objs = append(objs, *cassDCCRD)
-		}
-	}
-
-	envtest.WaitForCRDs(cfg, objs, testOptions)
-	err = k8sClient.Get(context.TODO(), client.ObjectKey{Name: cassDCCRD.GetName()}, cassDCCRD)
-	g.Expect(err).Should(Succeed())
-	g.Eventually(func() bool {
-		newver := cassDCCRD.GetResourceVersion()
-		eq := newver == ver
-		println(fmt.Sprintf("equality: %t, current resourceVersion: %s, old resourceVersion: %s", eq, newver, ver))
-		return eq
-	}).WithTimeout(time.Minute * 10).WithPolling(time.Second * 5).Should(BeFalse())
-
-	versionsSlice, found, err := unstructured.NestedSlice(unstructuredCRD.Object, "spec", "versions")
-	g.Expect(found).To(BeTrue())
-	_, found, err = unstructured.NestedFieldNoCopy(versionsSlice[0].(map[string]interface{}), "schema", "openAPIV3Schema", "properties", "spec", "properties", "configSecret")
-
-	g.Expect(err).Should(Succeed())
-	g.Expect(found).To(BeTrue())
-
-	By("tearing down the test environment")
-	gexec.KillAndWait(5 * time.Second)
-	err = testEnv.Stop()
-	g.Expect(err).ToNot(HaveOccurred())
 }

--- a/pkg/helmutil/fetch.go
+++ b/pkg/helmutil/fetch.go
@@ -18,7 +18,8 @@ const (
 	ManagedLabelValue = "Helm"
 	ReleaseAnnotation = "meta.helm.sh/release-name"
 
-	RepoURL = "https://helm.k8ssandra.io/"
+	RepoURL          = "https://helm.k8ssandra.io/"
+	DefaultChartName = "k8ssandra"
 )
 
 func GetChartTargetDir(targetVersion string) (string, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Uses `k8ssandra` as default chart name if it isn't provided.
This should fix the K8ssandra v1.x upgrade issues as a new `chartName` argument was introduced to support K8ssandra-operator, but no default value was defined to handle the former invocations made by K8ssandra v1.

**Which issue(s) this PR fixes**:
Fixes #1478 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
