### PR TITLE
Fix naming of cass-operator charts to work when used as a dependency

### DIFF
--- a/charts/cass-operator/Chart.yaml
+++ b/charts/cass-operator/Chart.yaml
@@ -3,8 +3,8 @@ name: cass-operator
 description: |
   Kubernetes operator which handles the provisioning and management of Apache Cassandra clusters.
 type: application
-version: 0.38.0
-appVersion: 1.13.0
+version: 0.39.0
+appVersion: 1.13.1
 dependencies:
   - name: k8ssandra-common
     version: 0.28.6

--- a/charts/cass-operator/templates/_helpers.tpl
+++ b/charts/cass-operator/templates/_helpers.tpl
@@ -2,6 +2,6 @@
 {{- if .Values.admissionWebhooks.customCertificate }}
 {{- .Values.admissionWebhooks.customCertificate }}
 {{- else }}
-{{- printf "%s/%s-serving-cert" .Release.Namespace .Release.Name }}
+{{- printf "%s/%s-serving-cert" .Release.Namespace (include "k8ssandra-common.fullname" .) }}
 {{- end }}
 {{- end }}

--- a/charts/cass-operator/templates/configmap.yaml
+++ b/charts/cass-operator/templates/configmap.yaml
@@ -33,8 +33,8 @@ data:
     apiVersion: config.k8ssandra.io/v1beta1
     kind: ImageConfig
     images:
-      system-logger: "k8ssandra/system-logger:v1.10.0"
-      config-builder: "datastax/cass-config-builder:1.0.4-ubi7"
+      system-logger: "k8ssandra/system-logger:v1.13.1"
+      config-builder: "datastax/cass-config-builder:1.0-ubi7"
 {{- if .Values.image.repositoryOverride }}
     {{- with .Values.image.repositoryOverride }}
       {{- toYaml . | nindent 6 }}

--- a/charts/cass-operator/templates/deployment.yaml
+++ b/charts/cass-operator/templates/deployment.yaml
@@ -10,7 +10,7 @@ kind: Deployment
 metadata:
   name: {{ include "k8ssandra-common.fullname" . }}
   labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
-    control-plane: {{ .Release.Name }}-controller-manager
+    control-plane: {{ include "k8ssandra-common.fullname" . }}-controller-manager
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -23,7 +23,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels: {{- include "k8ssandra-common.labels" . | indent 8 }}
-        control-plane: {{ .Release.Name }}-controller-manager
+        control-plane: {{ include "k8ssandra-common.fullname" . }}-controller-manager
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -89,7 +89,7 @@ spec:
         - name: cass-operator-certs-volume
           secret:
             defaultMode: 420
-            secretName: {{ .Release.Name }}-webhook-server-cert
+            secretName: {{ include "k8ssandra-common.fullname" . }}-webhook-server-cert
       {{- end }}
         - configMap:
             name: {{ include "k8ssandra-common.fullname" . }}-manager-config

--- a/charts/cass-operator/templates/validatingwebhookconfiguration.yaml
+++ b/charts/cass-operator/templates/validatingwebhookconfiguration.yaml
@@ -9,7 +9,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: {{ .Release.Name }}-validating-webhook-configuration
+  name: {{ include "k8ssandra-common.fullname" . }}-validating-webhook-configuration
   labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
   annotations:
     cert-manager.io/inject-ca-from: {{ include "cass-operator-certificate" . }}
@@ -18,7 +18,7 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: {{ .Release.Name }}-webhook-service
+      name: {{ include "k8ssandra-common.fullname" . }}-webhook-service
       namespace: {{ .Release.Namespace }}
       path: /validate-cassandra-datastax-com-v1beta1-cassandradatacenter
   failurePolicy: Fail
@@ -40,21 +40,23 @@ webhooks:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: {{ .Release.Name }}-selfsigned-issuer
+  name: {{ include "k8ssandra-common.fullname" . }}-selfsigned-issuer
+  labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
 spec:
   selfSigned: {}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ .Release.Name }}-serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
+  name: {{ include "k8ssandra-common.fullname" . }}-serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
+  labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
 spec:
   # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
   dnsNames:
-  - {{ printf "%s-webhook-service.%s.svc" .Release.Name .Release.Namespace }}
-  - {{ printf "%s-webhook-service.%s.svc.cluster.local" .Release.Name .Release.Namespace }}
+    -  {{ include "k8ssandra-common.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc
+    -  {{ include "k8ssandra-common.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
     kind: Issuer
-    name: {{ .Release.Name }}-selfsigned-issuer
-  secretName: {{ .Release.Name }}-webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize
+    name: {{ include "k8ssandra-common.fullname" . }}-selfsigned-issuer
+  secretName: {{ include "k8ssandra-common.fullname" . }}-webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize
 {{ end }}

--- a/charts/cass-operator/templates/webhook-service.yaml
+++ b/charts/cass-operator/templates/webhook-service.yaml
@@ -9,12 +9,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-webhook-service
+  name: {{ include "k8ssandra-common.fullname" . }}-webhook-service
   labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
 spec:
   ports:
     - port: 443
       targetPort: 9443
   selector:
-    control-plane: {{ .Release.Name }}-controller-manager
+    control-plane: {{ include "k8ssandra-common.fullname" . }}-controller-manager
 {{- end -}}

--- a/charts/cass-operator/values.yaml
+++ b/charts/cass-operator/values.yaml
@@ -29,7 +29,7 @@ image:
   # -- Pull policy for the operator container
   pullPolicy: IfNotPresent
   # -- Tag of the cass-operator image to pull from image.repository
-  tag: v1.13.0
+  tag: v1.13.1
   # -- Docker registry containing all cass-operator related images. Setting this
   # allows for usage of an internal registry without specifying serverImage,
   # configBuilderImage, and busyboxImage on all CassandraDatacenter objects.

--- a/charts/k8ssandra-operator/Chart.yaml
+++ b/charts/k8ssandra-operator/Chart.yaml
@@ -3,14 +3,14 @@ name: k8ssandra-operator
 description: |
   Kubernetes operator which handles the provisioning and management of K8ssandra clusters.
 type: application
-version: 0.38.5
+version: 0.39.0
 appVersion: 1.4.0
 dependencies:
   - name: k8ssandra-common
     version: 0.28.6
     repository: file://../k8ssandra-common
   - name: cass-operator
-    version: 0.38.0
+    version: 0.39.0
     repository: file://../cass-operator
 home: https://github.com/k8ssandra/k8ssandra-operator
 sources:


### PR DESCRIPTION
…in k8ssandra-operator. This changes name of multiple resources and some labels, causing cass-operator to redeploy itself

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
cass-operator Helm charts worked fine when deployed independently (like designed), however when used as a dependency in k8ssandra-operator, the k8ssandra-operator renamed certain resources to start conflicting with k8ssandra-operator resources.

This PR modifies the naming in cass-operator to work when k8ssandra-operator renames them..

**Which issue(s) this PR fixes**:
Fixes k8ssandra/k8ssandra-operator#769

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
