### PR TITLE
Upgrade k8ssandra-operator dependency 1.4.0 -> 1.4.1

### DIFF
--- a/charts/k8ssandra-operator/Chart.yaml
+++ b/charts/k8ssandra-operator/Chart.yaml
@@ -3,8 +3,8 @@ name: k8ssandra-operator
 description: |
   Kubernetes operator which handles the provisioning and management of K8ssandra clusters.
 type: application
-version: 0.39.1
-appVersion: 1.4.0
+version: 0.39.2
+appVersion: 1.4.1
 dependencies:
   - name: k8ssandra-common
     version: 0.29.0

--- a/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
+++ b/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
@@ -16734,7 +16734,7 @@ spec:
                           description: 'ServerVersion is the Cassandra or DSE version.
                             The following versions are supported: - Cassandra: 3.11.X
                             and 4.0.X - DSE: 6.8.X'
-                          pattern: (6\.8\.\d+)|(3\.11\.\d+)|(4\.0\.\d+)
+                          pattern: (6\.8\.\d+)|(3\.11\.\d+)|(4\.\d+\.\d+)
                           type: string
                         size:
                           description: Size is the number Cassandra pods to deploy
@@ -24150,7 +24150,7 @@ spec:
                     description: 'ServerVersion is the Cassandra or DSE version. The
                       following versions are supported: - Cassandra: 3.11.X and 4.0.X
                       - DSE: 6.8.X'
-                    pattern: (6\.8\.\d+)|(3\.11\.\d+)|(4\.0\.\d+)
+                    pattern: (6\.8\.\d+)|(3\.11\.\d+)|(4\.\d+\.\d+)
                     type: string
                   softPodAntiAffinity:
                     description: SoftPodAntiAffinity sets whether multiple Cassandra

--- a/charts/k8ssandra-operator/values.yaml
+++ b/charts/k8ssandra-operator/values.yaml
@@ -25,7 +25,7 @@ image:
   # -- Pull policy for the operator container
   pullPolicy: IfNotPresent
   # -- Tag of the k8ssandra-operator image to pull from image.repository
-  tag: v1.4.0
+  tag: v1.4.1
   # -- Docker registry containing all cass-operator related images. Setting this
   # allows for usage of an internal registry without specifying serverImage,
   # configBuilderImage, and busyboxImage on all CassandraDatacenter objects.


### PR DESCRIPTION
This is auto-generated update from the K8ssandra upgrade GHA workflow.
Check that CI passes correctly before merging this PR.