### PR TITLE
If global.clusterScopedResources is set to false, do not render any

### DIFF
--- a/charts/cass-operator/Chart.yaml
+++ b/charts/cass-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: cass-operator
 description: |
   Kubernetes operator which handles the provisioning and management of Apache Cassandra clusters.
 type: application
-version: 0.57.5
+version: 0.58.0
 appVersion: 1.24.1
 dependencies:
   - name: k8ssandra-common

--- a/charts/cass-operator/templates/role.yaml
+++ b/charts/cass-operator/templates/role.yaml
@@ -1,3 +1,7 @@
+{{- /*
+This is generated file from cass-operator/scripts/release-helm-chart.sh
+*/ -}}
+{{- if .Values.global.clusterScopedResources }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -156,6 +160,9 @@ rules:
       - get
       - list
       - watch
+{{- end }}
+{{- end }}
+{{- if (not .Values.global.clusterScoped) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/cass-operator/templates/rolebinding.yaml
+++ b/charts/cass-operator/templates/rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.clusterScopedResources }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -15,8 +16,9 @@ roleRef:
   kind: ClusterRole
   name: {{ template "k8ssandra-common.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
-{{- if not .Values.global.clusterScoped }}
+{{- end}}
 ---
+{{- if not .Values.global.clusterScoped }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/cass-operator/values.yaml
+++ b/charts/cass-operator/values.yaml
@@ -10,6 +10,8 @@ global:
   commonAnnotations: {}
   # -- Labels to be added to all deployed resources.
   commonLabels: {}
+  # -- Should we install cluster-scoped resources such as ClusterRole, ClusterRoleBinding
+  clusterScopedResources: true
 # -- A name in place of the chart name which is used in the metadata.name of
 # objects created by this chart.
 nameOverride: ''


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Allows blocking render of clusterScoped resources for cass-operator chart.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
