### PR TITLE
Upgrade cass-operator dependency 1.13.0 -> 1.13.1

### DIFF
--- a/charts/cass-operator/Chart.yaml
+++ b/charts/cass-operator/Chart.yaml
@@ -3,8 +3,8 @@ name: cass-operator
 description: |
   Kubernetes operator which handles the provisioning and management of Apache Cassandra clusters.
 type: application
-version: 0.38.0
-appVersion: 1.13.0
+version: 0.38.1
+appVersion: 1.13.1
 dependencies:
   - name: k8ssandra-common
     version: 0.28.6

--- a/charts/cass-operator/values.yaml
+++ b/charts/cass-operator/values.yaml
@@ -29,7 +29,7 @@ image:
   # -- Pull policy for the operator container
   pullPolicy: IfNotPresent
   # -- Tag of the cass-operator image to pull from image.repository
-  tag: v1.13.0
+  tag: v1.13.1
   # -- Docker registry containing all cass-operator related images. Setting this
   # allows for usage of an internal registry without specifying serverImage,
   # configBuilderImage, and busyboxImage on all CassandraDatacenter objects.

--- a/charts/k8ssandra-operator/Chart.yaml
+++ b/charts/k8ssandra-operator/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: 0.28.6
     repository: file://../k8ssandra-common
   - name: cass-operator
-    version: 0.38.0
+    version: 0.38.1
     repository: file://../cass-operator
 home: https://github.com/k8ssandra/k8ssandra-operator
 sources:

--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 version: 1.6.0-SNAPSHOT
 dependencies:
   - name: cass-operator
-    version: 0.35.3
+    version: 0.38.1
     repository: https://helm.k8ssandra.io
     condition: cass-operator.enabled
   - name: reaper-operator


### PR DESCRIPTION
This is auto-generated update from the K8ssandra upgrade GHA workflow.
Check that CI passes correctly before merging this PR.