### PR TITLE
Add common annotations and map both annotations and labels to all resources

### DIFF
--- a/charts/cass-operator/Chart.yaml
+++ b/charts/cass-operator/Chart.yaml
@@ -7,7 +7,7 @@ version: 0.57.3
 appVersion: 1.24.0
 dependencies:
   - name: k8ssandra-common
-    version: 0.29.1
+    version: 0.29.2
     repository: file://../k8ssandra-common
 home: https://github.com/k8ssandra/cass-operator
 sources:

--- a/charts/cass-operator/Chart.yaml
+++ b/charts/cass-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: cass-operator
 description: |
   Kubernetes operator which handles the provisioning and management of Apache Cassandra clusters.
 type: application
-version: 0.57.3
+version: 0.57.4
 appVersion: 1.24.0
 dependencies:
   - name: k8ssandra-common

--- a/charts/cass-operator/templates/configmap.yaml
+++ b/charts/cass-operator/templates/configmap.yaml
@@ -10,6 +10,10 @@ kind: ConfigMap
 metadata:
   name: {{ include "k8ssandra-common.fullname" . }}-manager-config
   labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
+  {{- with include "k8ssandra-common.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 apiVersion: v1
 data:
   controller_manager_config.yaml: |

--- a/charts/cass-operator/templates/deployment.yaml
+++ b/charts/cass-operator/templates/deployment.yaml
@@ -16,6 +16,10 @@ metadata:
   name: {{ include "k8ssandra-common.fullname" . }}
   labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
     control-plane: {{ include "k8ssandra-common.fullname" . }}-controller-manager
+  {{- with include "k8ssandra-common.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -23,11 +27,11 @@ spec:
       {{- include "k8ssandra-common.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- with include "k8ssandra-common.annotations" (dict "context" . "annotations" .Values.podAnnotations) }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
-      labels: {{- include "k8ssandra-common.labels" . | indent 8 }}
+      labels: {{ include "k8ssandra-common.labels" . | indent 8 }}
         control-plane: {{ include "k8ssandra-common.fullname" . }}-controller-manager
     spec:
       {{- if .Values.imagePullSecrets }}

--- a/charts/cass-operator/templates/leader_election_role.yaml
+++ b/charts/cass-operator/templates/leader_election_role.yaml
@@ -3,6 +3,10 @@ kind: Role
 metadata:
   name: {{ include "k8ssandra-common.fullname" . }}-leader
   labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
+  {{- with include "k8ssandra-common.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups:
       - ""

--- a/charts/cass-operator/templates/leader_election_role_binding.yaml
+++ b/charts/cass-operator/templates/leader_election_role_binding.yaml
@@ -3,6 +3,10 @@ kind: RoleBinding
 metadata:
   name: {{ include "k8ssandra-common.fullname" . }}-leader
   labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
+  {{- with include "k8ssandra-common.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/cass-operator/templates/role.yaml
+++ b/charts/cass-operator/templates/role.yaml
@@ -3,6 +3,10 @@ kind: ClusterRole
 metadata:
   name: {{ include "k8ssandra-common.fullname" . }}
   labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
+  {{- with include "k8ssandra-common.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 {{- if .Values.global.clusterScoped }}
 rules:
   - apiGroups:
@@ -158,6 +162,10 @@ kind: Role
 metadata:
   name: {{ template "k8ssandra-common.fullname" . }}
   labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
+  {{- with include "k8ssandra-common.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups:
       - ""

--- a/charts/cass-operator/templates/rolebinding.yaml
+++ b/charts/cass-operator/templates/rolebinding.yaml
@@ -2,6 +2,11 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "k8ssandra-common.fullname" . }}
+  labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
+  {{- with include "k8ssandra-common.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "k8ssandra-common.serviceAccountName" . }}
@@ -17,6 +22,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "k8ssandra-common.fullname" . }}
   labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
+  {{- with include "k8ssandra-common.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "k8ssandra-common.serviceAccountName" . }}

--- a/charts/cass-operator/templates/validatingwebhookconfiguration.yaml
+++ b/charts/cass-operator/templates/validatingwebhookconfiguration.yaml
@@ -14,6 +14,9 @@ metadata:
   labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
   annotations:
     cert-manager.io/inject-ca-from: {{ include "cass-operator.certificateName" . }}
+    {{- with include "k8ssandra-common.annotations" . }}
+    {{- . | nindent 4 }}
+    {{- end }}
 webhooks:
 - admissionReviewVersions:
   - v1
@@ -43,6 +46,10 @@ kind: Issuer
 metadata:
   name: {{ include "k8ssandra-common.fullname" . }}-selfsigned-issuer
   labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
+  {{- with include "k8ssandra-common.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   selfSigned: {}
 ---
@@ -51,6 +58,10 @@ kind: Certificate
 metadata:
   name: {{ include "k8ssandra-common.fullname" . }}-serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
   labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
+  {{- with include "k8ssandra-common.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
   dnsNames:

--- a/charts/cass-operator/templates/webhook-service.yaml
+++ b/charts/cass-operator/templates/webhook-service.yaml
@@ -12,6 +12,10 @@ kind: Service
 metadata:
   name: {{ include "k8ssandra-common.fullname" . }}-webhook-service
   labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
+  {{- with include "k8ssandra-common.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
     - port: 443

--- a/charts/cass-operator/values.yaml
+++ b/charts/cass-operator/values.yaml
@@ -6,6 +6,10 @@ global:
   # -- List of namespaces to watch for CassandraDatacenter resources.
   # If empty, the operator will watch all namespaces in cluster-scope installation.
   # watchNamespaces: []
+  # -- Annotations to be added to all deployed resources.
+  commonAnnotations: {}
+  # -- Labels to be added to all deployed resources.
+  commonLabels: {}
 # -- A name in place of the chart name which is used in the metadata.name of
 # objects created by this chart.
 nameOverride: ''

--- a/charts/k8ssandra-common/Chart.yaml
+++ b/charts/k8ssandra-common/Chart.yaml
@@ -3,7 +3,7 @@ name: k8ssandra-common
 description: |
   Helper library containing functions used by many of the K8ssandra stack Helm charts.
 type: library
-version: 0.29.1
+version: 0.29.2
 dependencies:
   - name: common
     version: 1.16.0

--- a/charts/k8ssandra-common/templates/_helpers.tpl
+++ b/charts/k8ssandra-common/templates/_helpers.tpl
@@ -24,6 +24,36 @@ Create chart name and version as used by the chart label.
 {{- define "k8ssandra-common.labels" }}
 {{ include "common.labels.standard" . }}
 app.kubernetes.io/part-of: k8ssandra-{{ .Release.Name }}-{{ .Release.Namespace }}
+{{- $commonLabels := dict -}}
+{{- if .Values.global.commonLabels -}}
+{{- $commonLabels = merge $commonLabels .Values.global.commonLabels -}}
+{{- end -}}
+{{- if .Values.commonLabels -}}
+{{- $commonLabels = merge $commonLabels .Values.commonLabels -}}
+{{- end -}}
+{{- if $commonLabels }}
+{{ toYaml $commonLabels | trim }}
+{{- end }}
+{{- end }}
+
+{{- define "k8ssandra-common.annotations" }}
+{{- $context := . -}}
+{{- if .context -}}
+{{- $context = .context -}}
+{{- end -}}
+{{- $commonAnnotations := dict -}}
+{{- if $context.Values.global.commonAnnotations -}}
+{{- $commonAnnotations = merge $commonAnnotations $context.Values.global.commonAnnotations -}}
+{{- end -}}
+{{- if $context.Values.commonAnnotations -}}
+{{- $commonAnnotations = merge $commonAnnotations $context.Values.commonAnnotations -}}
+{{- end -}}
+{{- if .annotations -}}
+{{- $commonAnnotations = merge $commonAnnotations .annotations -}}
+{{- end -}}
+{{- if $commonAnnotations -}}
+{{- toYaml $commonAnnotations | trim }}
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/charts/k8ssandra-common/templates/_helpers.tpl
+++ b/charts/k8ssandra-common/templates/_helpers.tpl
@@ -81,9 +81,10 @@ kind: ServiceAccount
 metadata:
   name: {{ include "k8ssandra-common.serviceAccountName" . }}
   labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- $annotations := include "k8ssandra-common.annotations" (dict "context" . "annotations" .Values.serviceAccount.annotations) }}
+  {{- if $annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- $annotations | nindent 4 }}
   {{- end }}
 {{- if semverCompare ">=1.24-0" .Capabilities.KubeVersion.GitVersion }}
 secrets:

--- a/charts/k8ssandra/Chart.yaml
+++ b/charts/k8ssandra/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
     repository: file://../medusa-operator
     condition: medusa.enabled
   - name: k8ssandra-common
-    version: 0.29.1
+    version: 0.29.2
     repository: file://../k8ssandra-common
   - name: kube-prometheus-stack
     version: 41.6.1

--- a/charts/medusa-operator/Chart.yaml
+++ b/charts/medusa-operator/Chart.yaml
@@ -8,7 +8,7 @@ version: 0.32.0
 appVersion: 0.1.0
 dependencies:
   - name: k8ssandra-common
-    version: 0.29.1
+    version: 0.29.2
     repository: file://../k8ssandra-common
 home: https://k8ssandra.io/
 sources:

--- a/charts/reaper-operator/Chart.yaml
+++ b/charts/reaper-operator/Chart.yaml
@@ -9,7 +9,7 @@ version: 0.32.3
 appVersion: 0.1.0
 dependencies:
   - name: k8ssandra-common
-    version: 0.29.1
+    version: 0.29.2
     repository: file://../k8ssandra-common
 home: https://k8ssandra.io/
 sources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Updates k8ssandra-common to apply commonLabels (local and global ones) to all resources using the labels helper function. Also duplicates the labels logic for annotations.

Makes cass-operator apply both labels and annotations to all the rendered templates.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
