### PR TITLE
If metrics are exposed (not bound to 127.0.0.1 and address is set), t…

### DIFF
--- a/charts/cass-operator/Chart.yaml
+++ b/charts/cass-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: cass-operator
 description: |
   Kubernetes operator which handles the provisioning and management of Apache Cassandra clusters.
 type: application
-version: 0.45.2
+version: 0.46.0
 appVersion: 1.18.2
 dependencies:
   - name: k8ssandra-common

--- a/charts/cass-operator/templates/deployment.yaml
+++ b/charts/cass-operator/templates/deployment.yaml
@@ -5,6 +5,10 @@
   {{- fail (print "cass-operator webhooks require cert-manager to be installed in the cluster") }}
 {{- end -}}
 
+{{- $metricsHostname := regexFind "[^:]*" .Values.metrics.address -}}
+{{- $metricsPort := regexFind "(?:)(\\d*)$" .Values.metrics.address -}}
+{{- $exposeMetrics := and $metricsPort (not (eq "127.0.0.1" $metricsHostname )) -}}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -42,11 +46,18 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "k8ssandra-common.flattenedImage" .Values.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if $webhooks }}
+          {{- if or $webhooks $exposeMetrics}}
           ports:
+          {{- if $webhooks }}
             - containerPort: 9443
               name: webhook-server
               protocol: TCP
+          {{- end }}
+          {{- if and $metricsPort (not (eq "127.0.0.1" $metricsHostname )) }}
+            - containerPort: {{ $metricsPort }}
+              name: metrics
+              protocol: TCP
+          {{- end }}
           {{- end }}
           volumeMounts:
             {{- if $webhooks }}


### PR DESCRIPTION
…hen add the containerPort to the cass-operator container

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Exposes the metrics containerPort correctly

**Which issue(s) this PR fixes**:
Fixes #1634

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
