### PR TITLE
Fix the missing --webhook-cert-path command, add ability to set metrics TLS

### DIFF
--- a/charts/cass-operator/Chart.yaml
+++ b/charts/cass-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: cass-operator
 description: |
   Kubernetes operator which handles the provisioning and management of Apache Cassandra clusters.
 type: application
-version: 0.62.1
+version: 0.62.2
 appVersion: 1.28.0
 dependencies:
   - name: k8ssandra-common

--- a/charts/cass-operator/templates/certificates.yaml
+++ b/charts/cass-operator/templates/certificates.yaml
@@ -1,0 +1,53 @@
+{{- $webhooks := .Values.admissionWebhooks.enabled -}}
+{{- $metricsTLSEnabled := .Values.metrics.tls.enabled | default false -}}
+
+{{ if or $webhooks $metricsTLSEnabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "k8ssandra-common.fullname" . }}-selfsigned-issuer
+  labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
+  {{- with include "k8ssandra-common.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "k8ssandra-common.fullname" . }}-serving-cert
+  labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
+  {{- with include "k8ssandra-common.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  dnsNames:
+    -  {{ include "k8ssandra-common.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc
+    -  {{ include "k8ssandra-common.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: {{ include "k8ssandra-common.fullname" . }}-selfsigned-issuer
+  secretName: {{ include "k8ssandra-common.fullname" . }}-webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "k8ssandra-common.fullname" . }}-metrics-serving-cert
+  labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
+  {{- with include "k8ssandra-common.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  dnsNames:
+    -  {{ include "k8ssandra-common.fullname" . }}-metrics-webhook-service.{{ .Release.Namespace }}.svc
+    -  {{ include "k8ssandra-common.fullname" . }}-metrics-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: {{ include "k8ssandra-common.fullname" . }}-selfsigned-issuer
+  secretName: {{ include "k8ssandra-common.fullname" . }}-metrics-webhook-server-cert
+{{ end }}

--- a/charts/cass-operator/templates/deployment.yaml
+++ b/charts/cass-operator/templates/deployment.yaml
@@ -9,6 +9,7 @@
 {{- $metricsHostname := regexFind "[^:]*" .Values.metrics.address -}}
 {{- $metricsPort := regexFind "(?:)(\\d*)$" .Values.metrics.address -}}
 {{- $exposeMetrics := and $metricsPort (not (eq "127.0.0.1" $metricsHostname )) -}}
+{{- $metricsTLSEnabled := .Values.metrics.tls.enabled | default false -}}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -45,6 +46,12 @@ spec:
         - name: {{ .Chart.Name }}
           args:
           - --config=/configs/controller_manager_config.yaml
+          {{- if $webhooks }}
+          - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+          {{- end }}
+          {{- if $metricsTLSEnabled }}
+          - --metrics-cert-path=/tmp/k8s-metrics-server/metrics-certs
+          {{- end }}
           command:
           - /manager
           securityContext:
@@ -68,6 +75,11 @@ spec:
             {{- if $webhooks }}
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cass-operator-certs-volume
+              readOnly: true
+            {{- end }}
+            {{- if $metricsTLSEnabled }}
+            - mountPath: /tmp/k8s-metrics-server/metrics-certs
+              name: cass-operator-metrics-certs-volume
               readOnly: true
             {{- end }}
             - mountPath: /configs
@@ -108,6 +120,12 @@ spec:
           secret:
             defaultMode: 420
             secretName: {{ include "k8ssandra-common.fullname" . }}-webhook-server-cert
+      {{- end }}
+      {{- if $metricsTLSEnabled }}
+        - name: cass-operator-metrics-certs-volume
+          secret:
+            defaultMode: 420
+            secretName: {{ include "k8ssandra-common.fullname" . }}-metrics-server-cert
       {{- end }}
         - configMap:
             name: {{ include "k8ssandra-common.fullname" . }}-manager-config

--- a/charts/cass-operator/templates/webhook-service.yaml
+++ b/charts/cass-operator/templates/webhook-service.yaml
@@ -23,3 +23,19 @@ spec:
   selector:
     control-plane: {{ include "k8ssandra-common.fullname" . }}-controller-manager
 {{- end -}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "k8ssandra-common.fullname" . }}-metrics-webhook-service
+  labels: {{ include "k8ssandra-common.labels" . | indent 4 }}
+  {{- with include "k8ssandra-common.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  ports:
+    - port: 8443
+      targetPort: 8443
+  selector:
+    control-plane: {{ include "k8ssandra-common.fullname" . }}-controller-manager

--- a/charts/cass-operator/values.yaml
+++ b/charts/cass-operator/values.yaml
@@ -27,7 +27,7 @@ global:
       k8ssandra-client:
         repository: "k8ssandra"
         name: "k8ssandra-client"
-        tag: "v0.8.3"
+        tag: "v0.8.4"
         # pullSecret: "k8ssandra-client-pull-secret" # Use of pullSecret removes the default pullSecrets for this image
         # pullPolicy: Always
     # -- defaults are used when other no override is present for the configured image or image type. All these values can be overridden under any image or image type.
@@ -166,5 +166,8 @@ imageConfig:
 # to 127.0.0.1:8080
 metrics:
   address: ":8080"
+  tls:
+    # -- Enable TLS for metrics endpoint
+    enabled: false
 # -- Allows to disable the check for cert-manager. For helm template, use --api-versions=cert-manager.io/v1 instead
 # disableCertManagerCheck: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Fixes TLS path in command line parameter
Adds ability to set TLS for metrics endpoint

**Which issue(s) this PR fixes**:
Fixes https://github.com/k8ssandra/cass-operator/issues/867

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
