### PR TITLE
Move imageConfig defaults settings to values.yaml

### DIFF
--- a/charts/cass-operator/Chart.yaml
+++ b/charts/cass-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: cass-operator
 description: |
   Kubernetes operator which handles the provisioning and management of Apache Cassandra clusters.
 type: application
-version: 0.53.6
+version: 0.54.0
 appVersion: 1.22.4
 dependencies:
   - name: k8ssandra-common

--- a/charts/cass-operator/templates/configmap.yaml
+++ b/charts/cass-operator/templates/configmap.yaml
@@ -53,13 +53,6 @@ data:
     {{ (cat "imagePullPolicy:" .Values.image.pullPolicy) }}
 {{- end }}
     defaults:
-      # Note, postfix is ignored if repository is not set
-      cassandra:
-        repository: "cr.k8ssandra.io/k8ssandra/cass-management-api"
-        suffix: "-ubi8"
-      dse:
-        repository: "cr.dtsx.io/datastax/dse-mgmtapi-6_8"
-        suffix: "-ubi8"
-      hcd:
-        repository: "cr.dtsx.io/datastax/hcd"
-        suffix: "-ubi"
+    {{- with .Values.imageConfig.defaults }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}

--- a/charts/cass-operator/values.yaml
+++ b/charts/cass-operator/values.yaml
@@ -82,6 +82,18 @@ imageConfig:
   systemLogger: cr.k8ssandra.io/k8ssandra/system-logger:v1.22.4
   configBuilder: cr.dtsx.io/datastax/cass-config-builder:1.0-ubi8
   k8ssandraClient: cr.k8ssandra.io/k8ssandra/k8ssandra-client:v0.5.0
+  defaults:
+    # Note, postfix is ignored if repository is not set
+    cassandra:
+      repository: "cr.k8ssandra.io/k8ssandra/cass-management-api"
+      suffix: "-ubi"
+    dse:
+      repository: "cr.dtsx.io/datastax/dse-mgmtapi-6_8"
+      suffix: "-ubi8"
+    hcd:
+      repository: "cr.dtsx.io/datastax/hcd"
+      suffix: "-ubi"
+
 # -- metrics allows to change the configuration of how metrics are exposed. Default is
 # to expose /metrics endpoint at port :8080. If you wish to make this available only on
 # localhost (such as when using kube-rbac-proxy to secure access to them), set the value


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

```
  image_config.yaml: |
    apiVersion: config.k8ssandra.io/v1beta1
    kind: ImageConfig
    images:
      system-logger: cr.k8ssandra.io/k8ssandra/system-logger:v1.22.3
      config-builder: cr.dtsx.io/datastax/cass-config-builder:1.0-ubi8
      k8ssandra-client: cr.k8ssandra.io/k8ssandra/k8ssandra-client:v0.5.0
    imagePullPolicy: IfNotPresent
    defaults:
      cassandra:
        repository: cr.k8ssandra.io/k8ssandra/cass-management-api
        suffix: -ubi
      dse:
        repository: cr.dtsx.io/datastax/dse-mgmtapi-6_8
        suffix: -ubi8
      hcd:
        repository: cr.dtsx.io/datastax/hcd
        suffix: -ubi
```

**Which issue(s) this PR fixes**:
Fixes https://github.com/k8ssandra/cass-operator/issues/715

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
