### PR TITLE
Update cass-operator chart to use UBI8 image of the cass-config-builder

### DIFF
--- a/charts/cass-operator/Chart.yaml
+++ b/charts/cass-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: cass-operator
 description: |
   Kubernetes operator which handles the provisioning and management of Apache Cassandra clusters.
 type: application
-version: 0.46.0
+version: 0.46.1
 appVersion: 1.18.2
 dependencies:
   - name: k8ssandra-common

--- a/charts/cass-operator/values.yaml
+++ b/charts/cass-operator/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 # 3.11/4.0 and DSE 6.8, while k8ssandraClient is used to build configs for 4.1
 imageConfig:
   systemLogger: cr.k8ssandra.io/k8ssandra/system-logger:v1.18.2
-  configBuilder: cr.dtsx.io/datastax/cass-config-builder:1.0-ubi7
+  configBuilder: cr.dtsx.io/datastax/cass-config-builder:1.0-ubi8
   k8ssandraClient: cr.k8ssandra.io/k8ssandra/k8ssandra-client:v0.2.2
 # -- metrics allows to change the configuration of how metrics are exposed. Default is
 # to expose /metrics endpoint at port :8080. If you wish to make this available only on


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Use UBI8 base image for the cass-config-builder instead of UBI7 (adds ARM64 support)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
