### PR TITLE
Upgrade Stargate dependency 1.0.63 -> 1.0.66

### DIFF
--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -445,7 +445,7 @@ stargate:
   enabled: true
   # -- version of Stargate to deploy. This is used in conjunction with cassandra.version to select the Stargate container image.
   # If stargate.image is set, this value has no effect.
-  version: "1.0.63"
+  version: "1.0.66"
   # -- Sets the Stargate container image. This value must be compatible
   # with the value provided for stargate.clusterVersion. If left blank (recommended),
   # k8ssandra will derive an appropriate image based on cassandra.clusterVersion.


### PR DESCRIPTION
This is auto-generated update from the K8ssandra upgrade GHA workflow.
Check that CI passes correctly before merging this PR.