### PR TITLE
Fix service account token generation for k8s 1.24+

### DIFF
--- a/charts/cass-operator/Chart.yaml
+++ b/charts/cass-operator/Chart.yaml
@@ -7,7 +7,7 @@ version: 0.39.0
 appVersion: 1.13.1
 dependencies:
   - name: k8ssandra-common
-    version: 0.28.6
+    version: 0.29.0
     repository: file://../k8ssandra-common
 home: https://github.com/k8ssandra/cass-operator
 sources:

--- a/charts/k8ssandra-common/Chart.yaml
+++ b/charts/k8ssandra-common/Chart.yaml
@@ -3,7 +3,7 @@ name: k8ssandra-common
 description: |
   Helper library containing functions used by many of the K8ssandra stack Helm charts.
 type: library
-version: 0.28.6
+version: 0.29.0
 dependencies:
   - name: common
     version: 1.16.0

--- a/charts/k8ssandra-common/templates/_helpers.tpl
+++ b/charts/k8ssandra-common/templates/_helpers.tpl
@@ -55,6 +55,10 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- if semverCompare ">=1.24-0" .Capabilities.KubeVersion.GitVersion }}
+secrets:
+  - name: {{ include "k8ssandra-common.serviceAccountName" . }}-token
+{{- end }}
 {{- if .Values.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets }}

--- a/charts/k8ssandra-operator/Chart.yaml
+++ b/charts/k8ssandra-operator/Chart.yaml
@@ -3,11 +3,11 @@ name: k8ssandra-operator
 description: |
   Kubernetes operator which handles the provisioning and management of K8ssandra clusters.
 type: application
-version: 0.39.0
+version: 0.39.1
 appVersion: 1.4.0
 dependencies:
   - name: k8ssandra-common
-    version: 0.28.6
+    version: 0.29.0
     repository: file://../k8ssandra-common
   - name: cass-operator
     version: 0.39.0

--- a/charts/k8ssandra-operator/templates/serviceaccount-token.yaml
+++ b/charts/k8ssandra-operator/templates/serviceaccount-token.yaml
@@ -1,0 +1,9 @@
+{{- if semverCompare ">=1.24-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "k8ssandra-common.serviceAccountName" . }}-token
+  annotations:
+    kubernetes.io/service-account.name: {{ include "k8ssandra-common.serviceAccountName" . }}
+type: kubernetes.io/service-account-token
+{{- end }}

--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
     repository: file://../medusa-operator
     condition: medusa.enabled
   - name: k8ssandra-common
-    version: 0.28.6
+    version: 0.29.0
     repository: file://../k8ssandra-common
   - name: kube-prometheus-stack
     version: 41.6.1

--- a/charts/medusa-operator/Chart.yaml
+++ b/charts/medusa-operator/Chart.yaml
@@ -8,7 +8,7 @@ version: 0.32.0
 appVersion: 0.1.0
 dependencies:
   - name: k8ssandra-common
-    version: 0.28.6
+    version: 0.29.0
     repository: file://../k8ssandra-common
 home: https://k8ssandra.io/
 sources:

--- a/charts/reaper-operator/Chart.yaml
+++ b/charts/reaper-operator/Chart.yaml
@@ -9,7 +9,7 @@ version: 0.32.3
 appVersion: 0.1.0
 dependencies:
   - name: k8ssandra-common
-    version: 0.28.6
+    version: 0.29.0
     repository: file://../k8ssandra-common
 home: https://k8ssandra.io/
 sources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Kubernetes 1.24 stopped creating secrets for service account tokens by default, relying instead on the TokenRequest API.
This is something we've dealt with in our Kustomization but not on Helm installs for k8ssandra-operator.
This PR adds a secret creation for the service account if the kube version is 1.24+ and references the secret in the service account manifest.

**Which issue(s) this PR fixes**:
Fixes k8ssandra/k8ssandra-operator#793

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
