### PR TITLE
Upgrade k8ssandra-operator dependency 1.2.0 -> 1.2.1

### DIFF
--- a/charts/k8ssandra-operator/Chart.yaml
+++ b/charts/k8ssandra-operator/Chart.yaml
@@ -3,8 +3,8 @@ name: k8ssandra-operator
 description: |
   Kubernetes operator which handles the provisioning and management of K8ssandra clusters.
 type: application
-version: 0.38.1
-appVersion: 1.2.0
+version: 0.38.2
+appVersion: 1.2.1
 dependencies:
   - name: k8ssandra-common
     version: 0.28.6

--- a/charts/k8ssandra-operator/values.yaml
+++ b/charts/k8ssandra-operator/values.yaml
@@ -25,7 +25,7 @@ image:
   # -- Pull policy for the operator container
   pullPolicy: IfNotPresent
   # -- Tag of the k8ssandra-operator image to pull from image.repository
-  tag: v1.2.0
+  tag: v1.2.1
   # -- Docker registry containing all cass-operator related images. Setting this
   # allows for usage of an internal registry without specifying serverImage,
   # configBuilderImage, and busyboxImage on all CassandraDatacenter objects.
@@ -55,7 +55,6 @@ securityContext:
 # `requests` and `limits` for `cpu` and `memory` while removing the existing
 # `{}`
 resources: {}
-
 # -- The cleaner is a pre-delete hook that that ensures objects with finalizers
 # get deleted. For example, cass-operator sets a finalizer on the
 # CassandraDatacenter. Kubernetes blocks deletion of an object until all of its


### PR DESCRIPTION
This is auto-generated update from the K8ssandra upgrade GHA workflow.
Check that CI passes correctly before merging this PR.