### PR TITLE
Disable the creation of the validating webhook when cluster level resources are disabled

### DIFF
--- a/charts/cass-operator/Chart.yaml
+++ b/charts/cass-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: cass-operator
 description: |
   Kubernetes operator which handles the provisioning and management of Apache Cassandra clusters.
 type: application
-version: 0.59.0
+version: 0.59.1
 appVersion: 1.25.0
 dependencies:
   - name: k8ssandra-common

--- a/charts/cass-operator/templates/validatingwebhookconfiguration.yaml
+++ b/charts/cass-operator/templates/validatingwebhookconfiguration.yaml
@@ -7,6 +7,7 @@
 {{- end -}}
 ---
 {{ if $webhooks }}
+{{- if .Values.global.clusterScopedResources }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -38,6 +39,7 @@ webhooks:
     resources:
     - cassandradatacenters
   sideEffects: None
+{{- end }}
 {{ end }}
 {{ if $webhooks }}
 ---


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This pull request includes a version update for the `cass-operator` chart and introduces a conditional block for cluster-scoped resources in the ValidatingWebhookConfiguration template. Below are the key changes:

### Version Update:
* [`charts/cass-operator/Chart.yaml`](diffhunk://#diff-4a567ecacde4b3189d86c51760c52e944b7f9d846fe7e770df66dfd7fd473970L6-R6): Updated the chart version from `0.59.0` to `0.59.1`.

### Template Enhancements:
* [`charts/cass-operator/templates/validatingwebhookconfiguration.yaml`](diffhunk://#diff-36fde6970f5b5c04df1357fa713151ca8e85b24e64f5dcf2dced0d12f0c5d8bfR10): Added a conditional block to include `ValidatingWebhookConfiguration` only if `.Values.global.clusterScopedResources` is set. This ensures the configuration is applied conditionally based on the cluster-scoped resource setting. [[1]](diffhunk://#diff-36fde6970f5b5c04df1357fa713151ca8e85b24e64f5dcf2dced0d12f0c5d8bfR10) [[2]](diffhunk://#diff-36fde6970f5b5c04df1357fa713151ca8e85b24e64f5dcf2dced0d12f0c5d8bfR42)

**Which issue(s) this PR fixes**:
Fixes #2291

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
