### PR TITLE
Added nodeSelector and tolerations to cass-operator helm chart

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -31,3 +31,4 @@ and date `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unr
 * [BUGFIX] [#1380](https://github.com/k8ssandra/k8ssandra/issues/1380) Enable webhook functionality in cass-operator if cert-manager is installed.
 * [BUGFIX] [#1404](https://github.com/k8ssandra/k8ssandra/issues/1404) Fix `garbage_collector` property to use G1GC
 * [ENHANCEMENT] [#1135](https://github.com/k8ssandra/k8ssandra/issues/1135)  Add support for service account annotations in helm chart.
+* [ENHANCEMENT] [#1612](https://github.com/k8ssandra/k8ssandra/issues/1612)  Add support for nodeSelector and tolerations in cass-operator helm chart.

--- a/charts/cass-operator/README.md
+++ b/charts/cass-operator/README.md
@@ -1,6 +1,6 @@
 # cass-operator
 
-![Version: 0.35.0](https://img.shields.io/badge/Version-0.35.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
+![Version: 0.42.0](https://img.shields.io/badge/Version-0.42.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 Kubernetes operator which handles the provisioning and management of Apache Cassandra clusters.
 
@@ -10,8 +10,8 @@ Kubernetes operator which handles the provisioning and management of Apache Cass
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| Cass Operator Team | cass-operator@datastax.com | https://github.com/k8ssandra/cass-operator |
-| K8ssandra Team | k8ssandra-developers@googlegroups.com | https://github.com/k8ssandra |
+| Cass Operator Team | <cass-operator@datastax.com> | <https://github.com/k8ssandra/cass-operator> |
+| K8ssandra Team | <k8ssandra-developers@googlegroups.com> | <https://github.com/k8ssandra> |
 
 ## Source Code
 
@@ -22,7 +22,7 @@ Kubernetes operator which handles the provisioning and management of Apache Cass
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../k8ssandra-common | k8ssandra-common | 0.28.4 |
+| file://../k8ssandra-common | k8ssandra-common | 0.29.0 |
 
 ## Values
 
@@ -33,15 +33,15 @@ Kubernetes operator which handles the provisioning and management of Apache Cass
 | fullnameOverride | string | `""` | A name in place of the value used for metadata.name in objects created by this chart. The default value has the form releaseName-chartName. |
 | commonLabels | object | `{}` | Labels to be added to all deployed resources. |
 | replicaCount | int | `1` | Sets the number of cass-operator pods. |
-| admissionWebhooks | object | `{"enabled":false}` | Configures admission webhooks deployed with cass-operator. |
-| admissionWebhooks.enabled | bool | `false` | Turns the admission webhooks on or off |
+| admissionWebhooks | object | `{"enabled":true}` | Configures admission webhooks deployed with cass-operator. |
+| admissionWebhooks.enabled | bool | `true` | Turns the admission webhooks on or off |
 | image.registry | string | `"docker.io"` | Container registry containing the repository where the image resides |
 | image.repository | string | `"k8ssandra/cass-operator"` | Docker repository for cass-operator |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the operator container |
-| image.tag | string | `"v1.10.0"` | Tag of the cass-operator image to pull from image.repository |
-| image.repositoryOverride | object | `{}` | Docker repositories containing all cass-operator related custom images. Setting this allows for usage of an internal registry without specifying serverImage, configBuilderImage, and busyboxImage on all CassandraDatacenter objects. |
-| image.registryOverride | string | `nil` | Docker registry where to Pull all cass-operator related images from. |
-| imagePullSecrets | list | `[]` | References to secrets to use when pulling images. See: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
+| image.tag | string | `"v1.16.0"` | Tag of the cass-operator image to pull from image.repository |
+| image.repositoryOverride | string | `nil` | Docker registry containing all cass-operator related images. Setting this allows for usage of an internal registry without specifying serverImage, configBuilderImage, and busyboxImage on all CassandraDatacenter objects. |
+| image.registryOverride | string | `nil` |  |
+| serviceAccount | object | `{"annotations":{}}` | References to secrets to use when pulling images. See: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ imagePullSecret: secretName |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | podAnnotations | object | `{}` | Annotations for the cass-operator pod. |
 | podSecurityContext | object | `{}` | PodSecurityContext for the cass-operator pod. See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
@@ -50,7 +50,8 @@ Kubernetes operator which handles the provisioning and management of Apache Cass
 | securityContext.runAsUser | int | `65534` | User for running the cass-operator container / process |
 | securityContext.readOnlyRootFilesystem | bool | `true` | Run cass-operator container having read-only root file system permissions. |
 | resources | object | `{}` | Resources requests and limits for the cass-operator pod. We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. If you want to specify resources, add `requests` and `limits` for `cpu` and `memory` while removing the existing `{}` |
-| vmwarePSPEnabled | bool | `false` | Enables specific VMware functionality. If you need this functionality it will automatically be enabled for you. |
+| nodeSelector | object | `{}` | Node labels for operator pod assignment. Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/  |
+| tolerations | list | `[]` | Node tolerations for server scheduling to nodes with taints. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/  |
 
 ----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)
+Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)

--- a/charts/cass-operator/templates/deployment.yaml
+++ b/charts/cass-operator/templates/deployment.yaml
@@ -80,6 +80,12 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
       volumes:
       {{- if $webhooks }}
         - name: cass-operator-certs-volume

--- a/charts/cass-operator/values.yaml
+++ b/charts/cass-operator/values.yaml
@@ -67,3 +67,11 @@ securityContext:
 # `requests` and `limits` for `cpu` and `memory` while removing the existing
 # `{}`
 resources: {}
+# -- Node labels for operator pod assignment.
+# Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+#
+nodeSelector: {}
+# -- Node tolerations for server scheduling to nodes with taints.
+# Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+#
+tolerations: []


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds nodeSelector and tolerations parameters support to cass-operator helm chart

**Which issue(s) this PR fixes**:
Fixes #1612 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)

I saw message this repository is deprecated, however, looks like cass-operator is still being released from this repo.
Looks like helm-docs was not executed for a while. I excluded everything but cass-operator helm chart docs update, let me know if I should run it for all charts.