### PR TITLE
Bugfix/mgmt api image

### DIFF
--- a/charts/cass-operator/templates/configmap.yaml
+++ b/charts/cass-operator/templates/configmap.yaml
@@ -32,6 +32,13 @@ data:
   image_config.yaml: |
     apiVersion: config.k8ssandra.io/v1beta1
     kind: ImageConfig
+    defaults:
+      # Note, postfix is ignored if repository is not set
+      cassandra:
+        repository: "k8ssandra/cass-management-api"
+      dse:
+        repository: "datastax/dse-mgmtapi-6_8"
+        suffix: "-ubi7"
     images:
       system-logger: {{ .Values.imageConfig.systemLogger }}
       config-builder: {{ .Values.imageConfig.configBuilder }}


### PR DESCRIPTION
**What this PR does**:

Fixes a problem where the k8ssandra-operator has been updated to use of management API images (instead of standard DSE server images) but the Helm charts have not been updated to reflect this.

**Which issue(s) this PR fixes**:
Fixes https://github.com/k8ssandra/k8ssandra-operator/issues/1013

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
